### PR TITLE
Added expert mode

### DIFF
--- a/src/cms/fixtures/test_data.json
+++ b/src/cms/fixtures/test_data.json
@@ -23,7 +23,8 @@
     "fields": {
       "user": 1,
       "organization": null,
-      "regions": []
+      "regions": [],
+      "expert_mode": true
     }
   },
   {

--- a/src/cms/forms/users/region_user_profile_form.py
+++ b/src/cms/forms/users/region_user_profile_form.py
@@ -15,7 +15,7 @@ class RegionUserProfileForm(UserProfileForm):
 
     class Meta:
         model = UserProfile
-        fields = ["organization"]
+        fields = ["organization", "expert_mode"]
 
     def __init__(self, data=None, instance=None):
 

--- a/src/cms/forms/users/user_profile_form.py
+++ b/src/cms/forms/users/user_profile_form.py
@@ -18,7 +18,7 @@ class UserProfileForm(forms.ModelForm):
 
     class Meta:
         model = UserProfile
-        fields = ["regions", "organization"]
+        fields = ["regions", "organization", "expert_mode"]
 
     def __init__(self, data=None, instance=None):
 

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-01 12:13+0000\n"
+"POT-Creation-Date: 2021-02-03 17:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: constants/administrative_division.py:52 templates/events/event_form.html:279
+#: constants/administrative_division.py:52 templates/events/event_form.html:281
 #: templates/pois/poi_form.html:184 templates/pois/poi_list.html:66
 #: templates/pois/poi_list_archived.html:40
 msgid "City"
@@ -497,8 +497,8 @@ msgstr "Seiten"
 msgid "All pages"
 msgstr "Alle Seiten"
 
-#: templates/_base.html:146 templates/pages/page_tree.html:46
-#: templates/pages/page_tree.html:50
+#: templates/_base.html:146 templates/pages/page_tree.html:48
+#: templates/pages/page_tree.html:52
 msgid "Create page"
 msgstr "Seite erstellen"
 
@@ -593,7 +593,7 @@ msgstr "Einstellungen"
 msgid "Admin Dashboard"
 msgstr "Admin Dashboard"
 
-#: templates/_base.html:254 templates/users/admin/user.html:92
+#: templates/_base.html:254 templates/users/admin/user.html:100
 msgid "Regions"
 msgstr "Regionen"
 
@@ -601,8 +601,8 @@ msgstr "Regionen"
 msgid "Languages"
 msgstr "Sprachen"
 
-#: templates/_base.html:266 templates/users/admin/user.html:87
-#: templates/users/region/user.html:77
+#: templates/_base.html:266 templates/users/admin/user.html:95
+#: templates/users/region/user.html:85
 msgid "Roles"
 msgstr "Rollen"
 
@@ -895,8 +895,8 @@ msgid "Not after"
 msgstr "Nicht nach"
 
 #: templates/events/_event_filter_form.html:34
-#: templates/events/event_form.html:480 templates/imprint/imprint_form.html:330
-#: templates/imprint/imprint_sbs.html:257 templates/pages/page_form.html:482
+#: templates/events/event_form.html:482 templates/imprint/imprint_form.html:330
+#: templates/imprint/imprint_sbs.html:257 templates/pages/page_form.html:486
 #: templates/pages/page_sbs.html:267 templates/pois/poi_form.html:329
 msgid "Location"
 msgstr "Ort"
@@ -939,8 +939,8 @@ msgstr "Event \"%(event_title)s\" bearbeiten"
 #: templates/events/event_list.html:72
 #: templates/events/event_list_archived.html:49
 #: templates/events/event_list_archived.html:55
-#: templates/pages/page_form.html:54 templates/pages/page_tree.html:68
-#: templates/pages/page_tree.html:74 templates/pages/page_tree_archived.html:29
+#: templates/pages/page_form.html:54 templates/pages/page_tree.html:70
+#: templates/pages/page_tree.html:76 templates/pages/page_tree_archived.html:29
 #: templates/pages/page_tree_archived.html:35 templates/pois/poi_form.html:53
 #: templates/pois/poi_list.html:46 templates/pois/poi_list.html:52
 #: templates/pois/poi_list_archived.html:29
@@ -997,7 +997,7 @@ msgstr "Version"
 #: templates/imprint/imprint_sbs.html:153 templates/pages/page_form.html:163
 #: templates/pages/page_revisions.html:44 templates/pages/page_sbs.html:82
 #: templates/pages/page_sbs.html:149 templates/pages/page_sbs.html:154
-#: templates/pages/page_tree.html:67 templates/pages/page_tree_archived.html:28
+#: templates/pages/page_tree.html:69 templates/pages/page_tree_archived.html:28
 #: templates/pois/poi_form.html:136 templates/pois/poi_list.html:45
 #: templates/pois/poi_list_archived.html:28
 #: templates/regions/region_form.html:87 templates/regions/region_list.html:32
@@ -1087,148 +1087,148 @@ msgstr "Uhrzeit"
 msgid "All-day"
 msgstr "Ganztägig"
 
-#: templates/events/event_form.html:213
+#: templates/events/event_form.html:214
 msgid "Recurrence"
 msgstr "Wiederholung"
 
-#: templates/events/event_form.html:216
+#: templates/events/event_form.html:217
 msgid "Recurring"
 msgstr "Wiederholend"
 
-#: templates/events/event_form.html:219
+#: templates/events/event_form.html:220
 msgid "Frequency"
 msgstr "Häufigkeit"
 
-#: templates/events/event_form.html:227 templates/events/event_form.html:241
+#: templates/events/event_form.html:228 templates/events/event_form.html:242
 msgid "Weekday"
 msgstr "Wochentag"
 
-#: templates/events/event_form.html:239
+#: templates/events/event_form.html:240
 msgid "Week"
 msgstr "Woche"
 
-#: templates/events/event_form.html:244
+#: templates/events/event_form.html:245
 msgid "Repeat every ... time(s)"
 msgstr "Jedes ...-te Mal wiederholen"
 
-#: templates/events/event_form.html:247
+#: templates/events/event_form.html:248
 msgid "Recurrence ends"
 msgstr "Wiederholung endet"
 
-#: templates/events/event_form.html:254
+#: templates/events/event_form.html:255
 msgid "Recurrence end date"
 msgstr "Wiederholung Enddatum"
 
-#: templates/events/event_form.html:258
+#: templates/events/event_form.html:260
 msgid "Where"
 msgstr "Wo"
 
-#: templates/events/event_form.html:260 templates/pois/poi_form.html:177
+#: templates/events/event_form.html:262 templates/pois/poi_form.html:177
 msgid "Address"
 msgstr "Adresse"
 
-#: templates/events/event_form.html:261
+#: templates/events/event_form.html:263
 msgid "Name of event location"
 msgstr "Name des Veranstaltungsortes"
 
-#: templates/events/event_form.html:265
+#: templates/events/event_form.html:267
 msgid "Remove location from event"
 msgstr "Veranstaltungsort von Veranstaltung entfernen"
 
-#: templates/events/event_form.html:274
+#: templates/events/event_form.html:276
 msgid ""
 "Create an event location or start typing the name of an existing location"
 msgstr ""
 "Erstelle einen Veranstaltungsort oder beginne den Namen eines bestehenden "
 "Veranstaltungsortes einzutippen"
 
-#: templates/events/event_form.html:277 templates/pois/poi_form.html:178
+#: templates/events/event_form.html:279 templates/pois/poi_form.html:178
 #: templates/pois/poi_list.html:64 templates/pois/poi_list_archived.html:38
 msgid "Street"
 msgstr "Straße"
 
-#: templates/events/event_form.html:281 templates/pois/poi_form.html:187
+#: templates/events/event_form.html:283 templates/pois/poi_form.html:187
 #: templates/pois/poi_list.html:67 templates/pois/poi_list_archived.html:41
 msgid "Country"
 msgstr "Land"
 
-#: templates/events/event_form.html:284
+#: templates/events/event_form.html:286
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:287 templates/imprint/imprint_form.html:203
-#: templates/pages/page_form.html:300 templates/pois/poi_form.html:201
+#: templates/events/event_form.html:289 templates/imprint/imprint_form.html:203
+#: templates/pages/page_form.html:302 templates/pois/poi_form.html:201
 #: templates/regions/region_icon_widget.html:4
 msgid "Icon"
 msgstr "Icon"
 
-#: templates/events/event_form.html:291 templates/imprint/imprint_form.html:207
+#: templates/events/event_form.html:293 templates/imprint/imprint_form.html:207
 #: templates/organizations/organization_form.html:65
-#: templates/pages/page_form.html:304 templates/pois/poi_form.html:205
+#: templates/pages/page_form.html:306 templates/pois/poi_form.html:205
 #: templates/regions/region_icon_widget.html:15
 msgid "Set icon"
 msgstr "Icon festlegen"
 
-#: templates/events/event_form.html:298
+#: templates/events/event_form.html:300
 #: templates/events/event_list_archived_row.html:97
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:305
+#: templates/events/event_form.html:307
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:308
+#: templates/events/event_form.html:310
 #: templates/events/event_list_row.html:100
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
-#: templates/events/event_form.html:315
+#: templates/events/event_form.html:317
 msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
-#: templates/events/event_form.html:321
+#: templates/events/event_form.html:323
 #: templates/events/event_list_archived_row.html:106
 #: templates/events/event_list_row.html:109
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
-#: templates/events/event_form.html:328
+#: templates/events/event_form.html:330
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:461 templates/imprint/imprint_form.html:311
-#: templates/imprint/imprint_sbs.html:238 templates/pages/page_form.html:447
+#: templates/events/event_form.html:463 templates/imprint/imprint_form.html:311
+#: templates/imprint/imprint_sbs.html:238 templates/pages/page_form.html:450
 #: templates/pages/page_sbs.html:248 templates/pois/poi_form.html:310
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:487 templates/imprint/imprint_form.html:337
-#: templates/imprint/imprint_sbs.html:264 templates/pages/page_form.html:489
+#: templates/events/event_form.html:489 templates/imprint/imprint_form.html:337
+#: templates/imprint/imprint_sbs.html:264 templates/pages/page_form.html:493
 #: templates/pages/page_sbs.html:274 templates/pois/poi_form.html:336
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:494 templates/imprint/imprint_form.html:344
-#: templates/imprint/imprint_sbs.html:271 templates/pages/page_form.html:496
+#: templates/events/event_form.html:496 templates/imprint/imprint_form.html:344
+#: templates/imprint/imprint_sbs.html:271 templates/pages/page_form.html:500
 #: templates/pages/page_sbs.html:281 templates/pois/poi_form.html:343
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:501 templates/imprint/imprint_form.html:351
-#: templates/imprint/imprint_sbs.html:278 templates/pages/page_form.html:503
+#: templates/events/event_form.html:503 templates/imprint/imprint_form.html:351
+#: templates/imprint/imprint_sbs.html:278 templates/pages/page_form.html:507
 #: templates/pages/page_sbs.html:288 templates/pois/poi_form.html:350
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:508 templates/imprint/imprint_form.html:358
-#: templates/imprint/imprint_sbs.html:285 templates/pages/page_form.html:510
+#: templates/events/event_form.html:510 templates/imprint/imprint_form.html:358
+#: templates/imprint/imprint_sbs.html:285 templates/pages/page_form.html:514
 #: templates/pages/page_sbs.html:295 templates/pois/poi_form.html:357
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:515 templates/imprint/imprint_form.html:365
-#: templates/imprint/imprint_sbs.html:292 templates/pages/page_form.html:517
+#: templates/events/event_form.html:517 templates/imprint/imprint_form.html:365
+#: templates/imprint/imprint_sbs.html:292 templates/pages/page_form.html:521
 #: templates/pages/page_sbs.html:302 templates/pois/poi_form.html:364
 msgid "Hint"
 msgstr "Tipp"
@@ -1255,7 +1255,7 @@ msgstr "ID"
 #: templates/languages/language_list.html:31
 #: templates/offer_templates/offer_template_list.html:29
 #: templates/organizations/organization_list.html:27
-#: templates/pages/page_tree.html:87 templates/pages/page_tree_archived.html:47
+#: templates/pages/page_tree.html:89 templates/pages/page_tree_archived.html:47
 #: templates/pois/poi_list.html:68 templates/pois/poi_list_archived.html:42
 #: templates/roles/list.html:25
 msgid "Options"
@@ -1661,7 +1661,7 @@ msgstr "Erstellt"
 
 #: templates/languages/language_list.html:30
 #: templates/offer_templates/offer_template_list.html:27
-#: templates/pages/page_tree.html:86 templates/regions/region_list.html:31
+#: templates/pages/page_tree.html:88 templates/regions/region_list.html:31
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
@@ -1928,15 +1928,15 @@ msgstr "Übergeordnete Seite"
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: templates/pages/page_form.html:275
+#: templates/pages/page_form.html:276
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:293
+#: templates/pages/page_form.html:295
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:294
+#: templates/pages/page_form.html:296
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -1944,17 +1944,17 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:311 templates/pages/page_form.html:312
-#: templates/pages/page_form.html:320
+#: templates/pages/page_form.html:313 templates/pages/page_form.html:314
+#: templates/pages/page_form.html:322
 #: templates/pages/page_tree_archived_node.html:94
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:317
+#: templates/pages/page_form.html:319
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:323
+#: templates/pages/page_form.html:325
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -1965,28 +1965,28 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
-#: templates/pages/page_form.html:336 templates/pages/page_form.html:337
+#: templates/pages/page_form.html:338 templates/pages/page_form.html:339
 #: templates/pages/page_tree_node.html:115
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:343
+#: templates/pages/page_form.html:345
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:349 templates/pages/page_form.html:367
+#: templates/pages/page_form.html:351 templates/pages/page_form.html:369
 #: templates/pages/page_tree_archived_node.html:112
 #: templates/pages/page_tree_node.html:128
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:353
+#: templates/pages/page_form.html:355
 #: templates/pages/page_tree_archived_node.html:108
 #: templates/pages/page_tree_node.html:124 views/pages/page_actions.py:203
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:354
+#: templates/pages/page_form.html:356
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -1997,7 +1997,7 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: templates/pages/page_form.html:373
+#: templates/pages/page_form.html:375
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
@@ -2027,47 +2027,47 @@ msgstr ""
 msgid "Archived pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/page_tree.html:40
+#: templates/pages/page_tree.html:41
 msgid "Filter pages"
 msgstr "Seiten filtern"
 
-#: templates/pages/page_tree.html:49
+#: templates/pages/page_tree.html:51
 msgid "You can only create pages in the default language"
 msgstr "Sie können Seiten nur in der Standard-Sprache anlegen"
 
-#: templates/pages/page_tree.html:107
+#: templates/pages/page_tree.html:109
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
-#: templates/pages/page_tree.html:119
+#: templates/pages/page_tree.html:121
 msgid "Bulk actions"
 msgstr "Aktionen"
 
-#: templates/pages/page_tree.html:123
+#: templates/pages/page_tree.html:125
 msgid "Please select"
 msgstr "bitte auswählen"
 
-#: templates/pages/page_tree.html:124
+#: templates/pages/page_tree.html:126
 msgid "Archive pages"
 msgstr "Seiten archivieren"
 
-#: templates/pages/page_tree.html:127
+#: templates/pages/page_tree.html:130
 msgid "Export XLIFF for translation to"
 msgstr "Exportiere XLIFF für Übersetzung nach"
 
-#: templates/pages/page_tree.html:130
+#: templates/pages/page_tree.html:134
 msgid "Export as PDF"
 msgstr "Als PDF Exportieren"
 
-#: templates/pages/page_tree.html:134
+#: templates/pages/page_tree.html:138
 msgid "Execute"
 msgstr "Ausführen"
 
-#: templates/pages/page_tree.html:145
+#: templates/pages/page_tree.html:150
 msgid "Upload XLIFF File"
 msgstr "XLIFF-Datei hochladen"
 
-#: templates/pages/page_tree.html:156
+#: templates/pages/page_tree.html:161
 msgid "Upload"
 msgstr "Hochladen"
 
@@ -2751,8 +2751,8 @@ msgstr "Vorname"
 msgid "Last Name"
 msgstr "Nachname"
 
-#: templates/users/admin/list.html:32 templates/users/admin/user.html:97
-#: templates/users/region/list.html:27 templates/users/region/user.html:82
+#: templates/users/admin/list.html:32 templates/users/admin/user.html:105
+#: templates/users/region/list.html:27 templates/users/region/user.html:90
 msgid "Organization"
 msgstr "Organisation"
 
@@ -2817,7 +2817,22 @@ msgstr "Feld leer lassen, um das Passwort nicht zu ändern"
 msgid "Enter the user's password here"
 msgstr "Passwort des Benutzers hier eingeben"
 
-#: templates/users/admin/user.html:108 templates/users/region/user.html:92
+#: templates/users/admin/user.html:87 templates/users/region/user.html:77
+msgid "Expert mode"
+msgstr "Expertenmodus"
+
+#: templates/users/admin/user.html:90 templates/users/region/user.html:80
+msgid ""
+"Enable this option to show up additional features like XLIFF import/export, "
+"page filtering, mirrored pages, page-based permissions, Do-Not-Translate-Tag "
+"and recurring events"
+msgstr ""
+"Aktiviert den Expertenmodus und ermöglicht zusätzliche Features wie XLIFF-"
+"Dateien zu importieren/exportieren, Seitenfilterung, Live Content, "
+"seitenbasierte Berechtigungen, Nicht-Übersetzen-Tag und wiederkehrende "
+"Veranstaltungen"
+
+#: templates/users/admin/user.html:116 templates/users/region/user.html:100
 msgid "Delete this user"
 msgstr "Diesen Benutzer löschen"
 
@@ -3554,6 +3569,12 @@ msgid ""
 msgstr ""
 "Ein Benutzer muss entweder Mitarbeiter/Super-Administrator sein, oder "
 "mindestens einer Region zugewiesen sein."
+
+#~ msgid "Toggle expert mode"
+#~ msgstr "Expertenmodus umschalten"
+
+#~ msgid "Other settings"
+#~ msgstr "Andere Einstellungen"
 
 #~ msgid "Yes, archive this page now."
 #~ msgstr "Ja, diese Seite jetzt archivieren"

--- a/src/cms/models/users/user_profile.py
+++ b/src/cms/models/users/user_profile.py
@@ -40,6 +40,7 @@ class UserProfile(models.Model):
         verbose_name="Date and time of last chat visit",
         help_text="The date and time when the user did read the chat the last time",
     )
+    expert_mode = models.BooleanField(default=False)
 
     @property
     def roles(self):

--- a/src/cms/templates/events/event_form.html
+++ b/src/cms/templates/events/event_form.html
@@ -210,49 +210,51 @@
                                 {% render_field event_form.end_time|add_error_class:"border-red-500" class="appearance-none block w-full bg-gray-200 text-gray-600 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
                             </div>
                         </div>
-                        <h3 class="font-bold mb-3 pt-4">{% trans 'Recurrence' %}</h3>
-                        <div class="checkbox-wrap relative my-2 pl-5" style="padding-top:2px;padding-bottom:2px;padding-left: 0">
-                            {% render_field event_form.is_recurring id="recurrence-rule-checkbox" %}
-                            <label for="is_recurring">{% trans 'Recurring' %}</label>
-                        </div>
-                        <div id="recurrence-rule"{% if not event_form.is_recurring.value %} class="hidden"{% endif %}>
-                            <label for="frequency" class="mt-4 mb-2 block font-bold text-sm">{% trans 'Frequency' %}</label>
-                            <div class="relative my-2">
-                                {% render_field recurrence_rule_form.frequency|add_error_class:"border-red-500" id="recurrence-frequency-select" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
-                                    <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                        <div class="{% if not request.user.profile.expert_mode %}hidden{% endif %}">
+                            <h3 class="font-bold mb-3 pt-4">{% trans 'Recurrence' %}</h3>
+                            <div class="checkbox-wrap relative my-2 pl-5" style="padding-top:2px;padding-bottom:2px;padding-left: 0">
+                                {% render_field event_form.is_recurring id="recurrence-rule-checkbox" %}
+                                <label for="is_recurring">{% trans 'Recurring' %}</label>
+                            </div>
+                            <div id="recurrence-rule"{% if not event_form.is_recurring.value %} class="hidden"{% endif %}>
+                                <label for="frequency" class="mt-4 mb-2 block font-bold text-sm">{% trans 'Frequency' %}</label>
+                                <div class="relative my-2">
+                                    {% render_field recurrence_rule_form.frequency|add_error_class:"border-red-500" id="recurrence-frequency-select" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                                    <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
+                                        <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                                    </div>
                                 </div>
-                            </div>
-                            <div id="recurrence-weekly"{% if not recurrence_rule_form.instance.frequency == 'WEEKLY' %} class="hidden"{% endif %}>
-                                <label for="weekdays_for_weekly" class="mt-4 mb-2 block font-bold text-sm">{% trans 'Weekday' %}</label>
-                                <select name="weekdays_for_weekly" id="id_weekdays_for_weekly" multiple="multiple" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500{% if recurrence_rule_form.weekdays_for_weekly.errors %} border-red-500{% endif %}">
-                                    {% for choice_value, choice_label in recurrence_rule_form.fields.weekdays_for_weekly.widget.choices %}
-                                    <option value="{{ choice_value }}"{% if not recurrence_rule_form.data|is_empty %}
-                                        {% if choice_value in recurrence_rule_form.data|get_int_list:'weekdays_for_weekly' %} selected="selected"{% endif %}
-                                    {% else %}
-                                        {% if choice_value in recurrence_rule_form.instance.weekdays_for_weekly %} selected="selected"{% endif %}
-                                    {% endif %}>{{ choice_label }}</option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                            <div id="recurrence-monthly"{% if not recurrence_rule_form.instance.frequency == 'MONTHLY' %} class="hidden"{% endif %}>
-                                <label class="mt-4 mb-2 block font-bold text-sm">{% trans 'Week' %}</label>
-                                {% render_field recurrence_rule_form.week_for_monthly|add_error_class:"border-red-500" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                                <label class="mt-4 mb-2 block font-bold text-sm">{% trans 'Weekday' %}</label>
-                                {% render_field recurrence_rule_form.weekday_for_monthly|add_error_class:"border-red-500" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                            </div>
-                            <label class="mt-4 mb-2 block font-bold text-sm">{% trans 'Repeat every ... time(s)' %}</label>
-                            {% render_field recurrence_rule_form.interval|add_error_class:"border-red-500" class="appearance-none block w-full bg-gray-200 text-gray-600 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                            <div class="checkbox-wrap relative mt-2 pl-5" style="padding-top:2px;padding-bottom:2px;padding-left:0;">
-                                {% render_field recurrence_rule_form.has_recurrence_end_date id="recurrence-end-checkbox" %} {% trans 'Recurrence ends' %}
-                            </div>
-                            <div id="recurrence-end"{% if not recurrence_rule_form.data|is_empty %}
-                                {% if not recurrence_rule_form.data.has_recurrence_end_date %} class="hidden"{% endif %}
-                            {% else %}
-                                {% if not recurrence_rule_form.instance.recurrence_end_date %} class="hidden"{% endif %}
-                            {% endif %}>
-                                <label class="mt-4 mb-2 block font-bold text-sm">{% trans 'Recurrence end date' %}</label>
-                                {% render_field recurrence_rule_form.recurrence_end_date|add_error_class:"border-red-500" class="appearance-none block w-full bg-gray-200 text-gray-600 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                                <div id="recurrence-weekly"{% if not recurrence_rule_form.instance.frequency == 'WEEKLY' %} class="hidden"{% endif %}>
+                                    <label for="weekdays_for_weekly" class="mt-4 mb-2 block font-bold text-sm">{% trans 'Weekday' %}</label>
+                                    <select name="weekdays_for_weekly" id="id_weekdays_for_weekly" multiple="multiple" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500{% if recurrence_rule_form.weekdays_for_weekly.errors %} border-red-500{% endif %}">
+                                        {% for choice_value, choice_label in recurrence_rule_form.fields.weekdays_for_weekly.widget.choices %}
+                                        <option value="{{ choice_value }}"{% if not recurrence_rule_form.data|is_empty %}
+                                            {% if choice_value in recurrence_rule_form.data|get_int_list:'weekdays_for_weekly' %} selected="selected"{% endif %}
+                                        {% else %}
+                                            {% if choice_value in recurrence_rule_form.instance.weekdays_for_weekly %} selected="selected"{% endif %}
+                                        {% endif %}>{{ choice_label }}</option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                                <div id="recurrence-monthly"{% if not recurrence_rule_form.instance.frequency == 'MONTHLY' %} class="hidden"{% endif %}>
+                                    <label class="mt-4 mb-2 block font-bold text-sm">{% trans 'Week' %}</label>
+                                    {% render_field recurrence_rule_form.week_for_monthly|add_error_class:"border-red-500" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                                    <label class="mt-4 mb-2 block font-bold text-sm">{% trans 'Weekday' %}</label>
+                                    {% render_field recurrence_rule_form.weekday_for_monthly|add_error_class:"border-red-500" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                                </div>
+                                <label class="mt-4 mb-2 block font-bold text-sm">{% trans 'Repeat every ... time(s)' %}</label>
+                                {% render_field recurrence_rule_form.interval|add_error_class:"border-red-500" class="appearance-none block w-full bg-gray-200 text-gray-600 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                                <div class="checkbox-wrap relative mt-2 pl-5" style="padding-top:2px;padding-bottom:2px;padding-left:0;">
+                                    {% render_field recurrence_rule_form.has_recurrence_end_date id="recurrence-end-checkbox" %} {% trans 'Recurrence ends' %}
+                                </div>
+                                <div id="recurrence-end"{% if not recurrence_rule_form.data|is_empty %}
+                                    {% if not recurrence_rule_form.data.has_recurrence_end_date %} class="hidden"{% endif %}
+                                {% else %}
+                                    {% if not recurrence_rule_form.instance.recurrence_end_date %} class="hidden"{% endif %}
+                                {% endif %}>
+                                    <label class="mt-4 mb-2 block font-bold text-sm">{% trans 'Recurrence end date' %}</label>
+                                    {% render_field recurrence_rule_form.recurrence_end_date|add_error_class:"border-red-500" class="appearance-none block w-full bg-gray-200 text-gray-600 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                                </div>
                             </div>
                         </div>
                         <h3 class="font-bold my-3">{% trans 'Where' %}</h3>

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -272,24 +272,26 @@
                         {% include "pages/_page_order_table.html" %}
                     </div>
                     {% if page %}
-                        <span class="font-bold mb-2 mt-4">{% trans 'Embed live content' %}</span>
-                        <div class="relative my-2">
-                            {% render_field page_form.mirrored_page_region id="mirrored_page_region" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                            <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
-                                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                        <div class="{% if not request.user.profile.expert_mode %}hidden{% endif %}">
+                            <span class="font-bold mb-2 mt-4">{% trans 'Embed live content' %}</span>
+                            <div class="relative my-2">
+                                {% render_field page_form.mirrored_page_region id="mirrored_page_region" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
+                                    <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                                </div>
                             </div>
-                        </div>
-                        <div class="relative my-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_div" data-url="{% url 'render_mirrored_page_field' %}?page_id={{ page_form.instance.id }}&region_id=">
-                            {% include "pages/_mirrored_page_field.html" %}
-                        </div>
-                        <div class="relative my-2 pb-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_first_div">
-                            {% render_field page_form.mirrored_page_first id="mirrored_page_first" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                            <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
-                                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                            <div class="relative my-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_div" data-url="{% url 'render_mirrored_page_field' %}?page_id={{ page_form.instance.id }}&region_id=">
+                                {% include "pages/_mirrored_page_field.html" %}
+                            </div>
+                            <div class="relative my-2 pb-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_first_div">
+                                {% render_field page_form.mirrored_page_first id="mirrored_page_first" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
+                                    <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                                </div>
                             </div>
                         </div>
                     {% endif %}
-                    {% if perms.cms.grant_page_permissions and region.page_permissions_enabled %}
+                    {% if perms.cms.grant_page_permissions and region.page_permissions_enabled and request.user.profile.expert_mode %}
                         <span class="block font-bold mb-2">{% trans 'Additional permissions for this page' %}</span>
                         <p class="italic">{% trans "This affects only users, who don't have the permission to change arbitrary pages anyway." %}</p>
                         <div id="page_permission_table">
@@ -442,6 +444,7 @@ document.addEventListener('DOMContentLoaded', function(){
         content_css : '{% static "css/tinymce_custom.css" %}',
         language: '{{LANGUAGE_CODE|slice:"0:2"}}',
         setup: (editor) => {
+            {% if request.user.profile.expert_mode %}
             editor.ui.registry.addButton('notranslate',
             {
                 tooltip: '{% trans 'Do not translate the selected text.' %}',
@@ -472,6 +475,7 @@ document.addEventListener('DOMContentLoaded', function(){
                     }
                 }
             });
+            {% endif %}
             editor.ui.registry.addIcon('pin_icon', '<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">		<path d="M256,0C161.896,0,85.333,76.563,85.333,170.667c0,28.25,7.063,56.26,20.49,81.104L246.667,506.5			c1.875,3.396,5.448,5.5,9.333,5.5s7.458-2.104,9.333-5.5l140.896-254.813c13.375-24.76,20.438-52.771,20.438-81.021			C426.667,76.563,350.104,0,256,0z M256,256c-47.052,0-85.333-38.281-85.333-85.333c0-47.052,38.281-85.333,85.333-85.333			s85.333,38.281,85.333,85.333C341.333,217.719,303.052,256,256,256z"/></svg>');
             editor.ui.registry.addIcon('www_icon','<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 viewBox="0 0 26 26" style="enable-background:new 0 0 26 26;" xml:space="preserve">	<path style="fill:#030104;" d="M8.083,11.222L6.419,15c-0.041,0.094-0.144,0.154-0.257,0.154H5.31		c-0.113,0-0.216-0.061-0.256-0.154l-0.79-1.803c-0.077-0.178-0.147-0.348-0.213-0.517c-0.073,0.186-0.148,0.359-0.223,0.525		l-0.833,1.8c-0.042,0.091-0.144,0.149-0.255,0.149H1.888c-0.117,0-0.219-0.063-0.259-0.158l-1.557-3.779		c-0.03-0.074-0.018-0.156,0.034-0.221s0.135-0.103,0.225-0.103H1.29c0.121,0,0.227,0.069,0.263,0.169l0.684,1.92		c0.057,0.162,0.11,0.315,0.159,0.461c0.06-0.146,0.125-0.3,0.194-0.463l0.842-1.932c0.041-0.093,0.143-0.155,0.256-0.155H4.48		c0.115,0,0.217,0.063,0.258,0.157l0.798,1.89c0.072,0.17,0.136,0.329,0.195,0.479c0.049-0.142,0.106-0.296,0.171-0.465l0.737-1.898		c0.038-0.098,0.143-0.164,0.26-0.164h0.926c0.091,0,0.175,0.039,0.227,0.104C8.105,11.064,8.115,11.147,8.083,11.222z		 M17.005,11.222L15.341,15c-0.041,0.094-0.144,0.154-0.256,0.154h-0.854c-0.113,0-0.215-0.061-0.256-0.154l-0.789-1.803		c-0.078-0.178-0.148-0.348-0.214-0.517c-0.073,0.186-0.148,0.359-0.223,0.525l-0.833,1.8c-0.042,0.091-0.143,0.149-0.255,0.149		h-0.853c-0.116,0-0.219-0.063-0.259-0.158l-1.557-3.779c-0.03-0.074-0.018-0.156,0.034-0.221c0.052-0.064,0.136-0.103,0.225-0.103		h0.959c0.121,0,0.227,0.069,0.263,0.169l0.683,1.92c0.057,0.162,0.11,0.315,0.161,0.461c0.059-0.146,0.123-0.3,0.192-0.463		l0.843-1.932c0.04-0.093,0.142-0.155,0.256-0.155H13.4c0.115,0,0.218,0.063,0.258,0.157l0.799,1.89		c0.071,0.17,0.135,0.329,0.193,0.479c0.051-0.142,0.106-0.296,0.172-0.465l0.737-1.898c0.038-0.098,0.144-0.164,0.261-0.164h0.926		c0.092,0,0.177,0.039,0.227,0.104C17.026,11.064,17.038,11.147,17.005,11.222z M25.926,11.222L24.263,15		c-0.042,0.094-0.144,0.154-0.257,0.154h-0.853c-0.113,0-0.216-0.061-0.256-0.154l-0.789-1.803		c-0.078-0.178-0.148-0.348-0.214-0.517c-0.073,0.186-0.149,0.359-0.224,0.525l-0.833,1.8c-0.042,0.091-0.144,0.149-0.255,0.149		H19.73c-0.117,0-0.22-0.063-0.26-0.158l-1.557-3.779c-0.029-0.074-0.019-0.156,0.033-0.221s0.136-0.103,0.226-0.103h0.96		c0.121,0,0.227,0.069,0.262,0.169l0.684,1.92c0.057,0.162,0.11,0.315,0.16,0.461c0.059-0.146,0.123-0.3,0.192-0.463l0.843-1.932		c0.041-0.093,0.143-0.155,0.257-0.155h0.791c0.115,0,0.218,0.063,0.258,0.157l0.798,1.89c0.072,0.17,0.137,0.329,0.196,0.479		c0.049-0.142,0.106-0.296,0.171-0.465l0.738-1.898c0.037-0.098,0.142-0.164,0.26-0.164h0.926c0.092,0,0.176,0.039,0.227,0.104		C25.946,11.064,25.958,11.147,25.926,11.222z"/>		<path style="fill:#030104;" d="M2.71,9c0.283-0.718,0.637-1.401,1.057-2.037C3.829,6.975,3.887,7,3.952,7h1.88			c-0.199,0.634-0.355,1.309-0.49,2h2.055c0.155-0.699,0.335-1.376,0.562-2h9.986c0.227,0.624,0.407,1.301,0.562,2h2.055			c-0.135-0.691-0.291-1.366-0.49-2h1.88c0.065,0,0.123-0.025,0.186-0.037C22.556,7.599,22.911,8.282,23.194,9h2.121			c-1.691-5.216-6.591-9-12.363-9S2.28,3.784,0.588,9H2.71z M20.478,5H19.29c-0.258-0.543-0.542-1.05-0.851-1.519			C19.179,3.909,19.861,4.419,20.478,5z M12.952,2c1.551,0,2.983,1.154,4.062,3H8.89C9.969,3.154,11.401,2,12.952,2z M7.463,3.481			C7.155,3.95,6.871,4.457,6.613,5H5.426C6.043,4.419,6.725,3.909,7.463,3.481z"/>		<path style="fill:#030104;" d="M23.194,17c-0.283,0.719-0.638,1.4-1.057,2.037C22.075,19.025,22.017,19,21.952,19h-1.881			c0.199-0.634,0.355-1.309,0.49-2h-2.055c-0.154,0.699-0.335,1.377-0.562,2H7.959c-0.227-0.623-0.407-1.301-0.562-2H5.343			c0.135,0.691,0.291,1.366,0.49,2H3.952c-0.065,0-0.123,0.025-0.185,0.037C3.348,18.4,2.993,17.719,2.71,17H0.588			c1.692,5.216,6.592,9,12.364,9s10.672-3.784,12.363-9H23.194z M5.426,21h1.188c0.258,0.543,0.542,1.051,0.85,1.519			C6.725,22.091,6.043,21.581,5.426,21z M12.952,24c-1.551,0-2.983-1.154-4.062-3h8.123C15.935,22.846,14.503,24,12.952,24z			 M18.44,22.519c0.309-0.468,0.593-0.976,0.851-1.519h1.188C19.861,21.581,19.179,22.091,18.44,22.519z"/></svg>');
             editor.ui.registry.addIcon('call_icon', '<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"	 width="16" height="16" viewBox="0 0 348.077 348.077" style="enable-background:new 0 0 348.077 348.077;"	 xml:space="preserve">			<path d="M340.273,275.083l-53.755-53.761c-10.707-10.664-28.438-10.34-39.518,0.744l-27.082,27.076				c-1.711-0.943-3.482-1.928-5.344-2.973c-17.102-9.476-40.509-22.464-65.14-47.113c-24.704-24.701-37.704-48.144-47.209-65.257				c-1.003-1.813-1.964-3.561-2.913-5.221l18.176-18.149l8.936-8.947c11.097-11.1,11.403-28.826,0.721-39.521L73.39,8.194				C62.708-2.486,44.969-2.162,33.872,8.938l-15.15,15.237l0.414,0.411c-5.08,6.482-9.325,13.958-12.484,22.02				C3.74,54.28,1.927,61.603,1.098,68.941C-6,127.785,20.89,181.564,93.866,254.541c100.875,100.868,182.167,93.248,185.674,92.876				c7.638-0.913,14.958-2.738,22.397-5.627c7.992-3.122,15.463-7.361,21.941-12.43l0.331,0.294l15.348-15.029				C350.631,303.527,350.95,285.795,340.273,275.083z"/></svg>');

--- a/src/cms/templates/pages/page_tree.html
+++ b/src/cms/templates/pages/page_tree.html
@@ -35,10 +35,12 @@
 
 
         <div class="w-1/2 flex flex-wrap justify-end">
+            {% if request.user.profile.expert_mode %}
             <button id="filter-toggle"
                     class="bg-gray-500 hover:bg-gray-600 text-gray-800 hover:text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline mr-3">
                 {% trans 'Filter pages' %}
             </button>
+            {% endif %}
             {% has_perm 'cms.edit_page' request.user as can_edit_pages %}
             {% if can_edit_pages %}
                 {% if region.default_language == language %}
@@ -122,11 +124,13 @@
                     <select class="h-full pl-4 pr-4 rounded shadow" style="padding-top: 5px;" name="bulk_action" id="bulk_action">
                         <option>{% trans 'Please select' %}</option>
                         <option value="archive_pages">{% trans 'Archive pages' %}
-                        {% for lang in languages %}
-                        {% if lang != region.default_language %}
-                        <option value="{{ lang.code }}">{% trans 'Export XLIFF for translation to' %} {{ lang.translated_name }}</option>
+                        {% if request.user.profile.expert_mode %}
+                            {% for lang in languages %}
+                            {% if lang != region.default_language %}
+                            <option value="{{ lang.code }}">{% trans 'Export XLIFF for translation to' %} {{ lang.translated_name }}</option>
+                            {% endif %}
+                            {% endfor %}
                         {% endif %}
-                        {% endfor %}
                         <option value="pdf_export">{% trans 'Export as PDF' %}</option>
                     </select>
                 </div>
@@ -138,25 +142,27 @@
                 </div>
             </form>
         </div>
-        <div class="flex-wrap relative w-1/2">
-            <form class="table-search relative flex flex-wrap h-full" method="post" enctype="multipart/form-data"
-                  action="{% url 'upload_xliff' region_slug=region.slug language_code=language.code%}">
-                 <div class="pl-3" style="padding-top: 0.4em;">
-                    {% trans 'Upload XLIFF File' %}
-                </div>
-               <div class="pl-3">
-                    <i data-feather="upload" class="absolute"></i>
-                    <input type="file" name="xliff_file" class="h-full pl-10 pr-4 rounded shadow" style="padding-top: 5px;">
-                    {% csrf_token %}
-                </div>
+        {% if request.user.profile.expert_mode %}
+            <div class="flex-wrap relative w-1/2">
+                <form class="table-search relative flex flex-wrap h-full" method="post" enctype="multipart/form-data"
+                    action="{% url 'upload_xliff' region_slug=region.slug language_code=language.code%}">
+                    <div class="pl-3" style="padding-top: 0.4em;">
+                        {% trans 'Upload XLIFF File' %}
+                    </div>
                 <div class="pl-3">
-                    <input type="submit"
-                       class="inline-block cursor-pointer bg-blue-500
-                       hover:bg-blue-600 text-white h-full
-                       font-bold py-2 px-4 rounded" value="{% trans 'Upload' %}" />
-                </div>
-            </form>
-        </div>
+                        <i data-feather="upload" class="absolute"></i>
+                        <input type="file" name="xliff_file" class="h-full pl-10 pr-4 rounded shadow" style="padding-top: 5px;">
+                        {% csrf_token %}
+                    </div>
+                    <div class="pl-3">
+                        <input type="submit"
+                        class="inline-block cursor-pointer bg-blue-500
+                        hover:bg-blue-600 text-white h-full
+                        font-bold py-2 px-4 rounded" value="{% trans 'Upload' %}" />
+                    </div>
+                </form>
+            </div>
+        {% endif %}
     </div>
 </div>
 

--- a/src/cms/templates/users/admin/user.html
+++ b/src/cms/templates/users/admin/user.html
@@ -84,6 +84,14 @@
                 </div>
 
                 <div class="py-4 border-b solid border-gray-200">
+                    <label for="id_expert_mode" class="font-bold mr-2 cursor-pointer">{% trans 'Expert mode' %}</label>
+                    {% render_field user_profile_form.expert_mode %}
+                    <p class="pt-2">
+                        {% trans 'Enable this option to show up additional features like XLIFF import/export, page filtering, mirrored pages, page-based permissions, Do-Not-Translate-Tag and recurring events' %}
+                    </p>
+                </div>
+                
+                <div class="py-4 border-b solid border-gray-200">
                     <label for="id_roles" class="font-bold block mb-2 cursor-pointer">{% trans 'Roles' %}</label>
                     {% render_field user_form.roles class+="w-full" %}
                 </div>

--- a/src/cms/templates/users/region/user.html
+++ b/src/cms/templates/users/region/user.html
@@ -74,6 +74,14 @@
                     </div>
 
                     <div class="py-4 border-b solid border-gray-200">
+                        <label for="id_expert_mode" class="font-bold mr-2 cursor-pointer">{% trans 'Expert mode' %}</label>
+                        {% render_field user_profile_form.expert_mode %}
+                        <p class="pt-2">
+                            {% trans 'Enable this option to show up additional features like XLIFF import/export, page filtering, mirrored pages, page-based permissions, Do-Not-Translate-Tag and recurring events' %}
+                        </p>
+                    </div>
+
+                    <div class="py-4 border-b solid border-gray-200">
                         <label for="id_roles" class="font-bold block mb-2 cursor-pointer">{% trans 'Roles' %}</label>
                         {% render_field user_form.roles class+="w-full" %}
                     </div>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Added expert mode for displaying additional features.

### Proposed changes
<!-- Describe this PR in more detail. -->

Enabling expert mode includes the following features:
- Page mirroring
- Recurring events
- Do-Not-Translate-Tag in page editor
- Page-based permissions
- XLIFF import/export
- Page filtering

### Additional context

Expert mode setting is saved per user account, additional expert-mode-checkbox for (region-)user supplied.
Expert mode does not add an additional role to database, because expert mode does not deal with any additional permissions when enabled. Disabling expert mode just simplifies the GUI by hiding the aforementioned features.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #499

### Screenshot

![expert_mode](https://user-images.githubusercontent.com/47010475/106758520-e23cd400-6631-11eb-84a9-ec29158fbba7.png)

