### PR TITLE
Adds pagination to lists

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -522,3 +522,12 @@ COMPRESS_ES6_COMPILER_CMD = 'export NODE_PATH="{paths}" && {browserify_bin} "{in
 
 #: Whether thumbnails should be stored in high resolution (used by :doc:`easy-thumbnails:index`)
 THUMBNAIL_HIGH_RESOLUTION = True
+
+##############
+# Pagination #
+##############
+
+#: Number of entries displayed per pagination chunk
+#: see :attr:`django-pagination:django.core.paginator.Paginator`
+
+PER_PAGE = 16

--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -528,6 +528,5 @@ THUMBNAIL_HIGH_RESOLUTION = True
 ##############
 
 #: Number of entries displayed per pagination chunk
-#: see :attr:`django-pagination:django.core.paginator.Paginator`
-
+#: see :class:`~django.core.paginator.Paginator`
 PER_PAGE = 16

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-19 14:03+0000\n"
+"POT-Creation-Date: 2021-02-19 18:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1827,7 +1827,7 @@ msgstr "Nicht nach"
 
 #: templates/events/_event_filter_form.html:34
 #: templates/events/event_form.html:347 templates/imprint/imprint_form.html:257
-#: templates/imprint/imprint_sbs.html:180 templates/pages/page_form.html:391
+#: templates/imprint/imprint_sbs.html:180 templates/pages/page_form.html:389
 #: templates/pages/page_sbs.html:190 templates/pois/poi_form.html:249
 msgid "Location"
 msgstr "Ort"
@@ -1990,7 +1990,7 @@ msgstr "Icon"
 
 #: templates/events/event_form.html:290 templates/imprint/imprint_form.html:205
 #: templates/organizations/organization_form.html:63
-#: templates/pages/page_form.html:272 templates/pois/poi_form.html:199
+#: templates/pages/page_form.html:270 templates/pois/poi_form.html:199
 #: templates/regions/region_icon_widget.html:16
 msgid "Set icon"
 msgstr "Icon festlegen"
@@ -2024,37 +2024,37 @@ msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
 #: templates/events/event_form.html:346 templates/imprint/imprint_form.html:256
-#: templates/imprint/imprint_sbs.html:179 templates/pages/page_form.html:390
+#: templates/imprint/imprint_sbs.html:179 templates/pages/page_form.html:388
 #: templates/pages/page_sbs.html:189 templates/pois/poi_form.html:248
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
 #: templates/events/event_form.html:349 templates/imprint/imprint_form.html:259
-#: templates/imprint/imprint_sbs.html:182 templates/pages/page_form.html:393
+#: templates/imprint/imprint_sbs.html:182 templates/pages/page_form.html:391
 #: templates/pages/page_sbs.html:192 templates/pois/poi_form.html:251
 msgid "Link"
 msgstr "Link"
 
 #: templates/events/event_form.html:351 templates/imprint/imprint_form.html:261
-#: templates/imprint/imprint_sbs.html:184 templates/pages/page_form.html:395
+#: templates/imprint/imprint_sbs.html:184 templates/pages/page_form.html:393
 #: templates/pages/page_sbs.html:194 templates/pois/poi_form.html:253
 msgid "Phone"
 msgstr "Telefon"
 
 #: templates/events/event_form.html:353 templates/imprint/imprint_form.html:263
-#: templates/imprint/imprint_sbs.html:186 templates/pages/page_form.html:397
+#: templates/imprint/imprint_sbs.html:186 templates/pages/page_form.html:395
 #: templates/pages/page_sbs.html:196 templates/pois/poi_form.html:255
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
 #: templates/events/event_form.html:355 templates/imprint/imprint_form.html:265
-#: templates/imprint/imprint_sbs.html:188 templates/pages/page_form.html:399
+#: templates/imprint/imprint_sbs.html:188 templates/pages/page_form.html:397
 #: templates/pages/page_sbs.html:198 templates/pois/poi_form.html:257
 msgid "Email"
 msgstr "Email"
 
 #: templates/events/event_form.html:357 templates/imprint/imprint_form.html:267
-#: templates/imprint/imprint_sbs.html:190 templates/pages/page_form.html:401
+#: templates/imprint/imprint_sbs.html:190 templates/pages/page_form.html:399
 #: templates/pages/page_sbs.html:200 templates/pois/poi_form.html:259
 msgid "Hint"
 msgstr "Tipp"
@@ -2250,15 +2250,15 @@ msgstr "In die Zwischenablage kopieren"
 msgid "Short URL"
 msgstr "Kurz-URL"
 
-#: templates/imprint/imprint_form.html:162 templates/pages/page_form.html:355
+#: templates/imprint/imprint_form.html:162 templates/pages/page_form.html:353
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: templates/imprint/imprint_form.html:169 templates/pages/page_form.html:362
+#: templates/imprint/imprint_form.html:169 templates/pages/page_form.html:360
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
-#: templates/imprint/imprint_form.html:183 templates/pages/page_form.html:376
+#: templates/imprint/imprint_form.html:183 templates/pages/page_form.html:374
 msgid "Show translations side by side"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
@@ -2666,15 +2666,15 @@ msgstr "Anordnung"
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: templates/pages/page_form.html:242
+#: templates/pages/page_form.html:241
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:261
+#: templates/pages/page_form.html:259
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:262
+#: templates/pages/page_form.html:260
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -2682,17 +2682,17 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:279 templates/pages/page_form.html:280
-#: templates/pages/page_form.html:288
+#: templates/pages/page_form.html:277 templates/pages/page_form.html:278
+#: templates/pages/page_form.html:286
 #: templates/pages/page_tree_archived_node.html:94
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:285
+#: templates/pages/page_form.html:283
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:291
+#: templates/pages/page_form.html:289
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -2703,28 +2703,28 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
-#: templates/pages/page_form.html:304 templates/pages/page_form.html:305
+#: templates/pages/page_form.html:302 templates/pages/page_form.html:303
 #: templates/pages/page_tree_node.html:124
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:311
+#: templates/pages/page_form.html:309
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:317 templates/pages/page_form.html:335
+#: templates/pages/page_form.html:315 templates/pages/page_form.html:333
 #: templates/pages/page_tree_archived_node.html:112
 #: templates/pages/page_tree_node.html:137
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:321
+#: templates/pages/page_form.html:319
 #: templates/pages/page_tree_archived_node.html:108
 #: templates/pages/page_tree_node.html:133 views/pages/page_actions.py:203
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:322
+#: templates/pages/page_form.html:320
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -2735,7 +2735,7 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: templates/pages/page_form.html:341
+#: templates/pages/page_form.html:339
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
@@ -3554,13 +3554,13 @@ msgstr "Bitte bestätigen Sie, dass dieses Event gelöscht werden soll"
 msgid "All translations of this event will also be deleted."
 msgstr "Alle Übersetzungen dieses Events werden gelöscht."
 
-#: views/events/event_list_view.py:86
+#: views/events/event_list_view.py:89
 msgid "Please create at least one language node before creating events."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie "
 "Veranstaltungen verwalten."
 
-#: views/events/event_list_view.py:92
+#: views/events/event_list_view.py:95
 msgid "You don't have the permission to edit or create events."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Veranstaltungen zu bearbeiten "
@@ -4007,12 +4007,12 @@ msgstr "Bitte bestätigen Sie, dass dieser Ort gelöscht werden soll"
 msgid "All translations of this location will also be deleted."
 msgstr "Alle Übersetzungen dieses Ortes werden gelöscht."
 
-#: views/pois/poi_list_view.py:81
+#: views/pois/poi_list_view.py:84
 msgid "Please create at least one language node before creating locations."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Orte verwalten."
 
-#: views/pois/poi_list_view.py:95
+#: views/pois/poi_list_view.py:98
 #, python-format
 msgid "You can only create locations in the default language (%(language)s)."
 msgstr "Sie können Orte nur in der Standard-Sprache (%(language)s) anlegen"
@@ -4037,7 +4037,7 @@ msgstr "Ort wurde erfolgreich veröffentlicht"
 msgid "Location was successfully saved"
 msgstr "Ort wurde erfolgreich gespeichert"
 
-#: views/push_notifications/push_notification_list_view.py:66
+#: views/push_notifications/push_notification_list_view.py:69
 msgid ""
 "Please create at least one language node before creating push notifications."
 msgstr ""

--- a/src/cms/static/css/style.less
+++ b/src/cms/static/css/style.less
@@ -16,6 +16,11 @@
         url('../fonts/raleway-v12-latin-regular.svg#Raleway') format('svg'); /* Legacy iOS */
 }
 
+@list-bg-color: white;
+@list-border-color: lightgray;
+@hover-bg-color: darken(@list-border-color, 20%);
+@active-bg-color: darken(@list-border-color, 10%);
+
 html, body {
     font-family: 'Raleway', sans-serif;
     font-size: 16px;
@@ -496,6 +501,34 @@ to add animation */
         &.active {
             max-height: 2000px;
             opacity: 1;
+        }
+    }
+}
+
+/* styling for pagination links */
+.pagination {
+    display: flex;
+    flex-direction: row-reverse;
+    margin-top: 0.5rem;
+    .step-links {
+        display: flex;
+        a {
+            display: inline-block;
+            width: 40px;
+            text-align: center;
+            line-height: 25px;
+            border: 1px solid @list-border-color;
+            border-radius: 10%;
+            box-shadow: 1px 1px @list-border-color;
+            padding: 0.25rem;
+            margin: 0.125rem;
+            background-color: @list-bg-color;
+            &.active {
+                background-color: @active-bg-color;
+            }
+            &:hover {
+                background-color: @hover-bg-color;
+            }
         }
     }
 }

--- a/src/cms/templates/events/event_list.html
+++ b/src/cms/templates/events/event_list.html
@@ -109,6 +109,8 @@
         </table>
     </div>
     {% include "../generic_confirmation_dialog.html" %}
+    {% url "events" as url %}
+    {% include "pagination.html" with url=url chunk=events %}
 {% endblock content %}
 
 {% block javascript %}

--- a/src/cms/templates/events/event_list_archived.html
+++ b/src/cms/templates/events/event_list_archived.html
@@ -92,6 +92,8 @@
         </table>
     </div>
     {% include "../generic_confirmation_dialog.html" %}
+    {% url "events" as url %}
+    {% include "pagination.html" with url=url chunk=events %}
 {% endblock content %}
 
 {% block javascript %}

--- a/src/cms/templates/languages/language_list.html
+++ b/src/cms/templates/languages/language_list.html
@@ -44,4 +44,6 @@
         </tbody>
     </table>
 </div>
+{% url "languages" as url %}
+{% include "pagination.html" with url=url chunk=languages %}
 {% endblock %}

--- a/src/cms/templates/offer_templates/offer_template_list.html
+++ b/src/cms/templates/offer_templates/offer_template_list.html
@@ -42,4 +42,6 @@
         </tbody>
     </table>
 </div>
+{% url "offer_templates" as url %}
+{% include "pagination.html" with url=url chunk=offer_templates %}
 {% endblock %}

--- a/src/cms/templates/offers/offer_list.html
+++ b/src/cms/templates/offers/offer_list.html
@@ -46,4 +46,6 @@
         </tbody>
     </table>
 </div>
+{% url "offers" as url %}
+{% include "pagination.html" with url=url chunk=offer_templates %}
 {% endblock %}

--- a/src/cms/templates/organizations/organization_list.html
+++ b/src/cms/templates/organizations/organization_list.html
@@ -40,4 +40,6 @@
         </tbody>
     </table>
 </div>
+{% url "organizations" as url %}
+{% include "pagination.html" with url=url chunk=organizations %}
 {% endblock %}

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -237,26 +237,24 @@
                     <div id="page_order_table" class="mb-4">
                         {% include "pages/_page_order_table.html" %}
                     </div>
-                    {% if page %}
-                        <div class="{% if not request.user.profile.expert_mode %}hidden{% endif %}">
-                            <span class="font-bold mb-2 mt-4">{% trans 'Embed live content' %}</span>
-                            <div class="relative my-2">
-                                {% render_field page_form.mirrored_page_region id="mirrored_page_region" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
-                                    <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
-                                </div>
-                            </div>
-                            <div class="relative my-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_div" data-url="{% url 'render_mirrored_page_field' %}?page_id={{ page_form.instance.id }}&region_id=">
-                                {% include "pages/_mirrored_page_field.html" %}
-                            </div>
-                            <div class="relative my-2 pb-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_first_div">
-                                {% render_field page_form.mirrored_page_first id="mirrored_page_first" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
-                                    <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
-                                </div>
+                    <div class="{% if not request.user.profile.expert_mode %}hidden{% endif %}">
+                        <span class="font-bold mb-2 mt-4">{% trans 'Embed live content' %}</span>
+                        <div class="relative my-2">
+                            {% render_field page_form.mirrored_page_region id="mirrored_page_region" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                            <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
+                                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
                             </div>
                         </div>
-                    {% endif %}
+                        <div class="relative my-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_div" data-url="{% url 'render_mirrored_page_field' %}?page_id={{ page_form.instance.id }}&region_id=">
+                            {% include "pages/_mirrored_page_field.html" %}
+                        </div>
+                        <div class="relative my-2 pb-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_first_div">
+                            {% render_field page_form.mirrored_page_first id="mirrored_page_first" class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
+                            <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
+                                <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
+                            </div>
+                        </div>
+                    </div>
                     {% if perms.cms.grant_page_permissions and region.page_permissions_enabled and request.user.profile.expert_mode %}
                         <span class="block font-bold mb-2">{% trans 'Additional permissions for this page' %}</span>
                         <p class="italic">{% trans "This affects only users, who don't have the permission to change arbitrary pages anyway." %}</p>

--- a/src/cms/templates/pagination.html
+++ b/src/cms/templates/pagination.html
@@ -1,0 +1,42 @@
+{% load arithmetic %}
+
+<!-- this document defines the navigation through paginated lists -->
+<!-- in general there are links for the 2 previous and next pages -->
+<!-- plus additional links to start, end, immediate next and immediate previous -->
+
+{% with num_pages=chunk.paginator.num_pages %}
+{% if num_pages > 1 %}
+<div class="pagination">
+    <div class="step-links">
+        <!-- pagination always contains left and right buttons -->
+        <!-- in case the left/right outer bounds are reached these links are disabled -->
+        <a href="{% if chunk.has_previous %}{{ url }}?chunk={{ chunk.previous_page_number }}{% else %}#{% endif %}" class="arrow-link">
+            <i data-feather="chevron-left" class="inline"></i>
+        </a>
+        <!-- pagination always allows to jump to start page -->
+        <a href="{{ url }}?chunk=1" class="{% if chunk.number == 1 %}active{% endif %}">1</a>
+        {% if chunk.number|diff:1 > 3 %}
+            <!-- if current page is more than 2 pages after start, hide those pages -->
+            <a href="#">...</a>
+        {% endif %}
+        {% for i in chunk.paginator.page_range|slice:'1:-1' %}
+            {% if i == chunk.number %}
+                <a href="#" class="active">{{ i }}</a>
+            {% elif i > chunk.number|diff:3 and i < chunk.number|add:3 %}
+                <!-- show only links to at most 2 previous/next pages -->
+                <a href="{{ url }}?chunk={{ i }}">{{ i }}</a>
+            {% endif %}
+        {% endfor %}
+        {% if num_pages|diff:chunk.number > 3 %}
+            <!-- if current page is more than 2 pages before end, hide those pages -->
+            <a href="#">...</a>
+        {% endif %}
+        <!-- pagination always allows to jump to last page -->
+        <a href="{{ url }}?chunk={{ num_pages }}" class="{% if chunk.number == num_pages %}active{% endif %}">{{ num_pages }}</a>
+        <a href="{% if chunk.has_next %}{{ url }}?chunk={{ chunk.next_page_number }}{% else %}#{% endif %}" class="arrow-link">
+            <i data-feather="chevron-right" class="inline-block"></i>
+        </a>
+    </div>
+</div>
+{% endif %}
+{% endwith %}

--- a/src/cms/templates/pois/poi_list.html
+++ b/src/cms/templates/pois/poi_list.html
@@ -83,6 +83,8 @@
     </table>
 </div>
 {% include "../generic_confirmation_dialog.html" %}
+{% url "pois" as url %}
+{% include "pagination.html" with url=url chunk=pois %}
 {% endblock %}
 
 {% block javascript %}

--- a/src/cms/templates/pois/poi_list_archived.html
+++ b/src/cms/templates/pois/poi_list_archived.html
@@ -57,6 +57,8 @@
     </table>
 </div>
 {% include "../generic_confirmation_dialog.html" %}
+{% url "pois" as url %}
+{% include "pagination.html" with url=url chunk=pois %}
 {% endblock %}
 
 {% block javascript %}

--- a/src/cms/templates/push_notifications/push_notification_list.html
+++ b/src/cms/templates/push_notifications/push_notification_list.html
@@ -53,4 +53,6 @@
         </tbody>
     </table>
 </div>
+{% url "push_notifications" as url %}
+{% include "pagination.html" with url=url chunk=push_notifications %}
 {% endblock %}

--- a/src/cms/templates/regions/region_list.html
+++ b/src/cms/templates/regions/region_list.html
@@ -46,4 +46,6 @@
         </tbody>
     </table>
 </div>
+{% url "regions" as url %}
+{% include "pagination.html" with url=url chunk=regions %}
 {% endblock %}

--- a/src/cms/templates/roles/list.html
+++ b/src/cms/templates/roles/list.html
@@ -38,4 +38,6 @@
         </tbody>
     </table>
 </div>
+{% url "roles" as url %}
+{% include "pagination.html" with url=url chunk=roles %}
 {% endblock %}

--- a/src/cms/templates/users/admin/list.html
+++ b/src/cms/templates/users/admin/list.html
@@ -48,4 +48,6 @@
         </tbody>
     </table>
 </div>
+{% url "users" as url %}
+{% include "pagination.html" with url=url chunk=users %}
 {% endblock %}

--- a/src/cms/templates/users/region/list.html
+++ b/src/cms/templates/users/region/list.html
@@ -41,4 +41,6 @@
         </tbody>
     </table>
 </div>
+{% url "region_users" as url %}
+{% include "pagination.html" with url=url chunk=users %}
 {% endblock %}

--- a/src/cms/templatetags/arithmetic.py
+++ b/src/cms/templatetags/arithmetic.py
@@ -1,0 +1,17 @@
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def diff(value, arg):
+    """subtract arg from value
+
+    :param value: origin value
+    :type value: int
+    :param arg: value to be subtracted
+    :type arg: int
+    :return: result of subtraction
+    :rtype: int
+    """
+    return value - arg

--- a/src/cms/views/languages/language_list_view.py
+++ b/src/cms/views/languages/language_list_view.py
@@ -1,9 +1,11 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
+from backend.settings import PER_PAGE
 from ...decorators import staff_required
 from ...models import Language
 
@@ -40,8 +42,13 @@ class LanguageListView(PermissionRequiredMixin, TemplateView):
         :return: The rendered template response
         :rtype: ~django.template.response.TemplateResponse
         """
+        languages = Language.objects.all()
+        # for consistent pagination querysets should be ordered
+        paginator = Paginator(languages.order_by("code"), PER_PAGE)
+        chunk = request.GET.get("chunk")
+        language_chunk = paginator.get_page(chunk)
         return render(
             request,
             self.template_name,
-            {**self.base_context, "languages": Language.objects.all()},
+            {**self.base_context, "languages": language_chunk},
         )

--- a/src/cms/views/offer_templates/offer_template_list_view.py
+++ b/src/cms/views/offer_templates/offer_template_list_view.py
@@ -1,9 +1,11 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.paginator import Paginator
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from django.shortcuts import render
 
+from backend.settings import PER_PAGE
 from ...decorators import staff_required
 from ...models import OfferTemplate
 
@@ -41,9 +43,12 @@ class OfferTemplateListView(PermissionRequiredMixin, TemplateView):
         :rtype: ~django.template.response.TemplateResponse
         """
         offer_templates = OfferTemplate.objects.all()
-
+        # for consistent pagination querysets should be ordered
+        paginator = Paginator(offer_templates.order_by("slug"), PER_PAGE)
+        chunk = request.GET.get("chunk")
+        offer_templates_chunk = paginator.get_page(chunk)
         return render(
             request,
             self.template_name,
-            {**self.base_context, "offer_templates": offer_templates},
+            {**self.base_context, "offer_templates": offer_templates_chunk},
         )

--- a/src/cms/views/offers/offer_list_view.py
+++ b/src/cms/views/offers/offer_list_view.py
@@ -1,9 +1,11 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.paginator import Paginator
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 from django.shortcuts import render
 
+from backend.settings import PER_PAGE
 from ...decorators import region_permission_required
 from ...models import Region, OfferTemplate
 
@@ -43,13 +45,16 @@ class OfferListView(PermissionRequiredMixin, TemplateView):
         # current region
         region = Region.get_current_region(request)
         offer_templates = OfferTemplate.objects.all()
-
+        # for consistent pagination querysets should be ordered
+        paginator = Paginator(offer_templates.order_by("slug"), PER_PAGE)
+        chunk = request.GET.get("chunk")
+        offer_chunk = paginator.get_page(chunk)
         return render(
             request,
             self.template_name,
             {
                 **self.base_context,
-                "offer_templates": offer_templates,
+                "offer_templates": offer_chunk,
                 "region_offer_templates": offer_templates.filter(offers__region=region),
             },
         )

--- a/src/cms/views/organizations/organization_list_view.py
+++ b/src/cms/views/organizations/organization_list_view.py
@@ -1,9 +1,11 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
+from backend.settings import PER_PAGE
 from ...decorators import staff_required
 from ...models import Organization
 
@@ -40,8 +42,13 @@ class OrganizationListView(PermissionRequiredMixin, TemplateView):
         :return: The rendered template response
         :rtype: ~django.template.response.TemplateResponse
         """
+        organizations = Organization.objects.all()
+        # for consistent pagination querysets should be ordered
+        paginator = Paginator(organizations.order_by("slug"), PER_PAGE)
+        chunk = request.GET.get("chunk")
+        organization_chunk = paginator.get_page(chunk)
         return render(
             request,
             self.template_name,
-            {**self.base_context, "organizations": Organization.objects.all()},
+            {**self.base_context, "organizations": organization_chunk},
         )

--- a/src/cms/views/regions/region_list_view.py
+++ b/src/cms/views/regions/region_list_view.py
@@ -1,9 +1,11 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
+from backend.settings import PER_PAGE
 from ...decorators import staff_required
 from ...models import Region
 
@@ -42,7 +44,10 @@ class RegionListView(PermissionRequiredMixin, TemplateView):
         :rtype: ~django.template.response.TemplateResponse
         """
         regions = Region.objects.all()
-
+        # for consistent pagination querysets should be ordered
+        paginator = Paginator(regions.order_by("created_date"), PER_PAGE)
+        chunk = request.GET.get("chunk")
+        region_chunk = paginator.get_page(chunk)
         return render(
-            request, self.template_name, {**self.base_context, "regions": regions}
+            request, self.template_name, {**self.base_context, "regions": region_chunk}
         )

--- a/src/cms/views/roles/role_list_view.py
+++ b/src/cms/views/roles/role_list_view.py
@@ -1,10 +1,12 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.contrib.auth.models import Group as Role
+from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
+from backend.settings import PER_PAGE
 from ...decorators import staff_required
 
 
@@ -42,7 +44,10 @@ class RoleListView(PermissionRequiredMixin, TemplateView):
         :rtype: ~django.template.response.TemplateResponse
         """
         roles = Role.objects.all()
-
+        # for consistent pagination querysets should be ordered
+        paginator = Paginator(roles.order_by("name"), PER_PAGE)
+        chunk = request.GET.get("chunk")
+        role_chunk = paginator.get_page(chunk)
         return render(
-            request, self.template_name, {**self.base_context, "roles": roles}
+            request, self.template_name, {**self.base_context, "roles": role_chunk}
         )

--- a/src/cms/views/users/region_user_list_view.py
+++ b/src/cms/views/users/region_user_list_view.py
@@ -1,9 +1,11 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
+from backend.settings import PER_PAGE
 from ...decorators import region_permission_required
 from ...models import Region
 
@@ -42,7 +44,10 @@ class RegionUserListView(PermissionRequiredMixin, TemplateView):
         """
 
         region = Region.get_current_region(request)
-
+        # for consistent pagination querysets should be ordered
+        paginator = Paginator(region.users.order_by("username"), PER_PAGE)
+        chunk = request.GET.get("chunk")
+        user_chunk = paginator.get_page(chunk)
         return render(
-            request, self.template_name, {**self.base_context, "users": region.users}
+            request, self.template_name, {**self.base_context, "users": user_chunk}
         )

--- a/src/cms/views/users/user_list_view.py
+++ b/src/cms/views/users/user_list_view.py
@@ -1,10 +1,12 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.core.paginator import Paginator
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
+from backend.settings import PER_PAGE
 from ...decorators import staff_required
 
 
@@ -42,7 +44,10 @@ class UserListView(PermissionRequiredMixin, TemplateView):
         """
 
         users = get_user_model().objects.all()
-
+        # for consistent pagination querysets should be ordered
+        paginator = Paginator(users.order_by("username"), PER_PAGE)
+        chunk = request.GET.get("chunk")
+        user_chunk = paginator.get_page(chunk)
         return render(
-            request, self.template_name, {**self.base_context, "users": users}
+            request, self.template_name, {**self.base_context, "users": user_chunk}
         )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Adds pagination for all objects lists

### Proposed changes
<!-- Describe this PR in more detail. -->

Generally shows pagination links only if there is more than one page to display, else hides all pagination links.
There is always a link to the first and the last page.
Additionally there are links for 2 previous and next pages.
To limit the number of links all other pages are displayed as `...`
Adds pagination to the following lists:

Admin:
- [x] Regions
- [x] Languages
- [x] Users
- [x] Roles
- [x] Organizations
- [x] Offer templates

Region:
- [x] Region user
- [x] Offers
- [x] Events
- [x] POIs
- [x] Push Notifications

### Lists without pagination
Trees and pagination should not be combined, therefore pagination is not applied to:
- Page tree
- Language tree

### Feedback lists and pagination

At the moment feedback is split into multiple querysets, which must first be combined to a single queryset, before pagination can be applied. So for now feedback pagination is skipped until the feedback refactoring is merged.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #620, #666

### Screenshots

![pagination1](https://user-images.githubusercontent.com/47010475/107875176-b08ffc80-6ebe-11eb-9302-b8097e31fa6c.png)

![pagination2](https://user-images.githubusercontent.com/47010475/107875192-c1d90900-6ebe-11eb-990a-5d9b674552c7.png)

