### PR TITLE
Fixes page mirroring bug

### DIFF
--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -245,7 +245,7 @@
                                 <img src="{% static 'svg/select-down-arrow.svg' %}" class="fill-current h-4 w-4" />
                             </div>
                         </div>
-                        <div class="relative my-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_div" data-url="{% url 'render_mirrored_page_field' %}?page_id={{ page_form.instance.id }}&region_id=">
+                        <div class="relative my-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_div" data-url="{% url 'render_mirrored_page_field' %}?{% if page_form.instance.id %}page_id={{ page_form.instance.id }}&{% endif %}region_id=">
                             {% include "pages/_mirrored_page_field.html" %}
                         </div>
                         <div class="relative my-2 pb-2 {% if not page.mirrored_page %}hidden{% endif %}" id="mirrored_page_first_div">

--- a/src/cms/views/pages/page_actions.py
+++ b/src/cms/views/pages/page_actions.py
@@ -848,13 +848,11 @@ def render_mirrored_page_field(request):
     region = get_object_or_404(Region, id=request.GET.get("region_id"))
     # Get the page in which the content should be embedded (to exclude it from the possible selections)
     page = Page.objects.filter(id=request.GET.get("page_id")).first()
-
     page_form = PageForm(
         {"mirrored_page_region": region.id},
         instance=page,
         region=region,
     )
-
     return render(
         request,
         "pages/_mirrored_page_field.html",


### PR DESCRIPTION

### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes page mirroring bug, which is caused by trying to set a mirrored page, when a completely new page is created.

### Proposed changes
<!-- Describe this PR in more detail. -->

- When a region for page mirroring is selected, an ajax request is
  triggered, which tries to retrieve the current page from database.
- So when there is a completely new page created, which has no entry in the
  database yet, this ajax request fails.
- That means the page mirroring field in the page form should be hidden
  for newly created pages.

### Alternatives
The proposed solution is the easiest, but if you wish, there would also be an ability to adjust the `render_mirrored_page_field` view, so that it can handle pages without a database entry:
https://github.com/Integreat/integreat-cms/blob/420ecee0f727fa4097d5f241f65d75a96a759dae/src/cms/views/pages/page_actions.py#L850

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #673
