### PR TITLE
Fixed detecting no changes for page form

### DIFF
--- a/src/cms/forms/pages/page_form.py
+++ b/src/cms/forms/pages/page_form.py
@@ -114,8 +114,8 @@ class PageForm(forms.ModelForm):
         (True, _("Embed mirrored page before this page")),
         (False, _("Embed mirrored page after this page")),
     )
-    mirrored_page_first = forms.ChoiceField(
-        choices=TRUE_FALSE_CHOICES, widget=forms.Select(), required=False
+    mirrored_page_first = forms.BooleanField(
+        widget=forms.Select(choices=TRUE_FALSE_CHOICES), required=False, initial=True
     )
 
     class Meta:


### PR DESCRIPTION

### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes change detection in page form

### Proposed changes
<!-- Describe this PR in more detail. -->

- Problem was that the mirror_page_first field (which was a ChoiceField) normalizes their values
  to strings (see https://docs.djangoproject.com/en/2.2/ref/forms/fields/#choicefield).
- So when comparing the initial value of the select widget True with the
  current value of the form field 'True',
  it always evaluated True != 'True'.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #466 
