### PR TITLE
XLIFF: import error for missing page, fixes #622

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-19 11:52+0000\n"
+"POT-Creation-Date: 2021-01-21 19:07+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -941,8 +941,8 @@ msgstr ""
 #: templates/imprint/imprint_sbs.html:87 templates/imprint/imprint_sbs.html:160
 #: templates/pages/page_form.html:179 templates/pages/page_revisions.html:64
 #: templates/pages/page_revisions.html:77 templates/pages/page_sbs.html:98
-#: templates/pages/page_sbs.html:170 templates/pages/page_xliff_confirm.html:43
-#: templates/pois/poi_form.html:150
+#: templates/pages/page_sbs.html:170 templates/pages/page_xliff_confirm.html:45
+#: templates/pages/page_xliff_confirm.html:52 templates/pois/poi_form.html:150
 #: templates/push_notifications/push_notification_form.html:62
 #: templates/push_notifications/push_notification_list.html:24
 msgid "Title"
@@ -1358,7 +1358,7 @@ msgstr "Kurz-URL"
 #: templates/imprint/imprint_sbs.html:90 templates/imprint/imprint_sbs.html:163
 #: templates/pages/page_form.html:182 templates/pages/page_revisions.html:66
 #: templates/pages/page_revisions.html:78 templates/pages/page_sbs.html:101
-#: templates/pages/page_sbs.html:173 templates/pages/page_xliff_confirm.html:45
+#: templates/pages/page_sbs.html:173 templates/pages/page_xliff_confirm.html:54
 #: templates/push_notifications/push_notification_form.html:67
 msgid "Content"
 msgstr "Inhalt"
@@ -2061,7 +2061,8 @@ msgstr "XLIFF Import überprüfen"
 
 #: templates/pages/page_xliff_confirm.html:32
 msgid ""
-"Please review the changes that will be done to the page translations below."
+"Please review the changes that will be applied to the page translations "
+"below."
 msgstr ""
 "Bitte überprüfen Sie die Änderungen, die an den Seiten-Übersetzungen "
 "vorgenommen werden."
@@ -2070,18 +2071,34 @@ msgstr ""
 msgid "Abort"
 msgstr "Abbrechen"
 
-#: templates/pages/page_xliff_confirm.html:41
+#: templates/pages/page_xliff_confirm.html:42
+msgid "Translation cannot be imported"
+msgstr "Übersetzung kann nicht importiert werden"
+
+#: templates/pages/page_xliff_confirm.html:43
+msgid "The page or target language does not exist."
+msgstr "Die Seite oder Zielsprache existiert nicht."
+
+#: templates/pages/page_xliff_confirm.html:46
+msgid "Page ID"
+msgstr "Seiten-ID"
+
+#: templates/pages/page_xliff_confirm.html:47
+msgid "Target language code"
+msgstr "Zielsprachencode"
+
+#: templates/pages/page_xliff_confirm.html:50
 msgid "file"
 msgstr "Datei"
 
-#: templates/pages/page_xliff_confirm.html:42
+#: templates/pages/page_xliff_confirm.html:51
 msgid "Warning: the translation has been updated since the XLIFF was exported."
 msgstr ""
 "Warnung: Die Seiten-Übersetzung hat sich geändert, seit die XLIFF exportiert "
 "wurde."
 
-#: templates/pages/page_xliff_confirm.html:44
-#: templates/pages/page_xliff_confirm.html:46
+#: templates/pages/page_xliff_confirm.html:53
+#: templates/pages/page_xliff_confirm.html:55
 msgid "No change"
 msgstr "Keine Änderungen vorgenommen."
 

--- a/src/cms/templates/pages/page_xliff_confirm.html
+++ b/src/cms/templates/pages/page_xliff_confirm.html
@@ -29,7 +29,7 @@ pre {
     <div class="m-4">
       <form action="{% url 'confirm_xliff_import' region_slug=region.slug language_code=language.code%}" method="POST">
         <h2 class="heading pb-4">{% trans 'Review XLIFF Import' %}</h2>
-        <p class="pb-4">{% trans 'Please review the changes that will be done to the page translations below.' %}</p>
+        <p class="pb-4">{% trans 'Please review the changes that will be applied to the page translations below.' %}</p>
         <input type="submit" value="{% trans 'Confirm' %}" class="inline-block cursor-pointer bg-blue-500 hover:bg-blue-600 text-white h-full font-bold py-2 px-4 rounded p-4">
         <input type="button" value="{% trans 'Abort' %}" onclick="window.location='{% url 'pages' region_slug=region.slug language_code=language.code %}';" class="inline-block cursor-pointer bg-red-500 hover:bg-red-600 text-white h-full font-bold py-2 px-4 rounded p-4">
         <input type="hidden" value={{ upload_dir }} name="upload_dir">
@@ -37,13 +37,23 @@ pre {
       </form>
     </div>
     {% for xliff_diff in translation_diffs %}
-    <div class="border border-green-500 m-4">
+    <div class="border border-{% if xliff_diff.error %}red{% else %}green{% endif %}-500 m-4">
+        {% if xliff_diff.error %}
+        <h2 class="heading font-normal m-4">{% trans 'Translation cannot be imported' %}</h2>
+        <p class="m-4">{% trans 'The page or target language does not exist.' %}
+        <ul class="list-disc m-4 pl-4">
+            <li class="">{% trans 'Title' %}: {{ xliff_diff.title }}</li>
+            <li class="">{% trans 'Page ID' %}: {{ xliff_diff.page_id }}</li>
+            <li class="">{% trans 'Target language code' %}: {{ xliff_diff.tgt_lang_code }}</li>
+        <ul>
+        {% else %}
         <h2 class="heading font-normal m-4">XLIFF {% trans 'file' %}: {{ xliff_diff.xliff_name }}</h2>
         {% if xliff_diff.current_version_newer %}<p class="text-red-700 m-4">{% trans 'Warning: the translation has been updated since the XLIFF was exported.' %}</p>{% endif %}
         <h2 class="heading font-normal m-4">{% trans 'Title' %}</h2>
         <pre class="diff m-4 p-4">{% if xliff_diff.title_diff %}{{xliff_diff.title_diff }}{% else %}{% trans 'No change' %}{% endif %}</pre>
         <h2 class="heading font-normal m-4">{% trans 'Content' %}</h2>
         <pre class="diff m-4 p-4">{% if xliff_diff.content_diff %}{{xliff_diff.content_diff }}{% else %}{% trans 'No change' %}{% endif %}</pre>
+        {% endif %}
     </div>
     {% endfor %}
 </div>


### PR DESCRIPTION
### Short description
When importing a XLIFF file, the attempt to import a translation for a not existing pages or language produces an error in the diff list.

![image](https://user-images.githubusercontent.com/15197000/105400517-54222000-5c25-11eb-9aad-0df9fb990b59.png)

### Proposed changes
This PR hands the information about failed imports to the template, where an alternative to the diff is rendered.

### Resolved issues
Fixes: #622 
