### PR TITLE
Fix drag & drop in page form

### DIFF
--- a/src/cms/static/js/pages/page_order.js
+++ b/src/cms/static/js/pages/page_order.js
@@ -58,8 +58,10 @@ function register_event_handlers() {
     u('.drop').each(function(node) {
         u(node).off('dragleave,dragover,drop');
     });
-    // Event handlers for drag events
-    u('.drag').on('dragstart', dragstart);
+    // Event handlers for drag events (delay because of behaviour in Chrome browser)
+    u('.drag').on('dragstart', function(event) {
+        window.setTimeout(dragstart, 0, event);
+    });
     u('.drag').handle('dragend', dragend);
     // Event handlers for drop events
     u('.drop').each(function(node) {
@@ -72,7 +74,12 @@ function register_event_handlers() {
 // Register all handlers once initially
 register_event_handlers();
 
-// This function handles the start of a dragging event
+/*
+ * This function handles the start of a dragging event
+ *
+ * Manipulating the dom during dragstart event fires immediately a dragend event (chrome browser),
+ * so the changes to the dom must be delayed
+ */
 function dragstart(event) {
     // change appearance of dragged item
     u(event.target).removeClass('text-gray-800');

--- a/src/cms/static/js/tree_drag_and_drop.js
+++ b/src/cms/static/js/tree_drag_and_drop.js
@@ -10,7 +10,7 @@ u('.drag').each(function(node) {
 function dragstart(event) {
     // prepare the dragged node id for data transfer
     event.dataTransfer.setData("text", u(event.target).attr("data-drag-id"));
-    window.setTimeout(change_dom, 50, event.target);
+    window.setTimeout(change_dom, 0, event.target);
     // get descendants of dragged node
     var descendants = JSON.parse(u(event.target).attr("data-node-descendants"));
     // add event listeners for hovering over drop regions


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix drag & drop in page form. The cause of the bug was identical to #494:
In Chromium, manipulating the DOM during dragstart event fires a dragend event immediately

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add delay to dragstart in order table of page form

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #713
