### PR TITLE
Remove random short URL

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-25 01:27+0000\n"
+"POT-Creation-Date: 2020-11-26 15:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -581,8 +581,8 @@ msgstr "Aktuelle Übersetzungen"
 #: templates/analytics/translation_coverage.html:46
 #: templates/events/event_form.html:93 templates/events/event_form.html:122
 #: templates/events/event_list_archived_row.html:54
-#: templates/events/event_list_row.html:54 templates/pages/page_form.html:100
-#: templates/pages/page_form.html:129 templates/pages/page_sbs.html:66
+#: templates/events/event_list_row.html:54 templates/pages/page_form.html:102
+#: templates/pages/page_form.html:131 templates/pages/page_sbs.html:66
 #: templates/pages/page_sbs.html:125
 #: templates/pages/page_tree_archived_node.html:59
 #: templates/pages/page_tree_node.html:54 templates/pois/poi_form.html:82
@@ -759,7 +759,7 @@ msgid "Not after"
 msgstr "Nicht nach"
 
 #: templates/events/_event_filter_form.html:34
-#: templates/events/event_form.html:475 templates/pages/page_form.html:424
+#: templates/events/event_form.html:475 templates/pages/page_form.html:426
 #: templates/pages/page_sbs.html:267 templates/pois/poi_form.html:321
 msgid "Location"
 msgstr "Ort"
@@ -886,8 +886,8 @@ msgstr "Zur Überprüfung vorlegen"
 
 #: templates/events/event_form.html:89 templates/events/event_form.html:118
 #: templates/events/event_list_archived_row.html:58
-#: templates/events/event_list_row.html:58 templates/pages/page_form.html:96
-#: templates/pages/page_form.html:125 templates/pages/page_sbs.html:62
+#: templates/events/event_list_row.html:58 templates/pages/page_form.html:98
+#: templates/pages/page_form.html:127 templates/pages/page_sbs.html:62
 #: templates/pages/page_sbs.html:121
 #: templates/pages/page_tree_archived_node.html:63
 #: templates/pages/page_tree_node.html:58 templates/pois/poi_form.html:78
@@ -897,8 +897,8 @@ msgstr "Übersetzung ist veraltet"
 
 #: templates/events/event_form.html:97 templates/events/event_form.html:126
 #: templates/events/event_list_archived_row.html:62
-#: templates/events/event_list_row.html:62 templates/pages/page_form.html:104
-#: templates/pages/page_form.html:133 templates/pages/page_sbs.html:70
+#: templates/events/event_list_row.html:62 templates/pages/page_form.html:106
+#: templates/pages/page_form.html:135 templates/pages/page_sbs.html:70
 #: templates/pages/page_sbs.html:129
 #: templates/pages/page_tree_archived_node.html:67
 #: templates/pages/page_tree_node.html:62 templates/pois/poi_form.html:86
@@ -908,15 +908,15 @@ msgstr "Übersetzung ist aktuell"
 
 #: templates/events/event_form.html:102 templates/events/event_form.html:131
 #: templates/events/event_list_archived_row.html:67
-#: templates/events/event_list_row.html:67 templates/pages/page_form.html:109
-#: templates/pages/page_form.html:138
+#: templates/events/event_list_row.html:67 templates/pages/page_form.html:111
+#: templates/pages/page_form.html:140
 #: templates/pages/page_tree_archived_node.html:72
 #: templates/pages/page_tree_node.html:67 templates/pois/poi_form.html:91
 #: templates/pois/poi_form.html:120 templates/pois/poi_list_row.html:66
 msgid "Translation missing"
 msgstr "Übersetzung fehlt"
 
-#: templates/events/event_form.html:107 templates/pages/page_form.html:114
+#: templates/events/event_form.html:107 templates/pages/page_form.html:116
 #: templates/pages/page_sbs.html:134 templates/pois/poi_form.html:96
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
@@ -932,7 +932,7 @@ msgstr "Version"
 
 #: templates/events/event_form.html:148 templates/events/event_list.html:69
 #: templates/events/event_list_archived.html:52
-#: templates/pages/page_form.html:156 templates/pages/page_revisions.html:44
+#: templates/pages/page_form.html:158 templates/pages/page_revisions.html:44
 #: templates/pages/page_sbs.html:82 templates/pages/page_sbs.html:149
 #: templates/pages/page_sbs.html:154 templates/pages/page_tree.html:61
 #: templates/pages/page_tree_archived.html:32 templates/pois/poi_form.html:137
@@ -941,7 +941,7 @@ msgstr "Version"
 msgid "Status"
 msgstr "Status"
 
-#: templates/events/event_form.html:151 templates/pages/page_form.html:159
+#: templates/events/event_form.html:151 templates/pages/page_form.html:161
 #: templates/pages/page_revisions.html:62
 #: templates/pages/page_revisions.html:76 templates/pages/page_sbs.html:84
 #: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:140
@@ -949,14 +949,14 @@ msgstr "Status"
 msgid "Permalink"
 msgstr "Permalink"
 
-#: templates/events/event_form.html:153 templates/pages/page_form.html:161
+#: templates/events/event_form.html:153 templates/pages/page_form.html:163
 #: templates/pages/page_sbs.html:159 templates/regions/region_form.html:55
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
-#: templates/events/event_form.html:164 templates/pages/page_form.html:172
+#: templates/events/event_form.html:164 templates/pages/page_form.html:174
 #: templates/pages/page_revisions.html:64
 #: templates/pages/page_revisions.html:77 templates/pages/page_sbs.html:98
 #: templates/pages/page_sbs.html:170 templates/pages/page_xliff_confirm.html:43
@@ -966,7 +966,7 @@ msgstr ""
 msgid "Title"
 msgstr "Titel"
 
-#: templates/events/event_form.html:165 templates/pages/page_form.html:173
+#: templates/events/event_form.html:165 templates/pages/page_form.html:175
 #: templates/pages/page_sbs.html:171 templates/pois/poi_form.html:151
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
@@ -979,17 +979,17 @@ msgstr "Beschreibung"
 msgid "Insert description here"
 msgstr "Beschreibung hier eingeben"
 
-#: templates/events/event_form.html:170 templates/pages/page_form.html:178
+#: templates/events/event_form.html:170 templates/pages/page_form.html:180
 #: templates/pages/page_sbs.html:176 templates/pois/poi_form.html:158
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
-#: templates/events/event_form.html:172 templates/pages/page_form.html:180
+#: templates/events/event_form.html:172 templates/pages/page_form.html:182
 #: templates/pages/page_sbs.html:178 templates/pois/poi_form.html:160
 msgid "This change does not require an update of the translations"
 msgstr "Diese Änderung erfordert keine angepasste Übersetzung"
 
-#: templates/events/event_form.html:182 templates/pages/page_form.html:222
+#: templates/events/event_form.html:182 templates/pages/page_form.html:224
 #: templates/pois/poi_form.html:170
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
@@ -1090,14 +1090,14 @@ msgstr "Land"
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:288 templates/pages/page_form.html:272
+#: templates/events/event_form.html:288 templates/pages/page_form.html:274
 #: templates/pois/poi_form.html:202 templates/regions/region_icon_widget.html:4
 msgid "Icon"
 msgstr "Icon"
 
 #: templates/events/event_form.html:292
 #: templates/organizations/organization_form.html:65
-#: templates/pages/page_form.html:276 templates/pois/poi_form.html:206
+#: templates/pages/page_form.html:278 templates/pois/poi_form.html:206
 #: templates/regions/region_icon_widget.html:15
 msgid "Set icon"
 msgstr "Icon festlegen"
@@ -1130,32 +1130,32 @@ msgstr "Veranstaltung löschen"
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:456 templates/pages/page_form.html:405
+#: templates/events/event_form.html:456 templates/pages/page_form.html:407
 #: templates/pages/page_sbs.html:248 templates/pois/poi_form.html:302
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:482 templates/pages/page_form.html:431
+#: templates/events/event_form.html:482 templates/pages/page_form.html:433
 #: templates/pages/page_sbs.html:274 templates/pois/poi_form.html:328
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:489 templates/pages/page_form.html:438
+#: templates/events/event_form.html:489 templates/pages/page_form.html:440
 #: templates/pages/page_sbs.html:281 templates/pois/poi_form.html:335
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:496 templates/pages/page_form.html:445
+#: templates/events/event_form.html:496 templates/pages/page_form.html:447
 #: templates/pages/page_sbs.html:288 templates/pois/poi_form.html:342
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:503 templates/pages/page_form.html:452
+#: templates/events/event_form.html:503 templates/pages/page_form.html:454
 #: templates/pages/page_sbs.html:295 templates/pois/poi_form.html:349
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:510 templates/pages/page_form.html:459
+#: templates/events/event_form.html:510 templates/pages/page_form.html:461
 #: templates/pages/page_sbs.html:302 templates/pois/poi_form.html:356
 msgid "Hint"
 msgstr "Tipp"
@@ -1690,58 +1690,58 @@ msgstr "Neue Übersetzung erstellen"
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page_form.html:153
+#: templates/pages/page_form.html:155
 msgid "Revision"
 msgstr "Revision"
 
-#: templates/pages/page_form.html:155
+#: templates/pages/page_form.html:157
 msgid "Show revisions"
 msgstr "Revisionen anzeigen"
 
-#: templates/pages/page_form.html:175 templates/pages/page_revisions.html:66
+#: templates/pages/page_form.html:177 templates/pages/page_revisions.html:66
 #: templates/pages/page_revisions.html:78 templates/pages/page_sbs.html:101
 #: templates/pages/page_sbs.html:173 templates/pages/page_xliff_confirm.html:45
 #: templates/push_notifications/push_notification_form.html:67
 msgid "Content"
 msgstr "Inhalt"
 
-#: templates/pages/page_form.html:176 templates/pages/page_sbs.html:174
+#: templates/pages/page_form.html:178 templates/pages/page_sbs.html:174
 msgid "Insert content here"
 msgstr "Inhalt hier eingeben"
 
-#: templates/pages/page_form.html:191
+#: templates/pages/page_form.html:193
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: templates/pages/page_form.html:198
+#: templates/pages/page_form.html:200
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
-#: templates/pages/page_form.html:212
+#: templates/pages/page_form.html:214
 msgid "Show translations side by side"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
-#: templates/pages/page_form.html:229
+#: templates/pages/page_form.html:231
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page_form.html:230
+#: templates/pages/page_form.html:232
 msgid "Parent Page"
 msgstr "Übergeordnete Seite"
 
-#: templates/pages/page_form.html:239
+#: templates/pages/page_form.html:241
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: templates/pages/page_form.html:244
+#: templates/pages/page_form.html:246
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:265
+#: templates/pages/page_form.html:267
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:266
+#: templates/pages/page_form.html:268
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -1749,37 +1749,37 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:283 templates/pages/page_form.html:284
+#: templates/pages/page_form.html:285 templates/pages/page_form.html:286
 #: templates/pages/page_tree_archived_node.html:87
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:285
+#: templates/pages/page_form.html:287
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:288 templates/pages/page_form.html:289
+#: templates/pages/page_form.html:290 templates/pages/page_form.html:291
 #: templates/pages/page_tree_node.html:91
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:291
+#: templates/pages/page_form.html:293
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:297 templates/pages/page_form.html:301
+#: templates/pages/page_form.html:299 templates/pages/page_form.html:303
 #: templates/pages/page_tree_archived_node.html:96
 #: templates/pages/page_tree_node.html:100
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:299
+#: templates/pages/page_form.html:301
 #: templates/pages/page_tree_archived_node.html:92
 #: templates/pages/page_tree_node.html:96
 msgid "You cannot delete a page which has children."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:303
+#: templates/pages/page_form.html:305
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
@@ -2866,32 +2866,32 @@ msgstr "Sie können keine Seite löschen, die Unterseiten besitzt"
 msgid "Page was successfully deleted"
 msgstr "Seite wurde erfolgreich gelöscht"
 
-#: views/pages/page_actions.py:461
+#: views/pages/page_actions.py:439
 #, python-brace-format
 msgid "The page \"{page}\" was successfully moved."
 msgstr "Die Seite \"{page}\" wurde erfolgreich verschoben."
 
-#: views/pages/page_actions.py:551 views/pages/page_actions.py:566
+#: views/pages/page_actions.py:529 views/pages/page_actions.py:544
 #, python-brace-format
 msgid "Information: The user {user} has this permission already."
 msgstr "Information: Der Nutzer {user} hat diese Berechtigung bereits"
 
-#: views/pages/page_actions.py:558
+#: views/pages/page_actions.py:536
 #, python-brace-format
 msgid "Success: The user {user} can now edit this page."
 msgstr "Erfolg: Der Nutzer {user} kann nun diese Seite bearbeiten"
 
-#: views/pages/page_actions.py:574
+#: views/pages/page_actions.py:552
 #, python-brace-format
 msgid "Success: The user {user} can now publish this page."
 msgstr "Erfolg: Der Nutzer {user} kann dieses Seite nun veröffentlichen"
 
-#: views/pages/page_actions.py:583 views/pages/page_actions.py:698
+#: views/pages/page_actions.py:561 views/pages/page_actions.py:676
 msgid "An error has occurred. Please contact an administrator."
 msgstr ""
 "Ein Fehler ist aufgetreten. Bitte kontaktieren Sie einen Administrator."
 
-#: views/pages/page_actions.py:666
+#: views/pages/page_actions.py:644
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the editors of this page, "
@@ -2901,12 +2901,12 @@ msgstr ""
 "bearbeiten wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin bearbeiten."
 
-#: views/pages/page_actions.py:672
+#: views/pages/page_actions.py:650
 #, python-brace-format
 msgid "Success: The user {user} cannot edit this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr bearbeiten"
 
-#: views/pages/page_actions.py:683
+#: views/pages/page_actions.py:661
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the publishers of this "
@@ -2916,7 +2916,7 @@ msgstr ""
 "veröffentlichen wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen."
 
-#: views/pages/page_actions.py:689
+#: views/pages/page_actions.py:667
 #, python-brace-format
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"

--- a/src/cms/models/pages/abstract_base_page_translation.py
+++ b/src/cms/models/pages/abstract_base_page_translation.py
@@ -1,9 +1,7 @@
-import string
-import random
-
 from django.db import models
+from django.urls import reverse
 from django.utils import timezone
-
+from backend.settings import BASE_URL
 from backend.settings import WEBAPP_URL
 
 from ...constants import status
@@ -41,7 +39,6 @@ class AbstractBasePageTranslation(models.Model):
     minor_edit = models.BooleanField(default=False)
     created_date = models.DateTimeField(default=timezone.now)
     last_updated = models.DateTimeField(auto_now=True)
-    short_url_id = models.CharField(max_length=10, default="")
 
     @property
     def page(self):
@@ -101,16 +98,15 @@ class AbstractBasePageTranslation(models.Model):
     @property
     def short_url(self):
         """
-        This function generates unique string and returns the short url to the page translation
+        This function returns the absolute short url to the page translation
 
         :return: The short url of a page translation
         :rtype: str
         """
-        if not (self.short_url_id):
-            chars = string.ascii_letters + string.digits
-            self.short_url_id = "".join((random.choice(chars) for i in range(10)))
-            self.save()
-        return self.short_url_id
+
+        return BASE_URL + reverse(
+            "expand_page_translation_id", kwargs={"short_url_id": self.id}
+        )
 
     @property
     def available_languages(self):

--- a/src/cms/static/js/copy-clipboard.js
+++ b/src/cms/static/js/copy-clipboard.js
@@ -1,10 +1,10 @@
 function short_url_to_clipboard(url) {
-    var copyText = document.getElementById("copy_to_clipboard");
-    var arr = window.location.href.split("/");
-    copyText.value = arr[0]+ "//" + arr[2] + "/" + url;
-    u('#copy_to_clipboard').removeClass('hidden');
-    copyText.select();
-    copyText.setSelectionRange(0, 99999);
+    let copyDivUmbrella = u('#copy_to_clipboard');
+    let copyDivPlain = copyDivUmbrella.first();
+    copyDivPlain.value = url;
+    copyDivUmbrella.removeClass('hidden');
+    copyDivPlain.select();
+    copyDivPlain.setSelectionRange(0, 99999);
     document.execCommand("copy");
-    u('#copy_to_clipboard').addClass('hidden');
+    copyDivUmbrella.addClass('hidden');
 }

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -75,9 +75,11 @@
             {% else %}
                 <input type="submit" name="submit_review" class="cursor-pointer bg-blue-500 hover:bg-green-600 text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Submit for review' %}" />
             {% endif %}
-            <button type="button" onclick="short_url_to_clipboard('s/p/{{ page_translation_form.instance.id }}');" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded">
+            {% if page_translation_form.instance.id %}
+            <button type="button" onclick="short_url_to_clipboard('{{ page_translation_form.instance.short_url }}');" class="cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 rounded">
                 <i data-feather="globe" class="inline-block text-gray-200"></i>
             </button>
+            {% endif %}
         {% endif %}
         </div>
         <div class="w-2/3 flex flex-wrap flex-col pr-2">

--- a/src/cms/templates/pages/page_tree_node.html
+++ b/src/cms/templates/pages/page_tree_node.html
@@ -103,7 +103,7 @@
             {% endif %}
         {% endif %}
         {% if page_translation %}
-        <a href="#" onclick="short_url_to_clipboard('s/{{ page_translation.short_url }}');" title="{% trans 'Copy short link' %}" class="py-3 px-2">
+        <a href="#" onclick="short_url_to_clipboard('{{ page_translation.short_url }}');" title="{% trans 'Copy short link' %}" class="py-3 px-2">
             <i data-feather="copy" class="inline-block text-gray-800"></i>
         </a>
         {% else %}

--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -43,11 +43,6 @@ urlpatterns = [
                     pages.expand_page_translation_id,
                     name="expand_page_translation_id",
                 ),
-                url(
-                    r"^(?P<short_url_id>[-\w]+)/",
-                    pages.expand_short_url,
-                    name="expand_short_url",
-                ),
             ]
         ),
     ),

--- a/src/cms/views/pages/__init__.py
+++ b/src/cms/views/pages/__init__.py
@@ -8,7 +8,6 @@ from .page_actions import (
     restore_page,
     view_page,
     delete_page,
-    expand_short_url,
     expand_page_translation_id,
     export_pdf,
     download_xliff,

--- a/src/cms/views/pages/page_actions.py
+++ b/src/cms/views/pages/page_actions.py
@@ -225,28 +225,6 @@ def export_pdf(request, region_slug, language_code):
     return response
 
 
-def expand_short_url(request, short_url_id):
-    """
-    Searches for a page with requested short_url_id and redirects to that page.
-
-    :param request: The current request
-    :type request: ~django.http.HttpResponse
-
-    :param short_url_id: The short url id of the requested page
-    :type short_url_id: str
-
-    :return: A redirection to the :class:`~cms.views.pages.page_tree_view.PageTreeView`
-    :rtype: ~django.http.HttpResponseRedirect
-    """
-
-    queryset = PageTranslation.objects.filter(short_url_id=short_url_id)
-    page_translation = queryset.first().latest_public_revision
-
-    if page_translation and not page_translation.page.archived:
-        return redirect(WEBAPP_URL + page_translation.get_absolute_url())
-    return HttpResponseNotFound("<h1>Page not found</h1>")
-
-
 def expand_page_translation_id(request, short_url_id):
     """
     Searches for a page translation with corresponding ID and redirects browser to web app


### PR DESCRIPTION
### Short description
Remove random short URL
### Proposed changes
`s/p/<ID>` we use the objects numeric ID in conjunction with a second part in the `URL /p/` to point towards pages. Events then get another URL, i.e.` s/e/<ID>`. ID in this case is the instance ID (integer) of a model in the database.
##Task Breakdown:
> 1.Remove URL to view pages.expand_short_url in [urls.py](url)
> 2. Remove the view `expand_short_url` in [page_actions.py](url)
> 3.Remove field `short_url_id` from [`abstract_base_page_translation.py`](url)
> 4.Re-implement the property function `short_ur`l in `abstract_base_page_translation.py` so it returns the short URL of pattern from above. You can use e.g. reverse("`expand_page_translation_id`", `short_url_id=self.id`) to get the url.
> 5.Fix the function `short_url_to_clipboard` in c[opy-clipboard.js](url) so it copies the correct short url to the clipboard.
### Resolved issues
Fixes: #539