### PR TITLE
Update currently in translation state on import/export XLIFF

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-21 19:07+0000\n"
+"POT-Creation-Date: 2021-01-22 11:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -226,7 +226,7 @@ msgid "Hidden"
 msgstr "Versteckt"
 
 #: constants/region_status.py:20 forms/pages/page_form.py:97
-#: forms/pages/page_form.py:115 templates/pages/page_form.html:154
+#: forms/pages/page_form.py:115 templates/pages/page_form.html:166
 #: templates/pages/page_tree_archived_node.html:23
 msgid "Archived"
 msgstr "Archiviert"
@@ -377,7 +377,7 @@ msgstr "Die Passwörter stimmen nicht überein."
 #: templates/events/event_list_archived.html:33
 #: templates/language_tree/language_tree.html:20
 #: templates/media/media_list.html:8 templates/offers/offer_list.html:15
-#: templates/pages/page_tree.html:35 templates/pages/page_tree_archived.html:21
+#: templates/pages/page_tree.html:34 templates/pages/page_tree_archived.html:21
 #: templates/pois/poi_list.html:31 templates/pois/poi_list_archived.html:21
 #: templates/push_notifications/push_notification_list.html:9
 #: templates/regions/region_list.html:14 templates/users/admin/list.html:14
@@ -444,7 +444,7 @@ msgstr "Neue Mediendatei hochladen"
 
 #: templates/_base.html:142 templates/feedback/region_feedback_list.html:24
 #: templates/feedback/region_feedback_list.html:136
-#: templates/pages/page_tree.html:19 templates/regions/region_form.html:196
+#: templates/pages/page_tree.html:18 templates/regions/region_form.html:196
 msgid "Pages"
 msgstr "Seiten"
 
@@ -452,8 +452,8 @@ msgstr "Seiten"
 msgid "All pages"
 msgstr "Alle Seiten"
 
-#: templates/_base.html:150 templates/pages/page_tree.html:43
-#: templates/pages/page_tree.html:47
+#: templates/_base.html:150 templates/pages/page_tree.html:42
+#: templates/pages/page_tree.html:46
 msgid "Create page"
 msgstr "Seite erstellen"
 
@@ -588,10 +588,13 @@ msgstr "Aktuelle Übersetzungen"
 #: templates/imprint/imprint_form.html:77
 #: templates/imprint/imprint_form.html:106
 #: templates/imprint/imprint_sbs.html:59 templates/imprint/imprint_sbs.html:114
-#: templates/pages/page_form.html:96 templates/pages/page_form.html:125
+#: templates/pages/page_form.html:96 templates/pages/page_form.html:137
 #: templates/pages/page_sbs.html:66 templates/pages/page_sbs.html:125
 #: templates/pages/page_tree_archived_node.html:65
-#: templates/pages/page_tree_node.html:54 templates/pois/poi_form.html:82
+#: templates/pages/page_tree_node.html:42
+#: templates/pages/page_tree_node.html:49
+#: templates/pages/page_tree_node.html:65
+#: templates/pages/page_tree_node.html:84 templates/pois/poi_form.html:82
 #: templates/pois/poi_form.html:111 templates/pois/poi_list_row.html:53
 msgid "Currently in translation"
 msgstr "Wird derzeit übersetzt"
@@ -770,7 +773,7 @@ msgstr "Nicht nach"
 
 #: templates/events/_event_filter_form.html:34
 #: templates/events/event_form.html:480 templates/imprint/imprint_form.html:327
-#: templates/imprint/imprint_sbs.html:257 templates/pages/page_form.html:456
+#: templates/imprint/imprint_sbs.html:257 templates/pages/page_form.html:482
 #: templates/pages/page_sbs.html:267 templates/pois/poi_form.html:326
 msgid "Location"
 msgstr "Ort"
@@ -811,8 +814,8 @@ msgstr "Event \"%(event_title)s\" bearbeiten"
 #: templates/events/event_list.html:76
 #: templates/events/event_list_archived.html:53
 #: templates/events/event_list_archived.html:59
-#: templates/pages/page_form.html:55 templates/pages/page_tree.html:62
-#: templates/pages/page_tree.html:68 templates/pages/page_tree_archived.html:33
+#: templates/pages/page_form.html:55 templates/pages/page_tree.html:61
+#: templates/pages/page_tree.html:67 templates/pages/page_tree_archived.html:33
 #: templates/pages/page_tree_archived.html:39 templates/pois/poi_form.html:54
 #: templates/pois/poi_list.html:50 templates/pois/poi_list.html:56
 #: templates/pois/poi_list_archived.html:33
@@ -851,10 +854,11 @@ msgstr "Zur Überprüfung vorlegen"
 #: templates/imprint/imprint_form.html:73
 #: templates/imprint/imprint_form.html:102
 #: templates/imprint/imprint_sbs.html:55 templates/imprint/imprint_sbs.html:110
-#: templates/pages/page_form.html:92 templates/pages/page_form.html:121
-#: templates/pages/page_sbs.html:62 templates/pages/page_sbs.html:121
+#: templates/pages/page_form.html:92 templates/pages/page_form.html:118
+#: templates/pages/page_form.html:133 templates/pages/page_sbs.html:62
+#: templates/pages/page_sbs.html:121
 #: templates/pages/page_tree_archived_node.html:69
-#: templates/pages/page_tree_node.html:58 templates/pois/poi_form.html:78
+#: templates/pages/page_tree_node.html:69 templates/pois/poi_form.html:78
 #: templates/pois/poi_form.html:107 templates/pois/poi_list_row.html:57
 msgid "Translation outdated"
 msgstr "Übersetzung ist veraltet"
@@ -865,10 +869,11 @@ msgstr "Übersetzung ist veraltet"
 #: templates/imprint/imprint_form.html:81
 #: templates/imprint/imprint_form.html:110
 #: templates/imprint/imprint_sbs.html:63 templates/imprint/imprint_sbs.html:118
-#: templates/pages/page_form.html:100 templates/pages/page_form.html:129
-#: templates/pages/page_sbs.html:70 templates/pages/page_sbs.html:129
+#: templates/pages/page_form.html:100 templates/pages/page_form.html:122
+#: templates/pages/page_form.html:141 templates/pages/page_sbs.html:70
+#: templates/pages/page_sbs.html:129
 #: templates/pages/page_tree_archived_node.html:73
-#: templates/pages/page_tree_node.html:62 templates/pois/poi_form.html:86
+#: templates/pages/page_tree_node.html:73 templates/pois/poi_form.html:86
 #: templates/pois/poi_form.html:115 templates/pois/poi_list_row.html:61
 msgid "Translation up-to-date"
 msgstr "Übersetzung ist aktuell"
@@ -878,9 +883,9 @@ msgstr "Übersetzung ist aktuell"
 #: templates/events/event_list_row.html:67
 #: templates/imprint/imprint_form.html:86
 #: templates/imprint/imprint_form.html:115 templates/pages/page_form.html:105
-#: templates/pages/page_form.html:134
+#: templates/pages/page_form.html:146
 #: templates/pages/page_tree_archived_node.html:78
-#: templates/pages/page_tree_node.html:67 templates/pois/poi_form.html:91
+#: templates/pages/page_tree_node.html:78 templates/pois/poi_form.html:91
 #: templates/pois/poi_form.html:120 templates/pois/poi_list_row.html:66
 msgid "Translation missing"
 msgstr "Übersetzung fehlt"
@@ -906,10 +911,10 @@ msgstr "Version"
 #: templates/imprint/imprint_form.html:133
 #: templates/imprint/imprint_revisions.html:42
 #: templates/imprint/imprint_sbs.html:75 templates/imprint/imprint_sbs.html:138
-#: templates/imprint/imprint_sbs.html:153 templates/pages/page_form.html:152
+#: templates/imprint/imprint_sbs.html:153 templates/pages/page_form.html:164
 #: templates/pages/page_revisions.html:44 templates/pages/page_sbs.html:82
 #: templates/pages/page_sbs.html:149 templates/pages/page_sbs.html:154
-#: templates/pages/page_tree.html:61 templates/pages/page_tree_archived.html:32
+#: templates/pages/page_tree.html:60 templates/pages/page_tree_archived.html:32
 #: templates/pois/poi_form.html:137 templates/pois/poi_list.html:49
 #: templates/pois/poi_list_archived.html:32
 #: templates/regions/region_form.html:87 templates/regions/region_list.html:32
@@ -920,7 +925,7 @@ msgstr "Status"
 #: templates/imprint/imprint_revisions.html:60
 #: templates/imprint/imprint_revisions.html:74
 #: templates/imprint/imprint_sbs.html:77 templates/imprint/imprint_sbs.html:140
-#: templates/imprint/imprint_sbs.html:155 templates/pages/page_form.html:166
+#: templates/imprint/imprint_sbs.html:155 templates/pages/page_form.html:191
 #: templates/pages/page_revisions.html:62
 #: templates/pages/page_revisions.html:76 templates/pages/page_sbs.html:84
 #: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:140
@@ -928,7 +933,7 @@ msgstr "Status"
 msgid "Permalink"
 msgstr "Permalink"
 
-#: templates/events/event_form.html:153 templates/pages/page_form.html:168
+#: templates/events/event_form.html:153 templates/pages/page_form.html:193
 #: templates/pages/page_sbs.html:159 templates/regions/region_form.html:55
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
@@ -939,7 +944,7 @@ msgstr ""
 #: templates/imprint/imprint_revisions.html:62
 #: templates/imprint/imprint_revisions.html:75
 #: templates/imprint/imprint_sbs.html:87 templates/imprint/imprint_sbs.html:160
-#: templates/pages/page_form.html:179 templates/pages/page_revisions.html:64
+#: templates/pages/page_form.html:204 templates/pages/page_revisions.html:64
 #: templates/pages/page_revisions.html:77 templates/pages/page_sbs.html:98
 #: templates/pages/page_sbs.html:170 templates/pages/page_xliff_confirm.html:45
 #: templates/pages/page_xliff_confirm.html:52 templates/pois/poi_form.html:150
@@ -949,7 +954,7 @@ msgid "Title"
 msgstr "Titel"
 
 #: templates/events/event_form.html:165 templates/imprint/imprint_form.html:147
-#: templates/imprint/imprint_sbs.html:161 templates/pages/page_form.html:180
+#: templates/imprint/imprint_sbs.html:161 templates/pages/page_form.html:205
 #: templates/pages/page_sbs.html:171 templates/pois/poi_form.html:151
 msgid "Insert title here"
 msgstr "Titel hier eingeben"
@@ -963,19 +968,19 @@ msgid "Insert description here"
 msgstr "Beschreibung hier eingeben"
 
 #: templates/events/event_form.html:170 templates/imprint/imprint_form.html:152
-#: templates/imprint/imprint_sbs.html:166 templates/pages/page_form.html:185
+#: templates/imprint/imprint_sbs.html:166 templates/pages/page_form.html:210
 #: templates/pages/page_sbs.html:176 templates/pois/poi_form.html:158
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
 #: templates/events/event_form.html:172 templates/imprint/imprint_form.html:154
-#: templates/imprint/imprint_sbs.html:168 templates/pages/page_form.html:187
+#: templates/imprint/imprint_sbs.html:168 templates/pages/page_form.html:212
 #: templates/pages/page_sbs.html:178 templates/pois/poi_form.html:160
 msgid "This change does not require an update of the translations"
 msgstr "Diese Änderung erfordert keine angepasste Übersetzung"
 
 #: templates/events/event_form.html:182 templates/imprint/imprint_form.html:196
-#: templates/pages/page_form.html:229 templates/pois/poi_form.html:170
+#: templates/pages/page_form.html:254 templates/pois/poi_form.html:170
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
 
@@ -1076,14 +1081,14 @@ msgid "Map"
 msgstr "Karte"
 
 #: templates/events/event_form.html:288 templates/imprint/imprint_form.html:204
-#: templates/pages/page_form.html:276 templates/pois/poi_form.html:202
+#: templates/pages/page_form.html:301 templates/pois/poi_form.html:202
 #: templates/regions/region_icon_widget.html:4
 msgid "Icon"
 msgstr "Icon"
 
 #: templates/events/event_form.html:292 templates/imprint/imprint_form.html:208
 #: templates/organizations/organization_form.html:65
-#: templates/pages/page_form.html:280 templates/pois/poi_form.html:206
+#: templates/pages/page_form.html:305 templates/pois/poi_form.html:206
 #: templates/regions/region_icon_widget.html:15
 msgid "Set icon"
 msgstr "Icon festlegen"
@@ -1117,37 +1122,37 @@ msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
 #: templates/events/event_form.html:461 templates/imprint/imprint_form.html:308
-#: templates/imprint/imprint_sbs.html:238 templates/pages/page_form.html:421
+#: templates/imprint/imprint_sbs.html:238 templates/pages/page_form.html:447
 #: templates/pages/page_sbs.html:248 templates/pois/poi_form.html:307
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
 #: templates/events/event_form.html:487 templates/imprint/imprint_form.html:334
-#: templates/imprint/imprint_sbs.html:264 templates/pages/page_form.html:463
+#: templates/imprint/imprint_sbs.html:264 templates/pages/page_form.html:489
 #: templates/pages/page_sbs.html:274 templates/pois/poi_form.html:333
 msgid "Link"
 msgstr "Link"
 
 #: templates/events/event_form.html:494 templates/imprint/imprint_form.html:341
-#: templates/imprint/imprint_sbs.html:271 templates/pages/page_form.html:470
+#: templates/imprint/imprint_sbs.html:271 templates/pages/page_form.html:496
 #: templates/pages/page_sbs.html:281 templates/pois/poi_form.html:340
 msgid "Phone"
 msgstr "Telefon"
 
 #: templates/events/event_form.html:501 templates/imprint/imprint_form.html:348
-#: templates/imprint/imprint_sbs.html:278 templates/pages/page_form.html:477
+#: templates/imprint/imprint_sbs.html:278 templates/pages/page_form.html:503
 #: templates/pages/page_sbs.html:288 templates/pois/poi_form.html:347
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
 #: templates/events/event_form.html:508 templates/imprint/imprint_form.html:355
-#: templates/imprint/imprint_sbs.html:285 templates/pages/page_form.html:484
+#: templates/imprint/imprint_sbs.html:285 templates/pages/page_form.html:510
 #: templates/pages/page_sbs.html:295 templates/pois/poi_form.html:354
 msgid "Email"
 msgstr "Email"
 
 #: templates/events/event_form.html:515 templates/imprint/imprint_form.html:362
-#: templates/imprint/imprint_sbs.html:292 templates/pages/page_form.html:491
+#: templates/imprint/imprint_sbs.html:292 templates/pages/page_form.html:517
 #: templates/pages/page_sbs.html:302 templates/pois/poi_form.html:361
 msgid "Hint"
 msgstr "Tipp"
@@ -1174,7 +1179,7 @@ msgstr "ID"
 #: templates/languages/language_list.html:31
 #: templates/offer_templates/offer_template_list.html:29
 #: templates/organizations/organization_list.html:27
-#: templates/pages/page_tree.html:81 templates/pages/page_tree_archived.html:51
+#: templates/pages/page_tree.html:80 templates/pages/page_tree_archived.html:51
 #: templates/pois/poi_list.html:72 templates/pois/poi_list_archived.html:46
 #: templates/roles/list.html:25
 msgid "Options"
@@ -1200,7 +1205,7 @@ msgstr "Noch keine Veranstaltungen archiviert."
 #: templates/pages/page_tree_archived_node.html:36
 #: templates/pages/page_tree_archived_node.html:51
 #: templates/pages/page_tree_node.html:25
-#: templates/pages/page_tree_node.html:40
+#: templates/pages/page_tree_node.html:45
 #: templates/pois/poi_list_archived_row.html:24
 #: templates/pois/poi_list_archived_row.html:39
 #: templates/pois/poi_list_row.html:24 templates/pois/poi_list_row.html:39
@@ -1303,6 +1308,7 @@ msgid "Dislike"
 msgstr "Gafällt mir nicht"
 
 #: templates/generic_confirmation_dialog.html:11
+#: templates/pages/page_form.html:180
 msgid "Warning"
 msgstr "Warnung"
 
@@ -1330,11 +1336,11 @@ msgstr "Neue Übersetzung des Impressums erstellen"
 msgid "Create imprint"
 msgstr "Impressum erstellen"
 
-#: templates/imprint/imprint_form.html:130 templates/pages/page_form.html:149
+#: templates/imprint/imprint_form.html:130 templates/pages/page_form.html:161
 msgid "Revision"
 msgstr "Revision"
 
-#: templates/imprint/imprint_form.html:132 templates/pages/page_form.html:151
+#: templates/imprint/imprint_form.html:132 templates/pages/page_form.html:163
 msgid "Show revisions"
 msgstr "Revisionen anzeigen"
 
@@ -1342,13 +1348,13 @@ msgstr "Revisionen anzeigen"
 #: templates/imprint/imprint_form.html:142
 #: templates/imprint/imprint_sbs.html:79 templates/imprint/imprint_sbs.html:84
 #: templates/imprint/imprint_sbs.html:142
-#: templates/imprint/imprint_sbs.html:147 templates/pages/page_form.html:162
+#: templates/imprint/imprint_sbs.html:147 templates/pages/page_form.html:174
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
 #: templates/imprint/imprint_form.html:140
 #: templates/imprint/imprint_sbs.html:82 templates/imprint/imprint_sbs.html:145
-#: templates/imprint/imprint_sbs.html:157 templates/pages/page_form.html:160
+#: templates/imprint/imprint_sbs.html:157 templates/pages/page_form.html:172
 msgid "Short URL"
 msgstr "Kurz-URL"
 
@@ -1356,7 +1362,7 @@ msgstr "Kurz-URL"
 #: templates/imprint/imprint_revisions.html:64
 #: templates/imprint/imprint_revisions.html:76
 #: templates/imprint/imprint_sbs.html:90 templates/imprint/imprint_sbs.html:163
-#: templates/pages/page_form.html:182 templates/pages/page_revisions.html:66
+#: templates/pages/page_form.html:207 templates/pages/page_revisions.html:66
 #: templates/pages/page_revisions.html:78 templates/pages/page_sbs.html:101
 #: templates/pages/page_sbs.html:173 templates/pages/page_xliff_confirm.html:54
 #: templates/push_notifications/push_notification_form.html:67
@@ -1364,20 +1370,20 @@ msgid "Content"
 msgstr "Inhalt"
 
 #: templates/imprint/imprint_form.html:150
-#: templates/imprint/imprint_sbs.html:164 templates/pages/page_form.html:183
+#: templates/imprint/imprint_sbs.html:164 templates/pages/page_form.html:208
 #: templates/pages/page_sbs.html:174
 msgid "Insert content here"
 msgstr "Inhalt hier eingeben"
 
-#: templates/imprint/imprint_form.html:165 templates/pages/page_form.html:198
+#: templates/imprint/imprint_form.html:165 templates/pages/page_form.html:223
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: templates/imprint/imprint_form.html:172 templates/pages/page_form.html:205
+#: templates/imprint/imprint_form.html:172 templates/pages/page_form.html:230
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
-#: templates/imprint/imprint_form.html:186 templates/pages/page_form.html:219
+#: templates/imprint/imprint_form.html:186 templates/pages/page_form.html:244
 msgid "Show translations side by side"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
@@ -1607,7 +1613,7 @@ msgstr "Erstellt"
 
 #: templates/languages/language_list.html:30
 #: templates/offer_templates/offer_template_list.html:27
-#: templates/pages/page_tree.html:80 templates/regions/region_list.html:31
+#: templates/pages/page_tree.html:79 templates/regions/region_list.html:31
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
@@ -1849,32 +1855,40 @@ msgstr "Neue Übersetzung erstellen"
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page_form.html:156
+#: templates/pages/page_form.html:168
 #: templates/pages/page_tree_archived_node.html:27
 msgid "Archived, because a parent page is archived"
 msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 
-#: templates/pages/page_form.html:236
+#: templates/pages/page_form.html:181
+msgid "Translation in progress"
+msgstr "Übersetzung wird durchgeführt"
+
+#: templates/pages/page_form.html:186
+msgid "Abort translation process"
+msgstr "Übersetzungsprozess abbrechen"
+
+#: templates/pages/page_form.html:261
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page_form.html:237
+#: templates/pages/page_form.html:262
 msgid "Parent Page"
 msgstr "Übergeordnete Seite"
 
-#: templates/pages/page_form.html:246
+#: templates/pages/page_form.html:271
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: templates/pages/page_form.html:251
+#: templates/pages/page_form.html:276
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:269
+#: templates/pages/page_form.html:294
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:270
+#: templates/pages/page_form.html:295
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -1882,17 +1896,17 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:287 templates/pages/page_form.html:288
-#: templates/pages/page_form.html:296
+#: templates/pages/page_form.html:312 templates/pages/page_form.html:313
+#: templates/pages/page_form.html:321
 #: templates/pages/page_tree_archived_node.html:94
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:293
+#: templates/pages/page_form.html:318
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:299
+#: templates/pages/page_form.html:324
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -1903,28 +1917,28 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
-#: templates/pages/page_form.html:312 templates/pages/page_form.html:313
-#: templates/pages/page_tree_node.html:91
+#: templates/pages/page_form.html:337 templates/pages/page_form.html:338
+#: templates/pages/page_tree_node.html:108
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:319
+#: templates/pages/page_form.html:344
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:325 templates/pages/page_form.html:343
+#: templates/pages/page_form.html:350 templates/pages/page_form.html:368
 #: templates/pages/page_tree_archived_node.html:112
-#: templates/pages/page_tree_node.html:104
+#: templates/pages/page_tree_node.html:121
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:329
+#: templates/pages/page_form.html:354
 #: templates/pages/page_tree_archived_node.html:108
-#: templates/pages/page_tree_node.html:100 views/pages/page_actions.py:203
+#: templates/pages/page_tree_node.html:117 views/pages/page_actions.py:203
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:330
+#: templates/pages/page_form.html:355
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -1935,7 +1949,7 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: templates/pages/page_form.html:349
+#: templates/pages/page_form.html:374
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
@@ -1961,39 +1975,39 @@ msgstr ""
 "Übersetze \"%(page_title)s\" von %(source_language)s nach "
 "%(target_language_name)s"
 
-#: templates/pages/page_tree.html:24
+#: templates/pages/page_tree.html:23
 msgid "Archived pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/page_tree.html:46
+#: templates/pages/page_tree.html:45
 msgid "You can only create pages in the default language"
 msgstr "Sie können Seiten nur in der Standard-Sprache anlegen"
 
-#: templates/pages/page_tree.html:101
+#: templates/pages/page_tree.html:100
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
-#: templates/pages/page_tree.html:113
+#: templates/pages/page_tree.html:112
 msgid "Bulk actions"
 msgstr "Aktionen"
 
-#: templates/pages/page_tree.html:117
+#: templates/pages/page_tree.html:116
 msgid "Please select"
 msgstr "bitte auswählen"
 
-#: templates/pages/page_tree.html:118
+#: templates/pages/page_tree.html:117
 msgid "Archive pages"
 msgstr "Seiten archivieren"
 
-#: templates/pages/page_tree.html:121
+#: templates/pages/page_tree.html:120
 msgid "Export XLIFF for translation to"
 msgstr "Exportiere XLIFF für Übersetzung nach"
 
-#: templates/pages/page_tree.html:124
+#: templates/pages/page_tree.html:123
 msgid "Export as PDF"
 msgstr "Als PDF Exportieren"
 
-#: templates/pages/page_tree.html:128
+#: templates/pages/page_tree.html:127
 msgid "Execute"
 msgstr "Ausführen"
 
@@ -2025,7 +2039,7 @@ msgstr ""
 "ist."
 
 #: templates/pages/page_tree_archived_node.html:90
-#: templates/pages/page_tree_node.html:84
+#: templates/pages/page_tree_node.html:101
 msgid "View page"
 msgstr "Seite ansehen"
 
@@ -2039,19 +2053,19 @@ msgstr ""
 msgid "This also involves non-archived subpages."
 msgstr "Dies betrifft auch nicht-archivierte Unterseiten."
 
-#: templates/pages/page_tree_node.html:87
+#: templates/pages/page_tree_node.html:104
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 
-#: templates/pages/page_tree_node.html:100
+#: templates/pages/page_tree_node.html:117
 msgid "This also involves archived subpages."
 msgstr "Dies betrifft auch archivierte Unterseiten."
 
-#: templates/pages/page_tree_node.html:114
+#: templates/pages/page_tree_node.html:131
 msgid "Copy short link"
 msgstr "Kurz-URL kopieren"
 
-#: templates/pages/page_tree_node.html:118
+#: templates/pages/page_tree_node.html:135
 msgid "You cannot copy a short link of a page which has no translation."
 msgstr "Sie können keine Kurz-URL zu einer fehlenden Übersetzung kopieren."
 
@@ -3146,32 +3160,36 @@ msgstr ""
 msgid "Page was successfully deleted"
 msgstr "Seite wurde erfolgreich gelöscht"
 
-#: views/pages/page_actions.py:462
+#: views/pages/page_actions.py:354
+msgid "Could not update page translation state"
+msgstr "Zustand der Übersetzung konnte nicht aktualisiert werden"
+
+#: views/pages/page_actions.py:491
 #, python-brace-format
 msgid "The page \"{page}\" was successfully moved."
 msgstr "Die Seite \"{page}\" wurde erfolgreich verschoben."
 
-#: views/pages/page_actions.py:552 views/pages/page_actions.py:567
+#: views/pages/page_actions.py:581 views/pages/page_actions.py:596
 #, python-brace-format
 msgid "Information: The user {user} has this permission already."
 msgstr "Information: Der Nutzer {user} hat diese Berechtigung bereits"
 
-#: views/pages/page_actions.py:559
+#: views/pages/page_actions.py:588
 #, python-brace-format
 msgid "Success: The user {user} can now edit this page."
 msgstr "Erfolg: Der Nutzer {user} kann nun diese Seite bearbeiten"
 
-#: views/pages/page_actions.py:575
+#: views/pages/page_actions.py:604
 #, python-brace-format
 msgid "Success: The user {user} can now publish this page."
 msgstr "Erfolg: Der Nutzer {user} kann dieses Seite nun veröffentlichen"
 
-#: views/pages/page_actions.py:584 views/pages/page_actions.py:699
+#: views/pages/page_actions.py:613 views/pages/page_actions.py:728
 msgid "An error has occurred. Please contact an administrator."
 msgstr ""
 "Ein Fehler ist aufgetreten. Bitte kontaktieren Sie einen Administrator."
 
-#: views/pages/page_actions.py:667
+#: views/pages/page_actions.py:696
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the editors of this page, "
@@ -3181,12 +3199,12 @@ msgstr ""
 "bearbeiten wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin bearbeiten."
 
-#: views/pages/page_actions.py:673
+#: views/pages/page_actions.py:702
 #, python-brace-format
 msgid "Success: The user {user} cannot edit this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr bearbeiten"
 
-#: views/pages/page_actions.py:684
+#: views/pages/page_actions.py:713
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the publishers of this "
@@ -3196,7 +3214,7 @@ msgstr ""
 "veröffentlichen wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen."
 
-#: views/pages/page_actions.py:690
+#: views/pages/page_actions.py:719
 #, python-brace-format
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"
@@ -3756,9 +3774,6 @@ msgstr ""
 
 #~ msgid "Registered 2FA key"
 #~ msgstr "Hinterlegte 2-Faktor-Schlüssel"
-
-#~ msgid "Edit translation"
-#~ msgstr "Diese Übersetzung bearbeiten"
 
 #~ msgid "Restore"
 #~ msgstr "Wiederherstellen"

--- a/src/cms/models/pages/abstract_base_page_translation.py
+++ b/src/cms/models/pages/abstract_base_page_translation.py
@@ -251,6 +251,10 @@ class AbstractBasePageTranslation(models.Model):
         # If the page translation is currently in translation, it is defined as not outdated
         if self.currently_in_translation:
             return False
+        return self.is_outdated_helper
+
+    @property
+    def is_outdated_helper(self):
         source_translation = self.source_translation
         # If self.language is the root language, this translation can never be outdated
         if not source_translation:

--- a/src/cms/page_xliff_converter.py
+++ b/src/cms/page_xliff_converter.py
@@ -415,6 +415,7 @@ class PageXliffHelper:
         tgt_trans.title = trans_fields["title"]
         tgt_trans.text = trans_fields["content"]
         tgt_trans.slug = PageXliffHelper._get_page_translation_slug(tgt_trans.title)
+        tgt_trans.currently_in_translation = False
         if tgt_trans.save():
             return True
         return False
@@ -554,3 +555,21 @@ class PageXliffHelper:
             "xliff_name": xliff_name,
         }
         return result_diff
+
+    @staticmethod
+    # pylint: disable=unused-argument
+    def post_translation_state(pages, language_code, translation_state):
+        """Update translation state according to parameter
+
+        :param pages: list of pages
+        :type pages: list
+        :param language_code: language code of translation
+        :type language_code: str
+        :param translation_state: value to set for currently_in_translation
+        :type translation_state: bool
+        """
+        for page in pages:
+            if language_code in [language.code for language in page.languages]:
+                PageTranslation.objects.filter(
+                    page__id=page.id, language__code=language_code
+                ).update(currently_in_translation=translation_state)

--- a/src/cms/static/js/pages/page_bulk_actions.js
+++ b/src/cms/static/js/pages/page_bulk_actions.js
@@ -2,44 +2,58 @@
  * This file contains all functions which are needed for the bulk actions for pages.
  */
 
-function select_all_pages() {
-    var selected_pages = document.getElementsByName("page_selected");
-    if (document.getElementsByName("select_all_pages")[0].checked == true) {
-        selected_pages.forEach(e => e.checked = true);
-    } else {
-        selected_pages.forEach(e => e.checked = false);
-    }
-}
-
-function bulk_action_execute() {
-    var action = document.getElementById('bulk_action').value;
-    // match action types
-    if ( action == "archive_pages" ) {
-        // TODO
-    } else if (action == "pdf_export") {
+u(document).on('DOMContentLoaded', function () {
+    
+    u('[name="select_all_pages"]').on('click', select_all_pages);
+    function select_all_pages() {
         var selected_pages = document.getElementsByName("page_selected");
-        pages = [];
-        selected_pages.forEach(e => {
-            if(e.checked) {
-                pages.push(e.value)
-            }
-        })
-        if (pages.length != 0) {
-            var pdf_export_url = document.getElementById("pdf_export_url").value;
-            window.open(pdf_export_url+"?pages="+pages.join(','));
-        } 
-    } else { // no previous match, than language code -> XLIFF export
-        var page_selected = document.getElementsByName("page_selected");
+        if (document.getElementsByName("select_all_pages")[0].checked == true) {
+            selected_pages.forEach(e => e.checked = true);
+        } else {
+            selected_pages.forEach(e => e.checked = false);
+        }
+    }
+
+    u("#bulk_action_btn").on('click', bulk_action_execute);
+    function bulk_action_execute() {
+        var action = u('#bulk_action').first().value;
         var pages = [];
-        page_selected.forEach(async function (page_checkbox) {
-            if(page_checkbox.checked) {
-                pages = pages.concat(page_checkbox.value);
-            }
-        });
+        u('input').filter(':checked').each((node, i) => pages.push(node.value));
         if (pages.length == 0) {
+            // abort if no pages selected
             return;
         }
-        var bulk_action_url = document.getElementById("bulk_action_url").value;
-        window.open(bulk_action_url+"?target_lang="+action+"&pages="+pages.join(','), "_blank");
+        // match action types
+        if ( action == "archive_pages" ) {
+            // TODO
+        } else if (action == "pdf_export") {
+            var pdf_export_url = document.getElementById("pdf_export_url").value;
+            window.open(pdf_export_url+"?pages="+pages.join(','));
+        } else { // no previous match, than language code -> XLIFF export
+            const state = true;
+            const url = u("#ajax_url").first().dataset.url;
+            var bulk_action_url = document.getElementById("bulk_action_url").value;
+            // download XLIFF
+            window.open(bulk_action_url+"?target_lang="+action+"&pages="+pages.join(','), "_blank");
+            updateTranslationIcon(pages, action);
+        }
     }
-}
+
+    function updateTranslationIcon(pages, languageCode) {
+        for (page of pages){
+            let pageNode = u(`#page-${page}`);
+            // get language for updating translation state icon
+            let targetLanguage = pageNode.find(`.${languageCode}`);
+            if (!targetLanguage.find("#translation-icon").find("span").hasClass("no-trans")) {
+                // if the page already contains a translation for the exported language
+                // hide inital translation state determind by templates context
+                targetLanguage.find("#translation-icon").addClass("hidden");
+                targetLanguage.find("#ajax-icon").removeClass("hidden");
+                // notify user that update was successful by setting right icon
+                pageNode.find(".translation-title").addClass("hidden");
+                pageNode.find(".ajax-title").removeClass("hidden");
+            }
+        }
+    }
+    
+});

--- a/src/cms/static/js/pages/unset_translation_state.js
+++ b/src/cms/static/js/pages/unset_translation_state.js
@@ -1,0 +1,44 @@
+/*
+These functions get triggered when user reset the currently_in_translation state
+ajax POST request for database update is send, update of translation state icons accordingly
+*/
+function unset_translation_state(pageId, languageCode) {
+    // fetch url from template
+    const url = u("#undo-translation").first().dataset.url;
+    const translationState = false;
+    // send ajax request for database update
+    post_translation_state(url, pageId, languageCode, translationState)
+    // on success update GUI
+    .then(response => update_translation_form(response));
+}
+
+/*
+sends ajax request for updating all pages 
+to the given translationState
+*/
+async function post_translation_state(url, pageId, languageCode, translationState) {
+    const data = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest',
+            'X-CSRFToken': u('[name=csrfmiddlewaretoken]').first().value
+        },
+        body: JSON.stringify({
+            'language': languageCode,
+            'pageId': pageId,
+            'translationState': translationState
+        })
+    }).then(response => response.json());
+    return data;
+}
+
+function update_translation_form(data) {
+    /* the icons representing the state of the translation 
+    depend on template context at the moment the form was called
+    so to update the GUI state, initial state gets hidden and current state is displayed */
+    let translationTab = u(`.${data["language"]}`);
+    translationTab.addClass("hidden");
+    translationTab.siblings(".ajax").removeClass("hidden");
+    u("#trans-warn").addClass("hidden");
+}

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -84,35 +84,47 @@
                     <li class="mr-1 {% if other_language == language %}z-10{% endif %}" style="margin-bottom: -2px">
                         <div class="bg-white text-blue-500 {% if other_language != language %}hover:bg-blue-500 hover:text-white{% endif %} border-l-2 border-t-2 border-r-2 border-blue-500 font-bold rounded-t-lg">
                             <div class="border-b-2 border-white">
-                        {% if other_language == language %}
-                            <div class="p-4">
-                                {% if page %}
-                                    {% if other_language in page.languages %}
-                                        {% if page_translation_form.instance.is_outdated %}
+                                {% if other_language == language %}
+                                    <div class="{{ language.code }} p-4">
+                                        {% if page %}
+                                            {% if other_language in page.languages %}
+                                                {% if page_translation_form.instance.is_outdated %}
+                                                    <span title="{% trans 'Translation outdated' %}">
+                                                        <i data-feather="alert-triangle" class="inline-block"></i>
+                                                    </span>
+                                                {% elif page_translation_form.instance.currently_in_translation %}
+                                                    <span title="{% trans 'Currently in translation' %}">
+                                                        <i data-feather="clock" class="inline-block"></i>
+                                                    </span>
+                                                {% else %}
+                                                    <span title="{% trans 'Translation up-to-date' %}">
+                                                        <i data-feather="check" class="inline-block"></i>
+                                                    </span>
+                                                {% endif %}
+                                            {% else %}
+                                                <span title="{% trans 'Translation missing' %}">
+                                                    <i data-feather="x" class="inline-block"></i>
+                                                </span>
+                                            {% endif %}
+                                        {% else %}
+                                            <span title="{% trans 'Create Translation' %}">
+                                                <i data-feather="plus" class="inline-block"></i>
+                                            </span>
+                                        {% endif %}
+                                        {{ other_language.translated_name }}
+                                    </div>
+                                    <div class="hidden ajax p-4">
+                                        {% if page_translation_form.instance.is_outdated_helper %}
                                             <span title="{% trans 'Translation outdated' %}">
                                                 <i data-feather="alert-triangle" class="inline-block"></i>
-                                            </span>
-                                        {% elif page_translation_form.instance.currently_in_translation %}
-                                            <span title="{% trans 'Currently in translation' %}">
-                                                <i data-feather="clock" class="inline-block"></i>
                                             </span>
                                         {% else %}
                                             <span title="{% trans 'Translation up-to-date' %}">
                                                 <i data-feather="check" class="inline-block"></i>
                                             </span>
                                         {% endif %}
-                                    {% else %}
-                                        <span title="{% trans 'Translation missing' %}">
-                                            <i data-feather="x" class="inline-block"></i>
-                                        </span>
-                                    {% endif %}
-                                {% else %}
-                                    <span title="{% trans 'Create Translation' %}">
-                                        <i data-feather="plus" class="inline-block"></i>
-                                    </span>
-                                {% endif %}
-                                {{ other_language.translated_name }}
-                            </div>
+                                        {{ other_language.translated_name }}
+                                    </div>
                         {% else %}
                             <a class="p-4 block" style="color: inherit;" href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=other_language.code %}">
                                 {% if other_language in page.languages %}
@@ -161,7 +173,20 @@
                         <a href="{{ page_translation_form.instance.short_url }}" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">{{ page_translation_form.instance.short_url }}</a>
                         <a href="#" onclick="short_url_to_clipboard('{{ page_translation_form.instance.short_url }}');" title="{% trans 'Copy to clipboard' %}" class="px-2 text-gray-800 hover:text-blue-500">
                             <i data-feather="copy" class="inline-block"></i>
-                        </a>
+                        </a><br>
+                        {% if page_translation_form.instance.currently_in_translation %}
+                            <div id="trans-warn">
+                                <i data-feather="alert-triangle" class="inline-block text-red-800"></i>
+                                <label class="inline-block mb-2 font-bold">{% trans 'Warning' %}:</label>
+                                {% trans 'Translation in progress' %}
+                                <a href="#" onclick="unset_translation_state('{{ page.id }}', '{{ page_translation_form.instance.language.code }}');"
+                                        id="undo-translation"
+                                        class="italic text-purple-500"
+                                        data-url="{% url 'post_translation_state_ajax' region_slug=region.slug %}">
+                                    {% trans 'Abort translation process' %}
+                                </a><br>
+                            </div>
+                        {% endif %}
                     {% endif %}
                     <label class="block mb-2 font-bold">{% trans 'Permalink' %}</label>
                     <div class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400">
@@ -364,6 +389,7 @@
 {% block javascript %}
 <script src="{% static 'js/pages/page_order.js' %}"></script>
 <script src="{% static 'js/pages/page_mirroring.js' %}"></script>
+<script src="{% static 'js/pages/unset_translation_state.js' %}"></script>
 {% endblock %}
 
 {% block javascript_nocompress %}

--- a/src/cms/templates/pages/page_tree.html
+++ b/src/cms/templates/pages/page_tree.html
@@ -8,7 +8,6 @@
 
 {% block javascript_head %}
     <script src="{% static 'js/confirmation-popups.js' %}"></script>
-    <script src="{% static 'js/pages/page_bulk_actions.js' %}"></script>
     <script src="{% static 'js/copy-clipboard.js' %}"></script>
 {% endblock %}
 
@@ -57,7 +56,7 @@
         <thead>
             <tr class="border-b border-solid border-gray-200">
                 <th class="text-sm text-left uppercase py-3 pl-4 pr-2 min"></th>
-                <th class="text-sm text-left uppercase py-3 pl-2 pr-2 min"><input type="checkbox" class="h-full" name="select_all_pages" onclick="select_all_pages();"></th>
+                <th class="text-sm text-left uppercase py-3 pl-2 pr-2 min"><input type="checkbox" class="h-full" name="select_all_pages"></th>
                 <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
@@ -125,9 +124,10 @@
                     </select>
                 </div>
                 <div class="pl-3">
-                    <input type="button" onclick="bulk_action_execute();" class="inline-block cursor-pointer bg-blue-500 hover:bg-blue-600 text-white h-full font-bold py-2 px-4 rounded" value="{% trans 'Execute' %}" />
+                    <input id="bulk_action_btn" type="button" class="inline-block cursor-pointer bg-blue-500 hover:bg-blue-600 text-white h-full font-bold py-2 px-4 rounded" value="{% trans 'Execute' %}" />
                     <input type="hidden" id="bulk_action_url" value="{% url 'download_xliff' region_slug=region.slug language_code=language.code%}">
                     <input type="hidden" id="pdf_export_url" value="{% url 'export_pdf' region_slug=region.slug language_code=language.code %}"> 
+                    <div id="ajax_url" class="hidden" data-url="{% url 'post_translation_state_ajax' region_slug=region.slug %}"></div>
                 </div>
             </form>
         </div>
@@ -158,4 +158,5 @@
 
 {% block javascript %}
 <script src="{% static 'js/tree_drag_and_drop.js' %}"></script>
+<script src="{% static 'js/pages/page_bulk_actions.js' %}"></script>
 {% endblock %}

--- a/src/cms/templates/pages/page_tree_node.html
+++ b/src/cms/templates/pages/page_tree_node.html
@@ -3,7 +3,7 @@
 {% load page_filters %}
 {% load tree_filters %}
 <tr data-drop-id="{{ node.id }}" data-drop-position="left" class="drop drop-between h-3 -m-3 hidden level-{{page.depth}}"><td colspan="9"><div><span></span></div></td></tr>
-<tr data-drop-id="{{ node.id }}" data-drop-position="last-child" class="drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100{% if page.depth > 0 %} child level-{{page.depth}}{% endif %}">
+<tr id="page-{{ node.id }}" data-drop-id="{{ node.id }}" data-drop-position="last-child" class="drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100{% if page.depth > 0 %} child level-{{page.depth}}{% endif %}">
     <td class="single_icon">
         <span data-drag-id="{{ page.id }}" data-node-descendants="{{ page|get_descendants }}" class="drag text-gray-800 block py-3 pl-4 pr-2 cursor-move" draggable="true">
             <i data-feather="move"></i>
@@ -34,11 +34,20 @@
             {% get_translation page LANGUAGE_CODE as backend_translation %}
             <td>
                 <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                    {% if backend_translation %}
-                        {{ backend_translation.title }}
-                    {% else %}
-                        <i>{% trans 'Translation not available' %}</i>
-                    {% endif %}
+                    <div class="translation-title">
+                        {% if backend_translation %}
+                            {% if not backend_translation.currently_in_translation %}
+                                {{ backend_translation.title }}
+                            {% else %}
+                                <i>{% trans 'Currently in translation' %}</i>
+                            {% endif %}
+                        {% else %}
+                            <i>{% trans 'Translation not available' %}</i>
+                        {% endif %}
+                    </div>
+                    <div class="ajax-title hidden">
+                        <i>{% trans 'Currently in translation' %}</i>
+                    </div>
                 </a>
             </td>
         {% endif %}
@@ -47,8 +56,10 @@
         <div class="block py-3 px-2 text-gray-800">
             <div class="lang-grid">
                 {% for other_language in languages %}
-                    <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=other_language.code %}">
+                    <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_code=other_language.code %}"
+                        class="{{ other_language.code }}">
                         {% get_translation page other_language.code as other_translation %}
+                        <div id="translation-icon">
                         {% if other_translation %}
                             {% if other_translation.currently_in_translation %}
                                 <span title="{% trans 'Currently in translation' %}">
@@ -64,10 +75,16 @@
                                 </span>
                             {% endif %}
                         {% else %}
-                            <span title="{% trans 'Translation missing' %}">
+                            <span title="{% trans 'Translation missing' %}" class="no-trans">
                                 <i data-feather="x" class="text-gray-800"></i>
                             </span>
                         {% endif %}
+                        </div>
+                        <div id="ajax-icon" class="hidden">
+                            <span title="{% trans 'Currently in translation' %}">
+                                <i data-feather="clock" class="text-gray-800"></i>
+                            </span>
+                        </div>
                     </a>
                 {% endfor %}
             </div>
@@ -119,6 +136,5 @@
             <i data-feather="copy" class="inline-block text-gray-400"></i>
         </a>
         {% endif %}
-        
     </td>
 </tr>

--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -314,6 +314,11 @@ urlpatterns = [
                     name="revoke_page_permission_ajax",
                 ),
                 url(
+                    r"^(?P<region_slug>[-\w]+)/post_translation_state$",
+                    pages.post_translation_state_ajax,
+                    name="post_translation_state_ajax",
+                ),
+                url(
                     r"^(?P<region_slug>[-\w]+)/(?P<parent_id>[0-9]+)/new_order_table$",
                     pages.get_new_page_order_table_ajax,
                     name="get_new_page_order_table_ajax",

--- a/src/cms/views/pages/__init__.py
+++ b/src/cms/views/pages/__init__.py
@@ -19,6 +19,7 @@ from .page_actions import (
     get_page_order_table_ajax,
     get_new_page_order_table_ajax,
     render_mirrored_page_field,
+    post_translation_state_ajax,
 )
 from .page_sbs_view import PageSideBySideView
 from .page_revision_view import PageRevisionView


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Update the translation state when XLIFF is imported or exported

### Proposed changes
<!-- Describe this PR in more detail. -->

- When XLIFF is exported, ajax request is send to update database entry of the translation and display clock icon to signal the successful update. 
- When XLIFF is imported, translation is created with currently_in_translation set to false.
- Warning in page form, when page is in translation process + ability to undo process

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #618

<del>### Open issue
I experienced behavior, that maybe you might not expect:</del>
<del>1. go to page tree of augsburg
2. export english XLIFF, which has 'up-to-date' arabic  pages (e.g. page "Stadtplan" from Augsburg)
3. refresh the website
4. see that initially 'up-to-date' arabic is no outdated</del>

<del>I guess that's due to the translation changes affecting the last_updated value, up for discussion if this needs a fix or not.</del>