### PR TITLE
Show latest feedback in dashboard

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-25 11:52+0000\n"
+"POT-Creation-Date: 2021-01-27 11:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -783,6 +783,47 @@ msgstr "Womöglich ist diese E-Mail Adresse nicht im System vorhanden."
 msgid "E-mail address"
 msgstr "E-Mail Adresse"
 
+#: templates/dashboard/admin_dashboard.html:5
+#: templates/feedback/admin_feedback_list.html:6
+msgid "Technical Feedback"
+msgstr "Technisches Feedback"
+
+#: templates/dashboard/admin_dashboard.html:9
+#: templates/feedback/admin_feedback_list.html:12
+#: templates/feedback/region_feedback_list.html:12
+#: templates/language_tree/language_tree.html:35
+#: templates/language_tree/language_tree_node_form.html:27
+msgid "Language"
+msgstr "Sprache"
+
+#: templates/dashboard/admin_dashboard.html:10
+#: templates/feedback/admin_feedback_list.html:13
+#: templates/feedback/region_feedback_list.html:13
+msgid "Comment"
+msgstr "Kommentar"
+
+#: templates/dashboard/admin_dashboard.html:11
+#: templates/feedback/admin_feedback_list.html:14
+#: templates/feedback/region_feedback_list.html:14
+#: templates/feedback/region_feedback_list.html:122
+msgid "Rating"
+msgstr "Bewertung"
+
+#: templates/dashboard/admin_dashboard.html:12
+#: templates/events/event_form.html:189
+#: templates/feedback/admin_feedback_list.html:15
+#: templates/feedback/region_feedback_list.html:15
+#: templates/media/media_list.html:23
+msgid "Date"
+msgstr "Datum"
+
+#: templates/dashboard/admin_dashboard.html:22
+#: templates/feedback/admin_feedback_list.html:18
+#: templates/feedback/region_feedback_list.html:18
+#: templates/feedback/region_feedback_list.html:131
+msgid "No Feedback available yet."
+msgstr "Noch kein Feedback vorhanden."
+
 #: templates/dashboard/dashboard.html:11
 msgid "At a glance"
 msgstr "Auf einen Blick"
@@ -988,13 +1029,6 @@ msgstr "Diese Änderung erfordert keine angepasste Übersetzung"
 #: templates/pages/page_form.html:254 templates/pois/poi_form.html:170
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
-
-#: templates/events/event_form.html:189
-#: templates/feedback/admin_feedback_list.html:15
-#: templates/feedback/region_feedback_list.html:15
-#: templates/media/media_list.html:23
-msgid "Date"
-msgstr "Datum"
 
 #: templates/events/event_form.html:192 templates/events/event_form.html:206
 #: templates/events/event_list.html:89
@@ -1226,10 +1260,6 @@ msgstr "Nicht festgelegt"
 msgid "Edit event"
 msgstr "Veranstaltung bearbeiten"
 
-#: templates/feedback/admin_feedback_list.html:6
-msgid "Technical Feedback"
-msgstr "Technisches Feedback"
-
 #: templates/feedback/admin_feedback_list.html:10
 #: templates/feedback/region_feedback_list.html:10
 #: templates/feedback/region_feedback_list.html:126
@@ -1240,30 +1270,6 @@ msgstr "Typ"
 #: templates/feedback/region_feedback_list.html:11
 msgid "Object"
 msgstr "Objekt"
-
-#: templates/feedback/admin_feedback_list.html:12
-#: templates/feedback/region_feedback_list.html:12
-#: templates/language_tree/language_tree.html:35
-#: templates/language_tree/language_tree_node_form.html:27
-msgid "Language"
-msgstr "Sprache"
-
-#: templates/feedback/admin_feedback_list.html:13
-#: templates/feedback/region_feedback_list.html:13
-msgid "Comment"
-msgstr "Kommentar"
-
-#: templates/feedback/admin_feedback_list.html:14
-#: templates/feedback/region_feedback_list.html:14
-#: templates/feedback/region_feedback_list.html:122
-msgid "Rating"
-msgstr "Bewertung"
-
-#: templates/feedback/admin_feedback_list.html:18
-#: templates/feedback/region_feedback_list.html:18
-#: templates/feedback/region_feedback_list.html:131
-msgid "No Feedback available yet."
-msgstr "Noch kein Feedback vorhanden."
 
 #: templates/feedback/admin_feedback_list.html:23
 msgid "Page"

--- a/src/cms/templates/dashboard/admin_dashboard.html
+++ b/src/cms/templates/dashboard/admin_dashboard.html
@@ -1,5 +1,25 @@
 {% extends "_base.html" %}
 {% load i18n %}
+
 {% block content %}
-    Admin Dashboard
+<h2>{% trans 'Technical Feedback' %}</h2>
+
+<table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
+    <tr class="border-b border-solid border-gray-200">
+        <th class="text-sm text-left uppercase py-3 pl-2">{% trans 'Language' %}</th>
+        <th class="text-sm text-left uppercase py-3">{% trans 'Comment' %}</th>
+        <th class="text-sm text-left uppercase py-3">{% trans 'Rating' %}</th>
+        <th class="text-sm text-right uppercase py-3 pr-2">{% trans 'Date' %}</th>
+    </tr>
+    {% for feedback in all_feedback %}
+    <tr>
+        <td class="pl-2 py-3">{{ feedback.language.translated_name }}</td>
+        <td>{{ feedback.comment }}</td>
+        <td>{{ feedback.get_emotion_display }}</td>
+        <td class="pr-2 text-right">{{ feedback.created_date }}</td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="6" class="px-2 py-3">{% trans 'No Feedback available yet.' %} </td></tr>
+    {% endfor %}
+</table>
 {% endblock %}

--- a/src/cms/views/dashboard/admin_dashboard_view.py
+++ b/src/cms/views/dashboard/admin_dashboard_view.py
@@ -4,6 +4,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
 from ...decorators import staff_required
+from ...models import Feedback
 
 
 @method_decorator(login_required, name="dispatch")
@@ -34,6 +35,14 @@ class AdminDashboardView(TemplateView):
         :return: The rendered template response
         :rtype: ~django.template.response.TemplateResponse
         """
+        all_feedback = Feedback.objects.filter(is_technical=True)[:5]
 
-        val = "To be defined"
-        return render(request, self.template_name, {"key": val, **self.base_context})
+        return render(
+            request,
+            self.template_name,
+            {
+                "current_menu_item": "admin_feedback",
+                "all_feedback": all_feedback,
+                **self.base_context,
+            },
+        )

--- a/src/cms/views/dashboard/dashboard_view.py
+++ b/src/cms/views/dashboard/dashboard_view.py
@@ -41,7 +41,6 @@ class DashboardView(TemplateView):
         :rtype: ~django.template.response.TemplateResponse
         """
 
-        val = "To be defined"
         language_code = translation.get_language()
         feed = feedparser.parse(RSS_FEED_URLS[language_code])
         # select five most recent feeds
@@ -54,7 +53,6 @@ class DashboardView(TemplateView):
             request,
             self.template_name,
             {
-                "key": val,
                 **self.base_context,
                 "feed": feed,
                 "home_page": RSS_FEED_URLS["home-page"],


### PR DESCRIPTION
### Short description
This should be a list of the last ~5 messages.
### Proposed changes
Show admins the latest feedback from app users in dashboard. This should be a list of the last ~5 messages. In some cases, the feedback only contains a thumbs up or down, in other cases it can contain a message. The title of the page or event concerned should be displayed as well and linked to the editing page.

Additional option: Add link that sends the message string to translate.google.com or deepl.com for translation. This can be useful if the feedback is given in a language the back end user does not understand. It is perfectly fine, if the link opens the translation website in a new tab. No need to fetch a translation via the API.

### Resolved issues
Fixes: #2