### PR TITLE
Pass environment variables only if they are set

### DIFF
--- a/src/backend/wsgi.py
+++ b/src/backend/wsgi.py
@@ -13,17 +13,9 @@ from django.core.wsgi import get_wsgi_application
 
 
 def application(environ, start_response):
-    os.environ["DJANGO_SECRET_KEY"] = environ["DJANGO_SECRET_KEY"]
-    os.environ["DJANGO_DEBUG"] = environ["DJANGO_DEBUG"]
-    os.environ["DJANGO_BASE_URL"] = environ["DJANGO_BASE_URL"]
-    os.environ["DJANGO_WEBAPP_URL"] = environ["DJANGO_WEBAPP_URL"]
-    os.environ["DJANGO_DB_HOST"] = environ["DJANGO_DB_HOST"]
-    os.environ["DJANGO_DB_PORT"] = environ["DJANGO_DB_PORT"]
-    os.environ["DJANGO_DB_USER"] = environ["DJANGO_DB_USER"]
-    os.environ["DJANGO_DB_NAME"] = environ["DJANGO_DB_NAME"]
-    os.environ["DJANGO_DB_PASSWORD"] = environ["DJANGO_DB_PASSWORD"]
-    os.environ["DJANGO_STATIC_ROOT"] = environ["DJANGO_STATIC_ROOT"]
-    os.environ["DJANGO_MEDIA_ROOT"] = environ["DJANGO_MEDIA_ROOT"]
+    for key in environ:
+        if key.startswith("DJANGO_"):
+            os.environ[key] = environ[key]
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
     _application = get_wsgi_application()


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
If I try to start the development server while no environment variables are set, I get the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.7/wsgiref/handlers.py", line 137, in run
    self.result = application(self.environ, self.start_response)
  File "/home/timo/integreat/integreat-cms/.venv/lib/python3.7/site-packages/django/contrib/staticfiles/handlers.py", line 65, in __call__
    return self.application(environ, start_response)
  File "/home/timo/integreat/integreat-cms/src/backend/wsgi.py", line 16, in application
    os.environ["DJANGO_SECRET_KEY"] = environ["DJANGO_SECRET_KEY"]
KeyError: 'DJANGO_SECRET_KEY'
Jan 09 12:29:40 INTEGREAT CMS - ERROR: "GET / HTTP/1.1" 500 59
```

### Proposed changes
<!-- Describe this PR in more detail. -->
- Only pass the environment variables if they are set

