### PR TITLE
Add current time zone

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -144,6 +144,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "cms.middleware.timezone_middleware.TimezoneMiddleware",
 ]
 
 #: Default URL dispatcher (see :setting:`django:ROOT_URLCONF`)
@@ -406,6 +407,9 @@ LANGUAGE_CODE = "de-de"
 #: A string representing the time zone for this installation
 #: (see :setting:`django:TIME_ZONE` and :doc:`topics/i18n/index`)
 TIME_ZONE = "UTC"
+
+#: A string representing the time zone that is used for rendering
+CURRENT_TIME_ZONE = "Europe/Berlin"
 
 #: A boolean that specifies whether Django’s translation system should be enabled
 #: (see :setting:`django:USE_I18N` and :doc:`topics/i18n/index`)

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-22 13:03+0000\n"
+"POT-Creation-Date: 2021-02-22 17:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -4168,6 +4168,12 @@ msgstr ""
 
 #~ msgid "PDF Export"
 #~ msgstr "PDF Export"
+
+#~ msgid "timezone"
+#~ msgstr "Zeitzone"
+
+#~ msgid "Timezone"
+#~ msgstr "Zeitzone"
 
 #~ msgid "Insert title here"
 #~ msgstr "Titel hier eingeben"

--- a/src/cms/middleware/timezone_middleware.py
+++ b/src/cms/middleware/timezone_middleware.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+from django.utils import timezone
+
+# pylint: disable=too-few-public-methods
+class TimezoneMiddleware:
+    """
+    Middleware class that sets the current time zone like specified in settings.py
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        timezone.activate(settings.CURRENT_TIME_ZONE)
+        return self.get_response(request)


### PR DESCRIPTION
### Short description
Adds a setting for `current time zone` that is used for rendering.


### Proposed changes
Add a setting `CURRENT_TIME_ZONE`
Add a middleware-function that sets the current time zone according to this setting


### Resolved issues

Fixes: #652

### Additonal
For further timezone handling, #662 and #663 have been created.
