### PR TITLE
Fix xhtml2pdf entry in Pipfile.lock

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -471,8 +471,10 @@
             "version": "==0.5.1"
         },
         "xhtml2pdf": {
-            "editable": true,
-            "path": "."
+            "hashes": [
+                "sha256:6797e974fac66f0efbe927c1539a2756ca4fe8777eaa5882bac132fc76b39421"
+            ],
+            "version": "==0.2.5"
         }
     },
     "develop": {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Sometimes, pipenv does strange things, like e.g. marking dependencies as local editable packages... 
I didn't yet find the reason for this, so we have to look out for this in the future. For now, this fixes the Pipfile.lock by reverting the changes introduced in 7a61ce9f9eb333f1c3386e8bc62578a01a6f88ce.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Fix xhtml2pdf dependency in Pipfile.lock

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
This should fix the failing build in #616 
