### PR TITLE
Change TinyMCE notranslate, fixes #596

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-26 15:05+0000\n"
+"POT-Creation-Date: 2020-12-01 13:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -759,7 +759,7 @@ msgid "Not after"
 msgstr "Nicht nach"
 
 #: templates/events/_event_filter_form.html:34
-#: templates/events/event_form.html:475 templates/pages/page_form.html:426
+#: templates/events/event_form.html:475 templates/pages/page_form.html:442
 #: templates/pages/page_sbs.html:267 templates/pois/poi_form.html:321
 msgid "Location"
 msgstr "Ort"
@@ -1135,27 +1135,27 @@ msgstr "Diese Veranstaltung löschen"
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:482 templates/pages/page_form.html:433
+#: templates/events/event_form.html:482 templates/pages/page_form.html:449
 #: templates/pages/page_sbs.html:274 templates/pois/poi_form.html:328
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:489 templates/pages/page_form.html:440
+#: templates/events/event_form.html:489 templates/pages/page_form.html:456
 #: templates/pages/page_sbs.html:281 templates/pois/poi_form.html:335
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:496 templates/pages/page_form.html:447
+#: templates/events/event_form.html:496 templates/pages/page_form.html:463
 #: templates/pages/page_sbs.html:288 templates/pois/poi_form.html:342
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:503 templates/pages/page_form.html:454
+#: templates/events/event_form.html:503 templates/pages/page_form.html:470
 #: templates/pages/page_sbs.html:295 templates/pois/poi_form.html:349
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:510 templates/pages/page_form.html:461
+#: templates/events/event_form.html:510 templates/pages/page_form.html:477
 #: templates/pages/page_sbs.html:302 templates/pois/poi_form.html:356
 msgid "Hint"
 msgstr "Tipp"

--- a/src/cms/static/css/tinymce_custom.css
+++ b/src/cms/static/css/tinymce_custom.css
@@ -1,3 +1,3 @@
-.notranslate {
+[translate="no"] {
     background-color: rosybrown;
 }

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -406,13 +406,29 @@ document.addEventListener('DOMContentLoaded', function(){
             {
                 tooltip: '{% trans 'Do not translate the selected text.' %}',
                 icon: 'permanent-pen',
-                    onAction: () => {
+                onAction: () => {
                     editor.focus();
-                    val = tinymce.activeEditor.dom.getAttrib(tinyMCE.activeEditor.selection.getNode(), "translate", "yes");
-                    if(val == "no") {
-                        tinymce.activeEditor.dom.setAttrib(tinyMCE.activeEditor.selection.getNode(), "translate", null);
-                    } else if (editor.selection.getContent().length > 0) {
-                        editor.selection.setContent('<span class="notranslate" translate="no">' + editor.selection.getContent() + '</span>');
+                    let current_node = tinymce.activeEditor.selection.getStart();
+                    let end_node = tinymce.activeEditor.selection.getEnd();
+                    let current_no_translate = editor.dom.getAttrib(current_node, "translate", null);
+                    if (current_node != end_node) {
+                        while (current_node) {
+                            if (current_no_translate == "no") {
+                                editor.dom.setAttrib(current_node, "translate", null);
+                            } else {
+                                editor.dom.setAttrib(current_node, "translate", "no");
+                            }
+                            if (current_node === end_node) {
+                                break;
+                            }
+                            current_node = current_node.nextSibling;
+                        }
+                    } else {
+                        if(current_no_translate == "no") {
+                            editor.dom.setAttrib(current_node, "translate", null);
+                        } else if (editor.selection.getContent().length > 0) {
+                            editor.execCommand('mceInsertContent', false, '<span translate="no">' + editor.selection.getContent({'format': 'html'}) + '</span>');
+                        }
                     }
                 }
             });


### PR DESCRIPTION
The current "Do not translate" button functionality is very basic: it wraps the selected text in span tags with the `translate="no"` property. It does not concern itself with the HTML structure of the page. This is a recipe for carnage.

This PR selects the actual DOM elements and toggles the `translate="no"` attribute for it.

Fixes: #596 

There are still some limitations: If the selection starts with a nested element, the selected siblings of ancestors will not receive the translate attribute. But this is IMHO acceptable. In such cases, other parts of the page need to be selected individually.