### PR TITLE
Access and set HTML content according to ESLint

### DIFF
--- a/src/cms/static/css/style.less
+++ b/src/cms/static/css/style.less
@@ -415,6 +415,7 @@ datalist option {
     width: 250px;
     top: 35px;
     border-radius: 4px;
+    white-space: pre;
     left: 50%;
     transform: translateX(-50%);
 }

--- a/src/cms/static/js/forms/file-field.js
+++ b/src/cms/static/js/forms/file-field.js
@@ -6,7 +6,7 @@ var inputs = document.querySelectorAll('.image-field');
 Array.prototype.forEach.call( inputs, function( input )
 {
     var label	 = input.nextElementSibling,
-        labelVal = label.innerHTML;
+        labelVal = label.textContent;
 
     input.addEventListener( 'change', function( e )
     {
@@ -15,10 +15,10 @@ Array.prototype.forEach.call( inputs, function( input )
 
         if( fileName ) {
             label.querySelector('span.standard_text').classList.add('hidden');
-            label.querySelector('span.filename').innerHTML = fileName;
+            label.querySelector('span.filename').textContent = fileName;
         } else {
             label.querySelector('span.standard_text').classList.remove('hidden');
-            label.innerHTML = labelVal;
+            label.textContent = labelVal;
         }
     });
 });

--- a/src/cms/static/js/pages/page_mirroring.js
+++ b/src/cms/static/js/pages/page_mirroring.js
@@ -9,7 +9,7 @@ function render_mirrored_page_field(event){
     // Check if a region was selected
     if(event.target.value === "") {
         // Remove mirrored page field to make sure no old value is selected
-        u('#mirrored_page_div').html("");
+        u('#mirrored_page_div').empty();
         // Hide fields
         u('#mirrored_page_div').addClass('hidden');
         u('#mirrored_page_first_div').addClass('hidden');
@@ -27,7 +27,8 @@ function render_mirrored_page_field(event){
             u('#mirrored_page_first_div').removeClass('hidden');
         }).catch(function (error) {
             // Show error message instead of field
-            u('#mirrored_page_div').html('<div class="bg-red-100 border-l-4 border-red-500 text-red-500 px-4 py-3 my-4" role="alert"><p>' + error.message + '</p></div>');
+            u('#mirrored_page_div').html('<div class="bg-red-100 border-l-4 border-red-500 text-red-500 px-4 py-3 my-4" role="alert"><p id="mirrored-page-error"></p></div>');
+            u('#mirrored-page-error').text(error.message);
             u('#mirrored_page_div').removeClass('hidden');
             u('#mirrored_page_first_div').addClass('hidden');
         });

--- a/src/cms/static/js/revisions.js
+++ b/src/cms/static/js/revisions.js
@@ -40,7 +40,7 @@ function handle_revision_slider_input(event) {
     // The last updated date of the revision
     const revision_date = u("#revision-" + current_revision).data("date");
     // Update the revision info box
-    revision_info.innerHTML = "Revision: " + current_revision + "<br>" + revision_date;
+    revision_info.textContent = `Revision: ${current_revision}\r\n${revision_date}`;
     // Calculate position of revision info box to make sure it stays within the area of the slider position
     revision_info.style.left = `calc(${position}% + (${125 - position * 2.5}px))`;
     // Hide all other revisions


### PR DESCRIPTION
### Short description
So far, we are accessing and changing elements by using the un-sanitized innerhtml()- and html()-method. According to ESLint this is bad behavior. I managed to use the correct methods for the innerhtml-parts, but we should do this for the html()-Methods as well.

See page_mirroring.js
