### PR TITLE
Always return JSON in API

### DIFF
--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
         include(
             [
                 url(r"languages/?$", languages),
-                url(r"(offers|extras)/?$", offers),
+                url(r"(?:offers|extras)/?$", offers),
                 url(
                     r"(?P<language_code>[-\w]+)/sent_push_notifications/?$",
                     sent_push_notifications,
@@ -63,11 +63,11 @@ urlpatterns = [
                     search_result_feedback.search_result_feedback,
                 ),
                 url(
-                    r"(?P<language_code>[-\w]+)/feedback/(extras|offers)/?$",
+                    r"(?P<language_code>[-\w]+)/feedback/(?:extras|offers)/?$",
                     offer_list_feedback.offer_list_feedback,
                 ),
                 url(
-                    r"(?P<language_code>[-\w]+)/feedback/(extra|offer)/?$",
+                    r"(?P<language_code>[-\w]+)/feedback/(?:extra|offer)/?$",
                     offer_feedback.offer_feedback,
                 ),
                 url(
@@ -75,9 +75,9 @@ urlpatterns = [
                     event_list_feedback.event_list_feedback,
                 ),
                 url(r"(?P<language_code>[-\w]+)/pages/?$", pages),
-                url(r"(?P<language_code>[-\w]+)/(offers|extras)/?$", offers),
+                url(r"(?P<language_code>[-\w]+)/(?:offers|extras)/?$", offers),
                 url(r"(?P<language_code>[-\w]+)/page/?$", single_page),
-                url(r"(?P<language_code>[-\w]+)/(imprint|disclaimer)/?$", imprint),
+                url(r"(?P<language_code>[-\w]+)/(?:imprint|disclaimer)/?$", imprint),
                 url(r"(?P<language_code>[-\w]+)/pdf/?$", pdf_export),
             ]
         ),

--- a/src/api/v3/feedback/event_feedback.py
+++ b/src/api/v3/feedback/event_feedback.py
@@ -1,4 +1,5 @@
 from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
 
 from api.decorators import feedback_handler
 from cms.models import EventFeedback, EventTranslation
@@ -50,17 +51,10 @@ def event_feedback_internal(data, region, language, comment, emotion, is_technic
     :return: JSON object according to APIv3 single page feedback endpoint definition
     :rtype: ~django.http.JsonResponse
     """
-    event_slug = data.get("slug")
-    if not event_slug:
-        return JsonResponse({"error": "Event slug is required."}, status=400)
-    try:
-        event = EventTranslation.objects.get(
-            event__region=region, language=language, slug=event_slug
-        ).event
-    except EventTranslation.DoesNotExist:
-        return JsonResponse(
-            {"error": f'No event found with slug "{event_slug}"'}, status=404
-        )
+    event = get_object_or_404(
+        EventTranslation, event__region=region, language=language, slug=data.get("slug")
+    )
+
     EventFeedback.objects.create(
         event=event,
         language=language,

--- a/src/api/v3/feedback/event_feedback.py
+++ b/src/api/v3/feedback/event_feedback.py
@@ -1,11 +1,13 @@
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 
-from api.decorators import feedback_handler
 from cms.models import EventFeedback, EventTranslation
+
+from ...decorators import json_response, feedback_handler
 
 
 @feedback_handler
+@json_response
 def event_feedback(data, region, language, comment, emotion, is_technical):
     """
     Store feedback about single event in database

--- a/src/api/v3/feedback/event_list_feedback.py
+++ b/src/api/v3/feedback/event_list_feedback.py
@@ -3,11 +3,13 @@ APIv3 endpoint for the events (list)
 """
 from django.http import JsonResponse
 
-from api.decorators import feedback_handler
 from cms.models import EventListFeedback
+
+from ...decorators import json_response, feedback_handler
 
 
 @feedback_handler
+@json_response
 # pylint: disable=unused-argument
 def event_list_feedback(data, region, language, comment, emotion, is_technical):
     """

--- a/src/api/v3/feedback/imprint_page_feedback.py
+++ b/src/api/v3/feedback/imprint_page_feedback.py
@@ -3,11 +3,13 @@ APIv3 endpoint for feedback about the imprint
 """
 from django.http import JsonResponse
 
-from api.decorators import feedback_handler
 from cms.models.feedback.imprint_page_feedback import ImprintPageFeedback
+
+from ...decorators import json_response, feedback_handler
 
 
 @feedback_handler
+@json_response
 def imprint_page_feedback(data, region, language, comment, emotion, is_technical):
     """
     Store feedback about imprint in database

--- a/src/api/v3/feedback/legacy_feedback_endpoint.py
+++ b/src/api/v3/feedback/legacy_feedback_endpoint.py
@@ -3,14 +3,16 @@ APIv3 legacy feedback endpoint for pages, events and imprint
 """
 from django.http import JsonResponse
 
-from api.decorators import feedback_handler
 from api.v3.feedback.event_feedback import event_feedback_internal
 from api.v3.feedback.imprint_page_feedback import imprint_page_feedback_internal
 from api.v3.feedback.page_feedback import page_feedback_internal
 from backend.settings import IMPRINT_SLUG
 
+from ...decorators import json_response, feedback_handler
+
 
 @feedback_handler
+@json_response
 def legacy_feedback_endpoint(data, region, language, comment, emotion, is_technical):
     """
     Decorate function for storing feedback about single page, imprint or event in database. This

--- a/src/api/v3/feedback/offer_feedback.py
+++ b/src/api/v3/feedback/offer_feedback.py
@@ -2,6 +2,7 @@
 APIv3 feedback endpoint for feedback about single offer
 """
 from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
 
 from api.decorators import feedback_handler
 from cms.models import OfferFeedback, Offer
@@ -29,14 +30,7 @@ def offer_feedback(data, region, language, comment, emotion, is_technical):
     :return: JSON object according to APIv3 offer feedback endpoint definition
     :rtype: ~django.http.JsonResponse
     """
-    offer_slug = data.get("slug", None)
-    if not offer_slug:
-        return JsonResponse({"error": "Offer slug is required."}, status=400)
-    offer = Offer.objects.filter(region=region, template__slug=offer_slug).first()
-    if offer is None:
-        return JsonResponse(
-            {"error": f'No offer found with slug "{offer_slug}"'}, status=404
-        )
+    offer = get_object_or_404(Offer, region=region, template__slug=data.get("slug"))
 
     OfferFeedback.objects.create(
         offer=offer,

--- a/src/api/v3/feedback/offer_feedback.py
+++ b/src/api/v3/feedback/offer_feedback.py
@@ -4,11 +4,13 @@ APIv3 feedback endpoint for feedback about single offer
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 
-from api.decorators import feedback_handler
 from cms.models import OfferFeedback, Offer
+
+from ...decorators import json_response, feedback_handler
 
 
 @feedback_handler
+@json_response
 # pylint: disable=unused-argument
 def offer_feedback(data, region, language, comment, emotion, is_technical):
     """

--- a/src/api/v3/feedback/offer_list_feedback.py
+++ b/src/api/v3/feedback/offer_list_feedback.py
@@ -3,11 +3,13 @@ APIv3 feedback endpoint for feedback about offers
 """
 from django.http import JsonResponse
 
-from api.decorators import feedback_handler
 from cms.models import OfferListFeedback
+
+from ...decorators import json_response, feedback_handler
 
 
 @feedback_handler
+@json_response
 # pylint: disable=unused-argument
 def offer_list_feedback(data, region, language, comment, emotion, is_technical):
     """

--- a/src/api/v3/feedback/page_feedback.py
+++ b/src/api/v3/feedback/page_feedback.py
@@ -4,11 +4,13 @@ APIv3 endpoint for feedback bout single pages
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 
-from api.decorators import feedback_handler
 from cms.models import PageFeedback, PageTranslation
+
+from ...decorators import json_response, feedback_handler
 
 
 @feedback_handler
+@json_response
 def page_feedback(data, region, language, comment, emotion, is_technical):
     """
     Decorate function for storing feedback about single page in database

--- a/src/api/v3/feedback/page_feedback.py
+++ b/src/api/v3/feedback/page_feedback.py
@@ -2,6 +2,7 @@
 APIv3 endpoint for feedback bout single pages
 """
 from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
 
 from api.decorators import feedback_handler
 from cms.models import PageFeedback, PageTranslation
@@ -53,18 +54,12 @@ def page_feedback_internal(data, region, language, comment, emotion, is_technica
     :return: JSON object according to APIv3 single page feedback endpoint definition
     :rtype: ~django.http.JsonResponse
     """
-    page_slug = data.get("slug", None)
-    if not page_slug:
-        return JsonResponse({"error": "Page slug is required."}, status=400)
-    page_translation = PageTranslation.objects.filter(
-        page__region=region, language=language, slug=page_slug
-    ).first()
-    if page_translation is None:
-        return JsonResponse(
-            {"error": f'No page found with slug "{page_slug}"'}, status=404
-        )
+    page = get_object_or_404(
+        PageTranslation, page__region=region, language=language, slug=data.get("slug")
+    ).page
+
     PageFeedback.objects.create(
-        page=page_translation.page,
+        page=page,
         language=language,
         emotion=emotion,
         comment=comment,

--- a/src/api/v3/feedback/region_feedback.py
+++ b/src/api/v3/feedback/region_feedback.py
@@ -3,11 +3,13 @@ APIv3 endpoint for feedback about full region (main level of content)
 """
 from django.http import JsonResponse
 
-from api.decorators import feedback_handler
 from cms.models import RegionFeedback
+
+from ...decorators import json_response, feedback_handler
 
 
 @feedback_handler
+@json_response
 # pylint: disable=unused-argument
 def region_feedback(data, region, language, comment, emotion, is_technical):
     """

--- a/src/api/v3/feedback/search_result_feedback.py
+++ b/src/api/v3/feedback/search_result_feedback.py
@@ -3,11 +3,13 @@ APIv3 app search result feedback endpoint
 """
 from django.http import JsonResponse
 
-from api.decorators import feedback_handler
 from cms.models import SearchResultFeedback
+
+from ...decorators import json_response, feedback_handler
 
 
 @feedback_handler
+@json_response
 # pylint: disable=unused-argument
 def search_result_feedback(data, region, language, comment, emotion, is_technical):
     """

--- a/src/api/v3/imprint.py
+++ b/src/api/v3/imprint.py
@@ -6,6 +6,8 @@ from django.http import JsonResponse
 from backend.settings import BASE_URL
 from cms.models import Region
 
+from ..decorators import json_response
+
 
 def transform_imprint(imprint_translation):
     """
@@ -35,6 +37,7 @@ def transform_imprint(imprint_translation):
     }
 
 
+@json_response
 # pylint: disable=unused-argument
 def imprint(request, region_slug, language_code):
     """

--- a/src/api/v3/imprint.py
+++ b/src/api/v3/imprint.py
@@ -3,6 +3,7 @@ imprint API endpoint
 """
 from django.http import JsonResponse
 
+from backend.settings import BASE_URL
 from cms.models import Region
 
 
@@ -16,6 +17,10 @@ def transform_imprint(imprint_translation):
     :return: return data necessary for API
     :rtype: dict
     """
+    if imprint_translation.page.icon:
+        thumbnail = BASE_URL + imprint_translation.page.icon.url
+    else:
+        thumbnail = None
     return {
         "id": imprint_translation.id,
         "url": imprint_translation.permalink,
@@ -25,7 +30,7 @@ def transform_imprint(imprint_translation):
         "content": imprint_translation.text,
         "parent": None,
         "available_languages": imprint_translation.available_languages,
-        "thumbnail": imprint_translation.page.icon,
+        "thumbnail": thumbnail,
         "hash": None,
     }
 
@@ -46,10 +51,9 @@ def imprint(request, region_slug, language_code):
     :rtype: ~django.http.JsonResponse
     """
     region = Region.get_current_region(request)
-    result = []
-    imprint_translation = region.imprint.get_public_translation(language_code)
-    if imprint_translation:
-        result.append(transform_imprint(imprint_translation))
-    return JsonResponse(
-        result, safe=False
-    )  # Turn off Safe-Mode to allow serializing arrays
+    if hasattr(region, "imprint"):
+        imprint_translation = region.imprint.get_public_translation(language_code)
+        if imprint_translation:
+            return JsonResponse(transform_imprint(imprint_translation))
+    # If imprint does not exist, return an empty response. Turn off Safe-Mode to allow serializing arrays
+    return JsonResponse([], safe=False)

--- a/src/api/v3/languages.py
+++ b/src/api/v3/languages.py
@@ -5,7 +5,10 @@ from django.http import JsonResponse
 
 from cms.models import Region
 
+from ..decorators import json_response
 
+
+@json_response
 # pylint: disable=unused-argument
 def languages(request, region_slug):
     """

--- a/src/api/v3/languages.py
+++ b/src/api/v3/languages.py
@@ -1,12 +1,12 @@
 """
 API-endpoint to deliver a JSON with all active languages of an region.
 """
-from django.core.exceptions import ObjectDoesNotExist
-from django.http import HttpResponse, JsonResponse
+from django.http import JsonResponse
 
 from cms.models import Region
 
 
+# pylint: disable=unused-argument
 def languages(request, region_slug):
     """
     Function to add all languages related to a region to a JSON.
@@ -19,26 +19,19 @@ def languages(request, region_slug):
     :return: JSON object according to APIv3 languages endpoint definition
     :rtype: ~django.http.JsonResponse
     """
-    try:
-        region = Region.objects.get(slug=region_slug)
+    region = Region.get_current_region(request)
 
-        result = list(
-            map(
-                lambda l: {
-                    "id": l.language.id,
-                    "code": l.language.code,
-                    "native_name": l.language.name,
-                    "dir": l.language.text_direction,
-                },
-                region.language_tree_nodes.filter(active=True),
-            )
+    result = list(
+        map(
+            lambda l: {
+                "id": l.language.id,
+                "code": l.language.code,
+                "native_name": l.language.native_name,
+                "dir": l.language.text_direction,
+            },
+            region.language_tree_nodes.filter(active=True),
         )
-        return JsonResponse(
-            result, safe=False
-        )  # Turn off Safe-Mode to allow serializing arrays
-    except ObjectDoesNotExist:
-        return HttpResponse(
-            f'No Region found with name "{region_slug}".',
-            content_type="text/plain",
-            status=404,
-        )
+    )
+    return JsonResponse(
+        result, safe=False
+    )  # Turn off Safe-Mode to allow serializing arrays

--- a/src/api/v3/offers.py
+++ b/src/api/v3/offers.py
@@ -5,6 +5,8 @@ from django.http import JsonResponse
 
 from cms.models import Region
 
+from ..decorators import json_response
+
 
 def transform_offer(offer):
     """
@@ -25,6 +27,7 @@ def transform_offer(offer):
     }
 
 
+@json_response
 # pylint: disable=unused-argument
 def offers(request, region_slug, language_code=None):
     """

--- a/src/api/v3/pages.py
+++ b/src/api/v3/pages.py
@@ -3,6 +3,7 @@ pages API endpoint
 """
 from django.http import JsonResponse
 
+from backend.settings import BASE_URL
 from cms.models import Region
 
 
@@ -16,6 +17,10 @@ def transform_page(page_translation):
     :return: return data necessary for API
     :rtype: dict
     """
+    if page_translation.page.icon:
+        thumbnail = BASE_URL + page_translation.page.icon.url
+    else:
+        thumbnail = None
     if page_translation.page.parent:
         parent = {
             "id": page_translation.page.parent.id,
@@ -39,7 +44,7 @@ def transform_page(page_translation):
         "parent": parent,
         "order": page_translation.page.lft,  # use left edge indicator of mptt model for order
         "available_languages": page_translation.available_languages,
-        "thumbnail": None,
+        "thumbnail": thumbnail,
         "hash": None,
     }
 

--- a/src/api/v3/pages.py
+++ b/src/api/v3/pages.py
@@ -6,6 +6,8 @@ from django.http import JsonResponse
 from backend.settings import BASE_URL
 from cms.models import Region
 
+from ..decorators import json_response
+
 
 def transform_page(page_translation):
     """
@@ -49,6 +51,7 @@ def transform_page(page_translation):
     }
 
 
+@json_response
 # pylint: disable=unused-argument
 def pages(request, region_slug, language_code):
     """

--- a/src/api/v3/pdf_export.py
+++ b/src/api/v3/pdf_export.py
@@ -10,8 +10,12 @@ from django.shortcuts import get_object_or_404
 from cms.models import Region
 from cms.utils.pdf_utils import generate_pdf
 
+from ..decorators import json_response
+
 logger = logging.getLogger(__name__)
 
+
+@json_response
 # pylint: disable=unused-argument
 def pdf_export(request, region_slug, language_code):
     """

--- a/src/api/v3/push_notifications.py
+++ b/src/api/v3/push_notifications.py
@@ -5,7 +5,10 @@ from django.http import JsonResponse
 
 from cms.models import PushNotificationTranslation
 
+from ..decorators import json_response
 
+
+@json_response
 def sent_push_notifications(request, region_slug, language_code):
     """
     Function to iterate through all sent push notifications related to a region and adds them to a JSON.

--- a/src/api/v3/regions.py
+++ b/src/api/v3/regions.py
@@ -2,7 +2,7 @@
 Views to return JSON representations of regions
 """
 from django.db.models import Exists, OuterRef
-from django.http import JsonResponse, HttpResponse
+from django.http import JsonResponse
 
 from cms.models import Region, Offer, Language
 from cms.constants import region_status
@@ -155,4 +155,4 @@ def pushnew(_):
         push_notification_channels=[],
     )
     region.save()
-    return HttpResponse("Pushing successful")
+    return JsonResponse({"success": "Pushing successful"}, status=201)

--- a/src/api/v3/regions.py
+++ b/src/api/v3/regions.py
@@ -7,6 +7,8 @@ from django.http import JsonResponse
 from cms.models import Region, Offer, Language
 from cms.constants import region_status
 
+from ..decorators import json_response
+
 
 def transform_region(region):
     """
@@ -61,6 +63,7 @@ def transform_region_by_status(region):
     }
 
 
+@json_response
 def regions(_):
     """
     List all regions that are not archived and transform result into JSON
@@ -84,6 +87,7 @@ def regions(_):
     )  # Turn off Safe-Mode to allow serializing arrays
 
 
+@json_response
 def liveregions(_):
     """
     List all regions that are not archived and transform result into JSON
@@ -107,6 +111,7 @@ def liveregions(_):
     )  # Turn off Safe-Mode to allow serializing arrays
 
 
+@json_response
 def hiddenregions(_):
     """
     List all regions that are hidden and transform result into JSON
@@ -130,6 +135,7 @@ def hiddenregions(_):
     )  # Turn off Safe-Mode to allow serializing arrays
 
 
+@json_response
 def pushnew(_):
     """
     This is a magic black box convenience function for development. There is no

--- a/src/api/v3/single_page.py
+++ b/src/api/v3/single_page.py
@@ -8,7 +8,10 @@ from django.shortcuts import get_object_or_404
 from cms.models import Region
 from .pages import transform_page
 
+from ..decorators import json_response
 
+
+@json_response
 # pylint: disable=unused-argument
 def single_page(request, region_slug, language_code):
     """

--- a/src/cms/models/regions/region.py
+++ b/src/cms/models/regions/region.py
@@ -1,7 +1,7 @@
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.http import Http404
 from django.utils import timezone
+from django.shortcuts import get_object_or_404
 
 from ...constants import region_status, administrative_division
 from ..languages.language import Language
@@ -133,10 +133,7 @@ class Region(models.Model):
         region_slug = request.resolver_match.kwargs.get("region_slug")
         if not region_slug:
             return None
-        region = cls.objects.filter(slug=region_slug)
-        if not region.exists():
-            raise Http404
-        return region.first()
+        return get_object_or_404(cls, slug=region_slug)
 
     def __str__(self):
         """


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This adds a custom decorator which makes sure the API always returns a JSON response, even if the error `Http404` is raised.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Make use of shortcut functions in API
- Add json_response decorator

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #578
