### PR TITLE
Add troubleshooting for developing on arm macs

### DIFF
--- a/sphinx/troubleshooting.rst
+++ b/sphinx/troubleshooting.rst
@@ -69,3 +69,38 @@ Not a git repository
 
         sudo add-apt-repository ppa:git-core/ppa
         sudo apt-get update
+
+MacOS on M1
+===========
+
+.. Error::
+
+    | There is no arm64 version of Python 3.7
+
+.. admonition:: Solution
+    :class: hint
+
+    Until a compatible version of Python 3.7 was released (the patch has already been merged: `python/cpython#22855 <https://github.com/python/cpython/pull/22855>`_). Until then you can use Python 3.8 instead. Just use homebrew and install it by running::
+
+        brew install python@3.8
+    
+    Also change `python_version` in `Pipfile` to `3.8`.
+
+.. Error::
+
+    | Error: pg_config executable not found.
+    | or
+    | ImportError: dlopen(/Users/xyz/Documents/Dev/integreat-cms/.venv/lib/python3.8/site-packages/psycopg2/_psycopg.cpython-38-darwin.so, 2): Symbol not found: _PQbackendPID
+    
+.. admonition:: Solution
+    :class: hint
+
+    There are some issues with the psycopg2 binary package right now. It needs to be compiled locally which requires postgres and libpq::
+
+        brew install libpq postgres --build-from-source 
+
+    The packages need to be built from source as the binary version of postgres is still x86. Building it from source works absolutely fine.
+    Afterwards psycopg2 needs to be reinstalled without using your local cache::
+
+        pipenv run pip uninstall psycopg2-binary
+        pipenv run pip install psycopg2-binary --no-cache-dir


### PR DESCRIPTION
### Short description
I had some issues while getting the application running on an M1 Macbook but was eventually able to solve the issues.

### Proposed changes
I explain:
* how to use a different python version
* how to compile postgres to get psycopg2 installed

It seems, like both issues will eventually go await once everyone adopts their software for the arm platform, but maybe it makes sense to have those steps in here for the meantime 😄 .