### PR TITLE
Setup autolink & custom_plugin

### DIFF
--- a/src/cms/static/js/forms/tinymce-init.js
+++ b/src/cms/static/js/forms/tinymce-init.js
@@ -12,8 +12,12 @@ tinymce.init({
     },
     contextmenu: "paste link",
     autosave_interval: '120s',
-    plugins: "code paste fullscreen autosave link preview media image lists directionality",
+    plugins: "code paste fullscreen autosave autolink link preview media image lists directionality",
+    external_plugins: {
+        'autolink_phone': '../js/tinymce_plugins/autolink_phone/plugin.js'
+    },
     toolbar: 'bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate removeformat | aligncenter indent outdent | link image',
+    link_default_protocol: 'https',
     style_formats: [
         { title: 'Headings', items: [
                 { title: 'Heading 2', format: 'h2' },

--- a/src/cms/static/js/tinymce_plugins/autolink_phone/index.js
+++ b/src/cms/static/js/tinymce_plugins/autolink_phone/index.js
@@ -1,0 +1,3 @@
+// Entry point for Tinymce hook.
+// Author: Jan-Ulrich Holtgrave (holtgrave@integreat-app.de)
+require('./plugin.js');

--- a/src/cms/static/js/tinymce_plugins/autolink_phone/plugin.js
+++ b/src/cms/static/js/tinymce_plugins/autolink_phone/plugin.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) Tiny Technologies, Inc. All rights reserved.
+ * Licensed under the LGPL or a commercial license.
+ * For LGPL see License.txt in the project root for license information.
+ * For commercial licenses see https://www.tiny.cloud/
+ *
+ * Version: 5.7.0 (2021-02-10)
+ */
+(function () {
+    'use strict';
+
+    var global = tinymce.util.Tools.resolve('tinymce.PluginManager');
+
+    var global$1 = tinymce.util.Tools.resolve('tinymce.Env');
+
+    var rangeEqualsDelimiterOrSpace = function (rangeString, delimiter) {
+      return rangeString === delimiter || rangeString === ' ' || rangeString.charCodeAt(0) === 160;
+    };
+    var handleEclipse = function (editor) {
+      parseCurrentLine(editor, -1, '(');
+    };
+    var handleSpacebar = function (editor) {
+      parseCurrentLine(editor, 0, '');
+    };
+    var handleEnter = function (editor) {
+      parseCurrentLine(editor, -1, '');
+    };
+    var scopeIndex = function (container, index) {
+      if (index < 0) {
+        index = 0;
+      }
+      if (container.nodeType === 3) {
+        var len = container.data.length;
+        if (index > len) {
+          index = len;
+        }
+      }
+      return index;
+    };
+    var setStart = function (rng, container, offset) {
+      if (container.nodeType !== 1 || container.hasChildNodes()) {
+        rng.setStart(container, scopeIndex(container, offset));
+      } else {
+        rng.setStartBefore(container);
+      }
+    };
+    var setEnd = function (rng, container, offset) {
+      if (container.nodeType !== 1 || container.hasChildNodes()) {
+        rng.setEnd(container, scopeIndex(container, offset));
+      } else {
+        rng.setEndAfter(container);
+      }
+    };
+    var parseCurrentLine = function (editor, endOffset, delimiter) {
+      var end, endContainer, bookmark, text, prev, len, rngText;
+      if (editor.selection.getNode().tagName === 'A') {
+        return;
+      }
+      var rng = editor.selection.getRng().cloneRange();
+      if (rng.startOffset < 5) {
+        prev = rng.endContainer.previousSibling;
+        if (!prev) {
+          if (!rng.endContainer.firstChild || !rng.endContainer.firstChild.nextSibling) {
+            return;
+          }
+          prev = rng.endContainer.firstChild.nextSibling;
+        }
+        len = prev.length;
+        setStart(rng, prev, len);
+        setEnd(rng, prev, len);
+        if (rng.endOffset < 5) {
+          return;
+        }
+        end = rng.endOffset;
+        endContainer = prev;
+      } else {
+        endContainer = rng.endContainer;
+        if (endContainer.nodeType !== 3 && endContainer.firstChild) {
+          while (endContainer.nodeType !== 3 && endContainer.firstChild) {
+            endContainer = endContainer.firstChild;
+          }
+          if (endContainer.nodeType === 3) {
+            setStart(rng, endContainer, 0);
+            setEnd(rng, endContainer, endContainer.nodeValue.length);
+          }
+        }
+        if (rng.endOffset === 1) {
+          end = 2;
+        } else {
+          end = rng.endOffset - 1 - endOffset;
+        }
+      }
+      var start = end;
+      do {
+        setStart(rng, endContainer, end >= 2 ? end - 2 : 0);
+        setEnd(rng, endContainer, end >= 1 ? end - 1 : 0);
+        end -= 1;
+        rngText = rng.toString();
+      } while (rngText !== ' ' && rngText !== '' && rngText.charCodeAt(0) !== 160 && end - 2 >= 0 && rngText !== delimiter);
+      if (rangeEqualsDelimiterOrSpace(rng.toString(), delimiter)) {
+        setStart(rng, endContainer, end);
+        setEnd(rng, endContainer, start);
+        end += 1;
+      } else if (rng.startOffset === 0) {
+        setStart(rng, endContainer, 0);
+        setEnd(rng, endContainer, start);
+      } else {
+        setStart(rng, endContainer, end);
+        setEnd(rng, endContainer, start);
+      }
+      text = rng.toString();
+      if (text.charAt(text.length - 1) === '.') {
+        setEnd(rng, endContainer, start - 1);
+      }
+      text = rng.toString().trim();
+      var matches = text.match('(112112112)|(110)');
+      console.log(matches);
+      if (matches) {
+        matches[1] = 'tel:' + matches[1];
+        bookmark = editor.selection.getBookmark();
+        editor.selection.setRng(rng);
+        editor.execCommand('createlink', false, matches[1] + matches[2]);
+        editor.selection.moveToBookmark(bookmark);
+        editor.nodeChanged();
+      }
+    };
+    var setup = function (editor) {
+      var autoUrlDetectState;
+      editor.on('keydown', function (e) {
+        if (e.keyCode === 13) {
+          return handleEnter(editor);
+        }
+      });
+      if (global$1.browser.isIE()) {
+        editor.on('focus', function () {
+          if (!autoUrlDetectState) {
+            autoUrlDetectState = true;
+            try {
+              editor.execCommand('AutoUrlDetect', false, true);
+            } catch (ex) {
+            }
+          }
+        });
+        return;
+      }
+      editor.on('keypress', function (e) {
+        if (e.keyCode === 41) {
+          return handleEclipse(editor);
+        }
+      });
+      editor.on('keyup', function (e) {
+        if (e.keyCode === 32) {
+          return handleSpacebar(editor);
+        }
+      });
+    };
+
+    function Plugin () {
+      global.add('autolink_phone', function (editor) {
+        setup(editor);
+      });
+    }
+
+    Plugin();
+
+}());


### PR DESCRIPTION
### Short description
This PR actives the inbuilt autolink plugin for the automated detection of mail addresses and enforces HTTPS for all links in our content. The found links are directly converted into a Link-Object and mail addresses are converted into :mailto-links.

Additionally, I created a custom tinymce plugin to detect phone numbers as well. Although, this isn't ready yet.


### Proposed changes
- Activate autolink plugin.
- Enforce HTTPS for all links (to be discussed).
- Add custom plugin to detect and modify phone numbers.

### Resolved issues

Fixes: #587 
