### PR TITLE
Combined last updated date for page with live content

### DIFF
--- a/src/api/v3/pages.py
+++ b/src/api/v3/pages.py
@@ -40,7 +40,7 @@ def transform_page(page_translation):
         "url": page_translation.permalink,
         "path": page_translation.slug,
         "title": page_translation.title,
-        "modified_gmt": page_translation.last_updated,
+        "modified_gmt": page_translation.combined_last_updated,
         "excerpt": page_translation.text,
         "content": page_translation.combined_text,
         "parent": parent,

--- a/src/cms/models/pages/page.py
+++ b/src/cms/models/pages/page.py
@@ -137,7 +137,7 @@ class Page(MPTTModel, AbstractBasePage):
         :rtype: str
         """
         if self.mirrored_page:
-            return self.mirrored_page.get_translation(language_code)
+            return self.mirrored_page.get_public_translation(language_code)
         return None
 
     class Meta:

--- a/src/cms/models/pages/page_translation.py
+++ b/src/cms/models/pages/page_translation.py
@@ -119,6 +119,20 @@ class PageTranslation(AbstractBasePageTranslation):
             return attached_text + self.text
         return self.text + attached_text
 
+    @property
+    def combined_last_updated(self):
+        """
+        This function combines the last_updated date from this PageTranslation and from a mirrored page.
+        If this translation has no content, then the date from the mirrored translation will be used. In
+        other cases, the date from this translation will be used.
+
+        :return: The last_upated date of this or the mirrored page translation
+        :rtype: ~datetime.datetime
+        """
+        if self.page.get_mirrored_page and not self.text:
+            return self.page.get_mirrored_page(self.language.code).last_updated
+        return self.last_updated
+
     @classmethod
     def get_translations(cls, region, language):
         """


### PR DESCRIPTION
### Short description
If a page is mirrored, the modified date in the API should be the one of the mirrored page, if the page translation itself has no content.


### Proposed changes
This adds a property `combined_last_updated` to the `PageTranslation` model that works in a similar way as the combined text property.

### Resolved issues

Fixes: #628 
