### PR TITLE
Fix get_pages() for archived pages

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-25 22:04+0000\n"
+"POT-Creation-Date: 2021-02-26 16:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -575,7 +575,7 @@ msgstr "Einstellungen"
 #: models/languages/language_tree_node.py:37 models/offers/offer.py:24
 #: models/pages/imprint_page.py:27 models/pages/page.py:40
 #: models/pois/poi.py:18 models/push_notifications/push_notification.py:17
-#: models/regions/region.py:311
+#: models/regions/region.py:312
 msgid "region"
 msgstr "Region"
 
@@ -1394,7 +1394,7 @@ msgstr ""
 "Dies gewährt allen Benutzern dieser Region Zugang zum überregionalen Autoren-"
 "Chat."
 
-#: models/regions/region.py:313 models/users/user_profile.py:30
+#: models/regions/region.py:314 models/users/user_profile.py:30
 msgid "regions"
 msgstr "Regionen"
 

--- a/src/cms/models/regions/region.py
+++ b/src/cms/models/regions/region.py
@@ -290,7 +290,8 @@ class Region(models.Model):
         """
         if archived:
             pages = self.archived_pages
-        pages = self.non_archived_pages
+        else:
+            pages = self.non_archived_pages
         if return_unrestricted_queryset:
             # Generate a new unrestricted queryset containing the same pages
             page_ids = [page.id for page in pages]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
In da858ad7199e27e49116bfc49ff722462f32ce2e (#715), I made a stupid mistake which resulted in `region.get_pages(archived=True)` returning all non-archived pages.
### Proposed changes
<!-- Describe this PR in more detail. -->
- Do not overwrite the `pages` variable with the non archived pages

