### PR TITLE
Support multi-line feedback

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-26 16:58+0000\n"
+"POT-Creation-Date: 2021-02-27 00:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1862,11 +1862,11 @@ msgstr "Kommentar"
 msgid "Date"
 msgstr "Datum"
 
-#: templates/dashboard/admin_dashboard.html:73
+#: templates/dashboard/admin_dashboard.html:78
 msgid "No Feedback available yet."
 msgstr "Noch kein Feedback vorhanden."
 
-#: templates/dashboard/admin_dashboard.html:78
+#: templates/dashboard/admin_dashboard.html:83
 msgid "Open feedback list"
 msgstr "Feedback-Liste öffnen"
 
@@ -2244,47 +2244,47 @@ msgstr "insgesamt"
 msgid "Marked as read by"
 msgstr "Als gelesen markiert von"
 
-#: templates/feedback/admin_feedback_list.html:110
+#: templates/feedback/admin_feedback_list.html:115
 msgid "No technical feedback found with these filters."
 msgstr "Kein technisches Feedback mit diesen Filtern gefunden."
 
-#: templates/feedback/admin_feedback_list.html:112
+#: templates/feedback/admin_feedback_list.html:117
 msgid "No technical feedback available yet."
 msgstr "Noch kein technisches Feedback vorhanden."
 
-#: templates/feedback/admin_feedback_list.html:123
-#: templates/feedback/region_feedback_list.html:117
+#: templates/feedback/admin_feedback_list.html:128
+#: templates/feedback/region_feedback_list.html:122
 #: templates/pages/page_tree.html:121
 msgid "Select bulk action"
 msgstr "Mehrfachaktion auswählen"
 
-#: templates/feedback/admin_feedback_list.html:124
-#: templates/feedback/region_feedback_list.html:118
+#: templates/feedback/admin_feedback_list.html:129
+#: templates/feedback/region_feedback_list.html:123
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: templates/feedback/admin_feedback_list.html:125
-#: templates/feedback/region_feedback_list.html:119
+#: templates/feedback/admin_feedback_list.html:130
+#: templates/feedback/region_feedback_list.html:124
 msgid "Mark as unread"
 msgstr "Als ungelesen markieren"
 
-#: templates/feedback/admin_feedback_list.html:127
-#: templates/feedback/region_feedback_list.html:121
+#: templates/feedback/admin_feedback_list.html:132
+#: templates/feedback/region_feedback_list.html:126
 #: templates/language_tree/language_tree.html:33
 msgid "Delete"
 msgstr "Löschen"
 
-#: templates/feedback/admin_feedback_list.html:134
-#: templates/feedback/region_feedback_list.html:128
+#: templates/feedback/admin_feedback_list.html:139
+#: templates/feedback/region_feedback_list.html:133
 #: templates/pages/page_tree.html:136
 msgid "Execute"
 msgstr "Ausführen"
 
-#: templates/feedback/region_feedback_list.html:104
+#: templates/feedback/region_feedback_list.html:109
 msgid "No feedback found with these filters."
 msgstr "Kein Feedback mit diesen Filtern gefunden."
 
-#: templates/feedback/region_feedback_list.html:106
+#: templates/feedback/region_feedback_list.html:111
 msgid "No feedback available yet."
 msgstr "Noch kein Feedback vorhanden."
 

--- a/src/cms/models/feedback/feedback.py
+++ b/src/cms/models/feedback/feedback.py
@@ -36,7 +36,7 @@ class Feedback(models.Model):
         verbose_name=_("rating"),
         help_text=_("Whether the feedback is positive or negative"),
     )
-    comment = models.CharField(max_length=1000, blank=True, verbose_name=_("comment"))
+    comment = models.TextField(blank=True, verbose_name=_("comment"))
     is_technical = models.BooleanField(
         verbose_name=_("technical"),
         help_text=_("Whether or not the feedback is targeted at the developers"),

--- a/src/cms/templates/dashboard/admin_dashboard.html
+++ b/src/cms/templates/dashboard/admin_dashboard.html
@@ -44,7 +44,12 @@
                             {% endif %}
                         </td>
                         <td class="pr-2 feedback-comment">
-                            {% if feedback.comment|words|length > 20 %}
+                            {% if feedback.comment.splitlines|length > 1 %}
+                                <span>
+                                    {{ feedback.comment.splitlines.0|truncatewords:20 }} <i data-feather="chevron-down" class="toggle-feedback-comment inline-block transform cursor-pointer hover:scale-125"></i>
+                                </span>
+                                <span class="hidden whitespace-pre-line">{{ feedback.comment }} <i data-feather="chevron-up" class="toggle-feedback-comment inline-block transform cursor-pointer hover:scale-125"></i></span>
+                            {% elif feedback.comment|words|length > 20 %}
                                 <span>
                                     {{ feedback.comment|truncatewords:20 }} <i data-feather="chevron-down" class="toggle-feedback-comment inline-block transform cursor-pointer hover:scale-125"></i>
                                 </span>

--- a/src/cms/templates/feedback/admin_feedback_list.html
+++ b/src/cms/templates/feedback/admin_feedback_list.html
@@ -59,6 +59,11 @@
             <td class="pr-2 feedback-comment">
                 {% if not feedback.comment %}
                     <i data-feather="minus" class="inline-block pr-1"></i>
+                {% elif feedback.comment.splitlines|length > 1 %}
+                    <span>
+                        {{ feedback.comment.splitlines.0|truncatewords:20 }} <i data-feather="chevron-down" class="toggle-feedback-comment inline-block transform cursor-pointer hover:scale-125"></i>
+                    </span>
+                    <span class="hidden whitespace-pre-line">{{ feedback.comment }} <i data-feather="chevron-up" class="toggle-feedback-comment inline-block transform cursor-pointer hover:scale-125"></i></span>
                 {% elif feedback.comment|words|length > 20 %}
                     <span>
                         {{ feedback.comment|truncatewords:20 }} <i data-feather="chevron-down" class="toggle-feedback-comment inline-block transform cursor-pointer hover:scale-125"></i>

--- a/src/cms/templates/feedback/region_feedback_list.html
+++ b/src/cms/templates/feedback/region_feedback_list.html
@@ -58,6 +58,11 @@
             <td class="pr-2 feedback-comment">
                 {% if not feedback.comment %}
                     <i data-feather="minus" class="inline-block pr-1"></i>
+                {% elif feedback.comment.splitlines|length > 1 %}
+                    <span>
+                        {{ feedback.comment.splitlines.0|truncatewords:20 }} <i data-feather="chevron-down" class="toggle-feedback-comment inline-block transform cursor-pointer hover:scale-125"></i>
+                    </span>
+                    <span class="hidden whitespace-pre-line">{{ feedback.comment }} <i data-feather="chevron-up" class="toggle-feedback-comment inline-block transform cursor-pointer hover:scale-125"></i></span>
                 {% elif feedback.comment|words|length > 20 %}
                     <span>
                         {{ feedback.comment|truncatewords:20 }} <i data-feather="chevron-down" class="toggle-feedback-comment inline-block transform cursor-pointer hover:scale-125"></i>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Support multi-line feedback

### Proposed changes
<!-- Describe this PR in more detail. -->
- Change `CharField` to `TextField`
- Use the css class `whitespace-pre-line` when rendering multi-line-feedback
- Collapse feedback which has multiple lines

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #719
