### PR TITLE
Adjust backend languages codes

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -52,8 +52,8 @@ TEST_BLOG_ID = 154
 
 #: RSS feed URLs to the Integreat blog
 RSS_FEED_URLS = {
-    "en-us": "https://integreat-app.de/en/feed/",
-    "de-de": "https://integreat-app.de/feed/",
+    "en": "https://integreat-app.de/en/feed/",
+    "de": "https://integreat-app.de/feed/",
     "home-page": "https://integreat-app.de/",
 }
 
@@ -390,8 +390,8 @@ LOGGING = {
 
 #: A list of all available languages (see :setting:`django:LANGUAGES` and :doc:`topics/i18n/index`)
 LANGUAGES = (
-    ("en-us", "English"),
-    ("de-de", "Deutsch"),
+    ("en", "English"),
+    ("de", "Deutsch"),
 )
 
 #: A list of directories where Django looks for translation files
@@ -400,7 +400,7 @@ LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
 
 #: A string representing the language slug for this installation
 #: (see :setting:`django:LANGUAGE_CODE` and :doc:`topics/i18n/index`)
-LANGUAGE_CODE = "de-de"
+LANGUAGE_CODE = "de"
 
 #: A string representing the time zone for this installation
 #: (see :setting:`django:TIME_ZONE` and :doc:`topics/i18n/index`)

--- a/src/cms/_tests.py
+++ b/src/cms/_tests.py
@@ -147,7 +147,7 @@ class SetupClass(TestCase):
             },
             user=self.user,
             region_slug="demo",
-            language_slug="en-us",
+            language_slug="en",
             publish=True,
         )
 
@@ -169,7 +169,7 @@ class SetupClass(TestCase):
             },
             user=self.user,
             region_slug="demo",
-            language_slug="en-us",
+            language_slug="en",
             publish=True,
         )
 
@@ -186,7 +186,7 @@ class SetupClass(TestCase):
             user=self.user,
             page_id=self.page_slot_one.id,
             region_slug="demo",
-            language_slug="de-de",
+            language_slug="de",
             publish=True,
         )
 
@@ -202,7 +202,7 @@ class SetupClass(TestCase):
             },
             user=self.user,
             region_slug="demo",
-            language_slug="en-us",
+            language_slug="en",
             publish=True,
         )
 
@@ -218,7 +218,7 @@ class SetupClass(TestCase):
             },
             user=self.user,
             region_slug="demo",
-            language_slug="en-us",
+            language_slug="en",
             publish=True,
         )
 
@@ -244,8 +244,8 @@ class PageFormTestCase(SetupClass):
         self.assertEqual(len(self.page_slot_one.languages), 2)
         self.assertEqual(len(self.page_slot_two.languages), 1)
 
-        self.assertIsNone(self.page_tunews.get_translation("de-de"))
-        self.assertIsNotNone(self.page_slot_one.get_translation("de-de"))
+        self.assertIsNone(self.page_tunews.get_translation("de"))
+        self.assertIsNotNone(self.page_slot_one.get_translation("de"))
 
     # pylint: disable=missing-function-docstring
     def test_pages(self):

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-14 11:38+0000\n"
+"POT-Creation-Date: 2021-03-16 16:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -18,8 +18,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: constants/administrative_division.py:38 templates/events/event_form.html:254
-#: templates/pois/poi_list.html:66 templates/pois/poi_list_archived.html:40
+#: constants/administrative_division.py:38 templates/events/event_form.html:253
+#: templates/pois/poi_list.html:65 templates/pois/poi_list_archived.html:39
 msgid "City"
 msgstr "Stadt"
 
@@ -214,7 +214,7 @@ msgstr "Nur verfügbare Übersetzungen senden"
 msgid "Use main language if no translation is available"
 msgstr "Benutze Haupt-Sprache, wenn keine Übersetzung verfügbar"
 
-#: constants/recurrence.py:21 templates/events/_event_filter_form.html:56
+#: constants/recurrence.py:21 templates/events/_event_filter_form.html:55
 msgid "Recurring events"
 msgstr "Sich wiederholende Veranstaltungen"
 
@@ -232,7 +232,7 @@ msgid "Hidden"
 msgstr "Versteckt"
 
 #: constants/region_status.py:18 forms/pages/page_form.py:146
-#: forms/pages/page_form.py:173 templates/pages/page_form.html:154
+#: forms/pages/page_form.py:173 templates/pages/page_form.html:153
 #: templates/pages/page_tree_archived_node.html:13
 msgid "Archived"
 msgstr "Archiviert"
@@ -257,46 +257,46 @@ msgstr "Links nach Rechts"
 msgid "Right to left"
 msgstr "Rechts nach Links"
 
-#: constants/translation_status.py:10 templates/events/event_form.html:71
-#: templates/events/event_form.html:100
-#: templates/events/event_list_archived_row.html:62
-#: templates/events/event_list_row.html:54
+#: constants/translation_status.py:10 templates/events/event_form.html:70
+#: templates/events/event_form.html:99
+#: templates/events/event_list_archived_row.html:61
+#: templates/events/event_list_row.html:53
 #: templates/imprint/imprint_form.html:53
 #: templates/imprint/imprint_form.html:82 templates/imprint/imprint_sbs.html:46
-#: templates/imprint/imprint_sbs.html:101 templates/pages/page_form.html:77
-#: templates/pages/page_form.html:99 templates/pages/page_form.html:118
+#: templates/imprint/imprint_sbs.html:101 templates/pages/page_form.html:76
+#: templates/pages/page_form.html:98 templates/pages/page_form.html:117
 #: templates/pages/page_sbs.html:53 templates/pages/page_sbs.html:112
-#: templates/pages/page_tree_archived_node.html:63
-#: templates/pages/page_tree_node.html:89 templates/pois/poi_form.html:60
-#: templates/pois/poi_form.html:89 templates/pois/poi_list_row.html:61
+#: templates/pages/page_tree_archived_node.html:62
+#: templates/pages/page_tree_node.html:88 templates/pois/poi_form.html:59
+#: templates/pois/poi_form.html:88 templates/pois/poi_list_row.html:60
 msgid "Translation up-to-date"
 msgstr "Übersetzung ist aktuell"
 
-#: constants/translation_status.py:11 templates/events/event_form.html:76
-#: templates/events/event_form.html:105
-#: templates/events/event_list_archived_row.html:67
-#: templates/events/event_list_row.html:59
+#: constants/translation_status.py:11 templates/events/event_form.html:75
+#: templates/events/event_form.html:104
+#: templates/events/event_list_archived_row.html:66
+#: templates/events/event_list_row.html:58
 #: templates/imprint/imprint_form.html:58
-#: templates/imprint/imprint_form.html:87 templates/pages/page_form.html:82
-#: templates/pages/page_form.html:123
-#: templates/pages/page_tree_archived_node.html:68
-#: templates/pages/page_tree_node.html:94 templates/pois/poi_form.html:65
-#: templates/pois/poi_form.html:94 templates/pois/poi_list_row.html:66
+#: templates/imprint/imprint_form.html:87 templates/pages/page_form.html:81
+#: templates/pages/page_form.html:122
+#: templates/pages/page_tree_archived_node.html:67
+#: templates/pages/page_tree_node.html:93 templates/pois/poi_form.html:64
+#: templates/pois/poi_form.html:93 templates/pois/poi_list_row.html:65
 msgid "Translation missing"
 msgstr "Übersetzung fehlt"
 
-#: constants/translation_status.py:12 templates/events/event_form.html:63
-#: templates/events/event_form.html:92
-#: templates/events/event_list_archived_row.html:58
-#: templates/events/event_list_row.html:50
+#: constants/translation_status.py:12 templates/events/event_form.html:62
+#: templates/events/event_form.html:91
+#: templates/events/event_list_archived_row.html:57
+#: templates/events/event_list_row.html:49
 #: templates/imprint/imprint_form.html:45
 #: templates/imprint/imprint_form.html:74 templates/imprint/imprint_sbs.html:38
-#: templates/imprint/imprint_sbs.html:93 templates/pages/page_form.html:69
-#: templates/pages/page_form.html:95 templates/pages/page_form.html:110
+#: templates/imprint/imprint_sbs.html:93 templates/pages/page_form.html:68
+#: templates/pages/page_form.html:94 templates/pages/page_form.html:109
 #: templates/pages/page_sbs.html:45 templates/pages/page_sbs.html:104
-#: templates/pages/page_tree_archived_node.html:59
-#: templates/pages/page_tree_node.html:85 templates/pois/poi_form.html:52
-#: templates/pois/poi_form.html:81 templates/pois/poi_list_row.html:57
+#: templates/pages/page_tree_archived_node.html:58
+#: templates/pages/page_tree_node.html:84 templates/pois/poi_form.html:51
+#: templates/pois/poi_form.html:80 templates/pois/poi_list_row.html:56
 msgid "Translation outdated"
 msgstr "Übersetzung ist veraltet"
 
@@ -436,16 +436,16 @@ msgid "Category"
 msgstr "Kategorie"
 
 #: forms/feedback/region_feedback_filter_form.py:31
-#: templates/events/event_form.html:122 templates/events/event_list.html:50
+#: templates/events/event_form.html:121 templates/events/event_list.html:50
 #: templates/events/event_list_archived.html:35
 #: templates/imprint/imprint_form.html:105
 #: templates/imprint/imprint_revisions.html:42
 #: templates/imprint/imprint_sbs.html:58 templates/imprint/imprint_sbs.html:121
-#: templates/imprint/imprint_sbs.html:136 templates/pages/page_form.html:152
+#: templates/imprint/imprint_sbs.html:136 templates/pages/page_form.html:151
 #: templates/pages/page_revisions.html:44 templates/pages/page_sbs.html:65
 #: templates/pages/page_sbs.html:132 templates/pages/page_sbs.html:137
 #: templates/pages/page_tree.html:67 templates/pages/page_tree_archived.html:26
-#: templates/pois/poi_form.html:111 templates/pois/poi_list.html:45
+#: templates/pois/poi_form.html:110 templates/pois/poi_list.html:45
 #: templates/pois/poi_list_archived.html:28
 #: templates/regions/region_list.html:32
 msgid "Status"
@@ -1688,20 +1688,20 @@ msgid "Translations up-to-date"
 msgstr "Aktuelle Übersetzungen"
 
 #: templates/analytics/translation_coverage.html:46
-#: templates/events/event_form.html:67 templates/events/event_form.html:96
-#: templates/events/event_list_archived_row.html:54
-#: templates/events/event_list_row.html:46
+#: templates/events/event_form.html:66 templates/events/event_form.html:95
+#: templates/events/event_list_archived_row.html:53
+#: templates/events/event_list_row.html:45
 #: templates/imprint/imprint_form.html:49
 #: templates/imprint/imprint_form.html:78 templates/imprint/imprint_sbs.html:42
-#: templates/imprint/imprint_sbs.html:97 templates/pages/page_form.html:73
-#: templates/pages/page_form.html:114 templates/pages/page_sbs.html:49
+#: templates/imprint/imprint_sbs.html:97 templates/pages/page_form.html:72
+#: templates/pages/page_form.html:113 templates/pages/page_sbs.html:49
 #: templates/pages/page_sbs.html:108
-#: templates/pages/page_tree_archived_node.html:55
-#: templates/pages/page_tree_node.html:58
-#: templates/pages/page_tree_node.html:65
-#: templates/pages/page_tree_node.html:81
-#: templates/pages/page_tree_node.html:100 templates/pois/poi_form.html:56
-#: templates/pois/poi_form.html:85 templates/pois/poi_list_row.html:53
+#: templates/pages/page_tree_archived_node.html:54
+#: templates/pages/page_tree_node.html:57
+#: templates/pages/page_tree_node.html:64
+#: templates/pages/page_tree_node.html:80
+#: templates/pages/page_tree_node.html:99 templates/pois/poi_form.html:55
+#: templates/pois/poi_form.html:84 templates/pois/poi_list_row.html:52
 msgid "Currently in translation"
 msgstr "Wird derzeit übersetzt"
 
@@ -1919,32 +1919,32 @@ msgstr "Zurück zur Startseite"
 msgid "Error"
 msgstr "Fehler"
 
-#: templates/events/_event_filter_form.html:14
+#: templates/events/_event_filter_form.html:13
 msgid "Date and time"
 msgstr "Datum und Uhrzeit"
 
-#: templates/events/_event_filter_form.html:17
+#: templates/events/_event_filter_form.html:16
 msgid "Not before"
 msgstr "Nicht vor"
 
-#: templates/events/_event_filter_form.html:26
+#: templates/events/_event_filter_form.html:25
 msgid "Not after"
 msgstr "Nicht nach"
 
-#: templates/events/_event_filter_form.html:35
-#: templates/events/event_form.html:318 templates/imprint/imprint_form.html:222
-#: templates/imprint/imprint_sbs.html:163 templates/pages/page_form.html:423
-#: templates/pages/page_sbs.html:173 templates/pois/poi_form.html:220
+#: templates/events/_event_filter_form.html:34
+#: templates/events/event_form.html:317 templates/imprint/imprint_form.html:222
+#: templates/imprint/imprint_sbs.html:163 templates/pages/page_form.html:422
+#: templates/pages/page_sbs.html:173 templates/pois/poi_form.html:219
 msgid "Location"
 msgstr "Ort"
 
-#: templates/events/_event_filter_form.html:36
-#: templates/events/event_list.html:69
-#: templates/events/event_list_archived.html:54
+#: templates/events/_event_filter_form.html:35
+#: templates/events/event_list.html:68
+#: templates/events/event_list_archived.html:53
 msgid "Event location"
 msgstr "Veranstaltungsort"
 
-#: templates/events/_event_filter_form.html:38
+#: templates/events/_event_filter_form.html:37
 #: templates/events/event_list.html:27
 #: templates/events/event_list_archived.html:16
 #: templates/language_tree/language_tree.html:16
@@ -1957,200 +1957,200 @@ msgstr "Veranstaltungsort"
 msgid "Search"
 msgstr "Suchen"
 
-#: templates/events/_event_filter_form.html:41
+#: templates/events/_event_filter_form.html:40
 msgid "Empty query input"
 msgstr "Sucheingabe löschen"
 
-#: templates/events/_event_filter_form.html:52
+#: templates/events/_event_filter_form.html:51
 msgid "All day events"
 msgstr "Ganztägige Veranstaltungen"
 
-#: templates/events/_event_filter_form.html:65
-#: templates/feedback/_admin_feedback_filter_form.html:59
-#: templates/feedback/_region_feedback_filter_form.html:52
-#: templates/pages/_page_filter_form.html:18
+#: templates/events/_event_filter_form.html:64
+#: templates/feedback/_admin_feedback_filter_form.html:58
+#: templates/feedback/_region_feedback_filter_form.html:51
+#: templates/pages/_page_filter_form.html:17
 msgid "Reset filter"
 msgstr "Filter zurücksetzen"
 
-#: templates/events/_event_filter_form.html:68
-#: templates/feedback/_admin_feedback_filter_form.html:62
-#: templates/feedback/_region_feedback_filter_form.html:54
-#: templates/pages/_page_filter_form.html:21
+#: templates/events/_event_filter_form.html:67
+#: templates/feedback/_admin_feedback_filter_form.html:61
+#: templates/feedback/_region_feedback_filter_form.html:53
+#: templates/pages/_page_filter_form.html:20
 msgid "Apply filter"
 msgstr "Filter anwenden"
 
-#: templates/events/_poi_query_result.html:11
+#: templates/events/_poi_query_result.html:10
 #, python-format
 msgid "Create location with title \"%(poi_query)s\""
 msgstr "Ort mit Titel \"%(poi_query)s\" erstellen"
 
-#: templates/events/event_form.html:22
+#: templates/events/event_form.html:21
 #, python-format
 msgid "Edit event \"%(event_title)s\""
 msgstr "Event \"%(event_title)s\" bearbeiten"
 
-#: templates/events/event_form.html:27 templates/events/event_list.html:51
-#: templates/events/event_list.html:57
+#: templates/events/event_form.html:26 templates/events/event_list.html:51
+#: templates/events/event_list.html:56
 #: templates/events/event_list_archived.html:36
-#: templates/events/event_list_archived.html:42
-#: templates/pages/page_form.html:27 templates/pages/page_tree.html:68
-#: templates/pages/page_tree.html:74 templates/pages/page_tree_archived.html:27
-#: templates/pages/page_tree_archived.html:33 templates/pois/poi_form.html:28
-#: templates/pois/poi_list.html:46 templates/pois/poi_list.html:52
+#: templates/events/event_list_archived.html:41
+#: templates/pages/page_form.html:26 templates/pages/page_tree.html:68
+#: templates/pages/page_tree.html:73 templates/pages/page_tree_archived.html:27
+#: templates/pages/page_tree_archived.html:32 templates/pois/poi_form.html:27
+#: templates/pois/poi_list.html:46 templates/pois/poi_list.html:51
 #: templates/pois/poi_list_archived.html:29
-#: templates/pois/poi_list_archived.html:35
+#: templates/pois/poi_list_archived.html:34
 msgid "Title in"
 msgstr "Titel auf"
 
-#: templates/events/event_form.html:31
+#: templates/events/event_form.html:30
 msgid "Create new event translation"
 msgstr "Neue Event-Übersetzung erstellen"
 
-#: templates/events/event_form.html:34
+#: templates/events/event_form.html:33
 msgid "Create new event"
 msgstr "Veranstaltung erstellen"
 
-#: templates/events/event_form.html:42 templates/imprint/imprint_form.html:29
-#: templates/imprint/imprint_sbs.html:25 templates/pages/page_form.html:41
-#: templates/pages/page_sbs.html:26 templates/pois/poi_form.html:37
+#: templates/events/event_form.html:41 templates/imprint/imprint_form.html:29
+#: templates/imprint/imprint_sbs.html:25 templates/pages/page_form.html:40
+#: templates/pages/page_sbs.html:26 templates/pois/poi_form.html:36
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
 
-#: templates/events/event_form.html:45 templates/imprint/imprint_form.html:30
-#: templates/imprint/imprint_sbs.html:26 templates/pages/page_form.html:49
-#: templates/pages/page_sbs.html:30 templates/pois/poi_form.html:38
+#: templates/events/event_form.html:44 templates/imprint/imprint_form.html:30
+#: templates/imprint/imprint_sbs.html:26 templates/pages/page_form.html:48
+#: templates/pages/page_sbs.html:30 templates/pois/poi_form.html:37
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: templates/events/event_form.html:47 templates/pages/page_form.html:52
+#: templates/events/event_form.html:46 templates/pages/page_form.html:51
 #: templates/pages/page_sbs.html:32
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
-#: templates/events/event_form.html:81 templates/imprint/imprint_form.html:63
-#: templates/imprint/imprint_sbs.html:106 templates/pages/page_form.html:87
-#: templates/pages/page_sbs.html:117 templates/pois/poi_form.html:70
+#: templates/events/event_form.html:80 templates/imprint/imprint_form.html:63
+#: templates/imprint/imprint_sbs.html:106 templates/pages/page_form.html:86
+#: templates/pages/page_sbs.html:117 templates/pois/poi_form.html:69
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
 
-#: templates/events/event_form.html:120
+#: templates/events/event_form.html:119
 #: templates/events/event_list_archived.html:34
 #: templates/imprint/imprint_sbs.html:56 templates/imprint/imprint_sbs.html:119
-#: templates/imprint/imprint_sbs.html:134 templates/pages/page_form.html:136
+#: templates/imprint/imprint_sbs.html:134 templates/pages/page_form.html:135
 #: templates/pages/page_sbs.html:63 templates/pages/page_sbs.html:130
-#: templates/pages/page_sbs.html:135 templates/pois/poi_form.html:109
+#: templates/pages/page_sbs.html:135 templates/pois/poi_form.html:108
 #: templates/pois/poi_list.html:44 templates/pois/poi_list_archived.html:27
 msgid "Version"
 msgstr "Version"
 
-#: templates/events/event_form.html:142 templates/imprint/imprint_form.html:122
-#: templates/imprint/imprint_sbs.html:147 templates/pages/page_form.html:225
-#: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:130
+#: templates/events/event_form.html:141 templates/imprint/imprint_form.html:122
+#: templates/imprint/imprint_sbs.html:147 templates/pages/page_form.html:224
+#: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:129
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
-#: templates/events/event_form.html:155 templates/imprint/imprint_form.html:167
-#: templates/pois/poi_form.html:143
+#: templates/events/event_form.html:154 templates/imprint/imprint_form.html:167
+#: templates/pois/poi_form.html:142
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
 
-#: templates/events/event_form.html:187
+#: templates/events/event_form.html:186
 msgid "Recurrence"
 msgstr "Wiederholung"
 
-#: templates/events/event_form.html:233
+#: templates/events/event_form.html:232
 msgid "Where"
 msgstr "Wo"
 
-#: templates/events/event_form.html:236
+#: templates/events/event_form.html:235
 msgid "Name of event location"
 msgstr "Name des Veranstaltungsortes"
 
-#: templates/events/event_form.html:240
+#: templates/events/event_form.html:239
 msgid "Remove location from event"
 msgstr "Veranstaltungsort von Veranstaltung entfernen"
 
-#: templates/events/event_form.html:249
+#: templates/events/event_form.html:248
 msgid ""
 "Create an event location or start typing the name of an existing location"
 msgstr ""
 "Erstelle einen Veranstaltungsort oder beginne den Namen eines bestehenden "
 "Veranstaltungsortes einzutippen"
 
-#: templates/events/event_form.html:252 templates/pois/poi_list.html:64
-#: templates/pois/poi_list_archived.html:38
+#: templates/events/event_form.html:251 templates/pois/poi_list.html:63
+#: templates/pois/poi_list_archived.html:37
 msgid "Street"
 msgstr "Straße"
 
-#: templates/events/event_form.html:256 templates/pois/poi_list.html:67
-#: templates/pois/poi_list_archived.html:41
+#: templates/events/event_form.html:255 templates/pois/poi_list.html:66
+#: templates/pois/poi_list_archived.html:40
 msgid "Country"
 msgstr "Land"
 
-#: templates/events/event_form.html:259
+#: templates/events/event_form.html:258
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:268
-#: templates/events/event_list_archived_row.html:97
+#: templates/events/event_form.html:267
+#: templates/events/event_list_archived_row.html:96
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:275
+#: templates/events/event_form.html:274
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:278 templates/events/event_list_row.html:92
+#: templates/events/event_form.html:277 templates/events/event_list_row.html:91
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
-#: templates/events/event_form.html:285
+#: templates/events/event_form.html:284
 msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
-#: templates/events/event_form.html:291
-#: templates/events/event_list_archived_row.html:106
-#: templates/events/event_list_row.html:101
+#: templates/events/event_form.html:290
+#: templates/events/event_list_archived_row.html:105
+#: templates/events/event_list_row.html:100
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
-#: templates/events/event_form.html:298
+#: templates/events/event_form.html:297
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:317 templates/imprint/imprint_form.html:221
-#: templates/imprint/imprint_sbs.html:162 templates/pages/page_form.html:422
-#: templates/pages/page_sbs.html:172 templates/pois/poi_form.html:219
+#: templates/events/event_form.html:316 templates/imprint/imprint_form.html:221
+#: templates/imprint/imprint_sbs.html:162 templates/pages/page_form.html:421
+#: templates/pages/page_sbs.html:172 templates/pois/poi_form.html:218
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:320 templates/imprint/imprint_form.html:224
-#: templates/imprint/imprint_sbs.html:165 templates/pages/page_form.html:425
-#: templates/pages/page_sbs.html:175 templates/pois/poi_form.html:222
+#: templates/events/event_form.html:319 templates/imprint/imprint_form.html:224
+#: templates/imprint/imprint_sbs.html:165 templates/pages/page_form.html:424
+#: templates/pages/page_sbs.html:175 templates/pois/poi_form.html:221
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:322 templates/imprint/imprint_form.html:226
-#: templates/imprint/imprint_sbs.html:167 templates/pages/page_form.html:427
-#: templates/pages/page_sbs.html:177 templates/pois/poi_form.html:224
+#: templates/events/event_form.html:321 templates/imprint/imprint_form.html:226
+#: templates/imprint/imprint_sbs.html:167 templates/pages/page_form.html:426
+#: templates/pages/page_sbs.html:177 templates/pois/poi_form.html:223
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:324 templates/imprint/imprint_form.html:228
-#: templates/imprint/imprint_sbs.html:169 templates/pages/page_form.html:429
-#: templates/pages/page_sbs.html:179 templates/pois/poi_form.html:226
+#: templates/events/event_form.html:323 templates/imprint/imprint_form.html:228
+#: templates/imprint/imprint_sbs.html:169 templates/pages/page_form.html:428
+#: templates/pages/page_sbs.html:179 templates/pois/poi_form.html:225
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:326 templates/imprint/imprint_form.html:230
-#: templates/imprint/imprint_sbs.html:171 templates/pages/page_form.html:431
-#: templates/pages/page_sbs.html:181 templates/pois/poi_form.html:228
+#: templates/events/event_form.html:325 templates/imprint/imprint_form.html:230
+#: templates/imprint/imprint_sbs.html:171 templates/pages/page_form.html:430
+#: templates/pages/page_sbs.html:181 templates/pois/poi_form.html:227
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:328 templates/imprint/imprint_form.html:232
-#: templates/imprint/imprint_sbs.html:173 templates/pages/page_form.html:433
-#: templates/pages/page_sbs.html:183 templates/pois/poi_form.html:230
+#: templates/events/event_form.html:327 templates/imprint/imprint_form.html:232
+#: templates/imprint/imprint_sbs.html:173 templates/pages/page_form.html:432
+#: templates/pages/page_sbs.html:183 templates/pois/poi_form.html:229
 msgid "Hint"
 msgstr "Tipp"
 
@@ -2164,33 +2164,33 @@ msgstr "Archivierte Veranstaltungen"
 msgid "Filter events"
 msgstr "Veranstaltungen filtern"
 
-#: templates/events/event_list.html:70
-#: templates/events/event_list_archived.html:55
+#: templates/events/event_list.html:69
+#: templates/events/event_list_archived.html:54
 msgid "Start"
 msgstr "Beginn"
 
-#: templates/events/event_list.html:71
-#: templates/events/event_list_archived.html:56
+#: templates/events/event_list.html:70
+#: templates/events/event_list_archived.html:55
 msgid "End"
 msgstr "Ende"
 
-#: templates/events/event_list.html:72
-#: templates/events/event_list_archived.html:57
+#: templates/events/event_list.html:71
+#: templates/events/event_list_archived.html:56
 #: templates/languages/language_list.html:32
 #: templates/offer_templates/offer_template_list.html:29
 #: templates/organizations/organization_list.html:27
-#: templates/pages/page_tree.html:87 templates/pages/page_tree_archived.html:45
-#: templates/pois/poi_list.html:68 templates/pois/poi_list_archived.html:42
+#: templates/pages/page_tree.html:86 templates/pages/page_tree_archived.html:44
+#: templates/pois/poi_list.html:67 templates/pois/poi_list_archived.html:41
 #: templates/roles/list.html:25
 msgid "Options"
 msgstr "Optionen"
 
-#: templates/events/event_list.html:86
-#: templates/events/event_list_archived.html:71
+#: templates/events/event_list.html:85
+#: templates/events/event_list_archived.html:70
 msgid "No events found with these filters."
 msgstr "Keine Veranstaltungen mit diesem Filter gefunden."
 
-#: templates/events/event_list.html:88
+#: templates/events/event_list.html:87
 msgid "No events available yet."
 msgstr "Noch keine Veranstaltungen vorhanden."
 
@@ -2199,35 +2199,35 @@ msgstr "Noch keine Veranstaltungen vorhanden."
 msgid "ID"
 msgstr "ID"
 
-#: templates/events/event_list_archived.html:73
+#: templates/events/event_list_archived.html:72
 msgid "No events archived yet."
 msgstr "Noch keine Veranstaltungen archiviert."
 
 #: templates/events/event_list_archived_row.html:25
-#: templates/events/event_list_archived_row.html:40
+#: templates/events/event_list_archived_row.html:39
 #: templates/events/event_list_row.html:17
-#: templates/events/event_list_row.html:32
+#: templates/events/event_list_row.html:31
 #: templates/pages/page_tree_archived_node.html:26
-#: templates/pages/page_tree_archived_node.html:41
+#: templates/pages/page_tree_archived_node.html:40
 #: templates/pages/page_tree_node.html:41
-#: templates/pages/page_tree_node.html:61
+#: templates/pages/page_tree_node.html:60
 #: templates/pois/poi_list_archived_row.html:24
-#: templates/pois/poi_list_archived_row.html:39
-#: templates/pois/poi_list_row.html:24 templates/pois/poi_list_row.html:39
+#: templates/pois/poi_list_archived_row.html:38
+#: templates/pois/poi_list_row.html:24 templates/pois/poi_list_row.html:38
 msgid "Translation not available"
 msgstr "Übersetzung nicht verfügbar"
 
-#: templates/events/event_list_archived_row.html:81
-#: templates/events/event_list_row.html:73
+#: templates/events/event_list_archived_row.html:80
+#: templates/events/event_list_row.html:72
 msgid "Not specified"
 msgstr "Nicht festgelegt"
 
-#: templates/events/event_list_row.html:89
+#: templates/events/event_list_row.html:88
 msgid "Edit event"
 msgstr "Veranstaltung bearbeiten"
 
-#: templates/feedback/_admin_feedback_filter_form.html:37
-#: templates/feedback/_region_feedback_filter_form.html:30
+#: templates/feedback/_admin_feedback_filter_form.html:36
+#: templates/feedback/_region_feedback_filter_form.html:29
 msgid "Time range"
 msgstr "Zeitraum"
 
@@ -2272,7 +2272,7 @@ msgstr "Noch kein technisches Feedback vorhanden."
 
 #: templates/feedback/admin_feedback_list.html:128
 #: templates/feedback/region_feedback_list.html:122
-#: templates/pages/page_tree.html:117
+#: templates/pages/page_tree.html:116
 msgid "Select bulk action"
 msgstr "Mehrfachaktion auswählen"
 
@@ -2294,7 +2294,7 @@ msgstr "Löschen"
 
 #: templates/feedback/admin_feedback_list.html:139
 #: templates/feedback/region_feedback_list.html:133
-#: templates/pages/page_tree.html:132
+#: templates/pages/page_tree.html:131
 msgid "Execute"
 msgstr "Ausführen"
 
@@ -2307,7 +2307,7 @@ msgid "No feedback available yet."
 msgstr "Noch kein Feedback vorhanden."
 
 #: templates/generic_confirmation_dialog.html:11
-#: templates/pages/page_form.html:173
+#: templates/pages/page_form.html:172
 msgid "Warning"
 msgstr "Warnung"
 
@@ -2375,13 +2375,13 @@ msgstr "Permalink"
 #: templates/imprint/imprint_form.html:114
 #: templates/imprint/imprint_sbs.html:62 templates/imprint/imprint_sbs.html:67
 #: templates/imprint/imprint_sbs.html:125
-#: templates/imprint/imprint_sbs.html:130 templates/pages/page_form.html:167
+#: templates/imprint/imprint_sbs.html:130 templates/pages/page_form.html:166
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
 #: templates/imprint/imprint_form.html:112
 #: templates/imprint/imprint_sbs.html:65 templates/imprint/imprint_sbs.html:128
-#: templates/imprint/imprint_sbs.html:140 templates/pages/page_form.html:165
+#: templates/imprint/imprint_sbs.html:140 templates/pages/page_form.html:164
 msgid "Short URL"
 msgstr "Kurz-URL"
 
@@ -2389,7 +2389,7 @@ msgstr "Kurz-URL"
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: templates/imprint/imprint_form.html:143 templates/pages/page_form.html:395
+#: templates/imprint/imprint_form.html:143 templates/pages/page_form.html:394
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
@@ -2608,7 +2608,7 @@ msgstr "Erstellt"
 
 #: templates/languages/language_list.html:31
 #: templates/offer_templates/offer_template_list.html:27
-#: templates/pages/page_tree.html:86 templates/regions/region_list.html:31
+#: templates/pages/page_tree.html:85 templates/regions/region_list.html:31
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
@@ -2687,7 +2687,7 @@ msgstr "Angebots-Vorlagen verwalten"
 msgid "Active since"
 msgstr "Aktiv seit"
 
-#: templates/offers/offer_list.html:33 templates/pages/page_form.html:305
+#: templates/offers/offer_list.html:33 templates/pages/page_form.html:304
 #: templates/regions/region_list.html:33 templates/settings/user.html:62
 msgid "Actions"
 msgstr "Aktionen"
@@ -2729,11 +2729,11 @@ msgstr "Vorschaubild"
 msgid "No organizations available yet."
 msgstr "Noch keine Organisationen vorhanden."
 
-#: templates/pages/_page_order_table.html:17
+#: templates/pages/_page_order_table.html:16
 msgid "Change the position of the page with drag & drop."
 msgstr "Ändern Sie die Position der Seite mit Drag & Drop."
 
-#: templates/pages/_page_order_table.html:51
+#: templates/pages/_page_order_table.html:50
 msgid "New Page"
 msgstr "Neue Seite"
 
@@ -2768,65 +2768,65 @@ msgstr "Diese Benutzer können die Seite bearbeiten und veröffentlichen"
 msgid "Add to publishers"
 msgstr "Erlaubnis zum Veröffentlichen erteilen"
 
-#: templates/pages/page_form.html:22
+#: templates/pages/page_form.html:21
 #, python-format
 msgid "Edit page \"%(page_title)s\""
 msgstr "Seite \"%(page_title)s\" bearbeiten"
 
-#: templates/pages/page_form.html:31
+#: templates/pages/page_form.html:30
 msgid "Create new translation"
 msgstr "Neue Übersetzung erstellen"
 
-#: templates/pages/page_form.html:34
+#: templates/pages/page_form.html:33
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page_form.html:47
+#: templates/pages/page_form.html:46
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: templates/pages/page_form.html:139
+#: templates/pages/page_form.html:138
 msgid "Show versions"
 msgstr "Versionen anzeigen"
 
-#: templates/pages/page_form.html:156
+#: templates/pages/page_form.html:155
 #: templates/pages/page_tree_archived_node.html:17
 msgid "Archived, because a parent page is archived"
 msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 
-#: templates/pages/page_form.html:174
+#: templates/pages/page_form.html:173
 msgid "Translation in progress"
 msgstr "Übersetzung wird durchgeführt"
 
-#: templates/pages/page_form.html:182
+#: templates/pages/page_form.html:181
 msgid "Abort translation process"
 msgstr "Übersetzungsprozess abbrechen"
 
-#: templates/pages/page_form.html:219
+#: templates/pages/page_form.html:218
 msgid "Minor edit"
 msgstr "Geringfügige Änderung"
 
-#: templates/pages/page_form.html:235
+#: templates/pages/page_form.html:234
 msgid "Settings of the page"
 msgstr "Einstellungen der Seite"
 
-#: templates/pages/page_form.html:242
+#: templates/pages/page_form.html:241
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page_form.html:252
+#: templates/pages/page_form.html:251
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: templates/pages/page_form.html:257
+#: templates/pages/page_form.html:256
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:276
+#: templates/pages/page_form.html:275
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:277
+#: templates/pages/page_form.html:276
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -2834,17 +2834,17 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:313 templates/pages/page_form.html:314
-#: templates/pages/page_form.html:322
-#: templates/pages/page_tree_archived_node.html:84
+#: templates/pages/page_form.html:312 templates/pages/page_form.html:313
+#: templates/pages/page_form.html:321
+#: templates/pages/page_tree_archived_node.html:83
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:319
+#: templates/pages/page_form.html:318
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:325
+#: templates/pages/page_form.html:324
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -2855,28 +2855,28 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
-#: templates/pages/page_form.html:338 templates/pages/page_form.html:339
-#: templates/pages/page_tree_node.html:124
+#: templates/pages/page_form.html:337 templates/pages/page_form.html:338
+#: templates/pages/page_tree_node.html:123
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:345
+#: templates/pages/page_form.html:344
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:351 templates/pages/page_form.html:369
-#: templates/pages/page_tree_archived_node.html:102
-#: templates/pages/page_tree_node.html:137
+#: templates/pages/page_form.html:350 templates/pages/page_form.html:368
+#: templates/pages/page_tree_archived_node.html:101
+#: templates/pages/page_tree_node.html:136
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:355
-#: templates/pages/page_tree_archived_node.html:98
-#: templates/pages/page_tree_node.html:133 views/pages/page_actions.py:205
+#: templates/pages/page_form.html:354
+#: templates/pages/page_tree_archived_node.html:97
+#: templates/pages/page_tree_node.html:132 views/pages/page_actions.py:205
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:356
+#: templates/pages/page_form.html:355
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -2887,15 +2887,15 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: templates/pages/page_form.html:375
+#: templates/pages/page_form.html:374
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: templates/pages/page_form.html:388
+#: templates/pages/page_form.html:387
 msgid "Translator view"
 msgstr "Übersetzeransicht"
 
-#: templates/pages/page_form.html:409
+#: templates/pages/page_form.html:408
 msgid "Show translator view"
 msgstr "Übersetzeransicht anzeigen"
 
@@ -2939,27 +2939,27 @@ msgstr "Sie können Seiten nur in der Standard-Sprache anlegen"
 msgid "Hierarchy"
 msgstr "Hierarchie"
 
-#: templates/pages/page_tree.html:107
+#: templates/pages/page_tree.html:106
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
-#: templates/pages/page_tree.html:118
+#: templates/pages/page_tree.html:117
 msgid "Archive pages"
 msgstr "Seiten archivieren"
 
-#: templates/pages/page_tree.html:119
+#: templates/pages/page_tree.html:118
 msgid "Export as PDF"
 msgstr "Als PDF Exportieren"
 
-#: templates/pages/page_tree.html:123
+#: templates/pages/page_tree.html:122
 msgid "Export XLIFF for translation to"
 msgstr "Exportiere XLIFF für Übersetzung nach"
 
-#: templates/pages/page_tree.html:138
+#: templates/pages/page_tree.html:137
 msgid "Upload XLIFF File"
 msgstr "XLIFF-Datei hochladen"
 
-#: templates/pages/page_tree.html:148
+#: templates/pages/page_tree.html:147
 msgid "Upload"
 msgstr "Hochladen"
 
@@ -2967,7 +2967,7 @@ msgstr "Hochladen"
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/page_tree_archived.html:60
+#: templates/pages/page_tree_archived.html:59
 msgid "No pages archived yet."
 msgstr "Noch keine Seiten archiviert."
 
@@ -2986,18 +2986,18 @@ msgstr ""
 "Diese Seite ist archiviert, weil eine ihrer übergeordneten Seiten archiviert "
 "ist."
 
-#: templates/pages/page_tree_archived_node.html:80
-#: templates/pages/page_tree_node.html:117
+#: templates/pages/page_tree_archived_node.html:79
+#: templates/pages/page_tree_node.html:116
 msgid "View page"
 msgstr "Seite ansehen"
 
-#: templates/pages/page_tree_archived_node.html:92
+#: templates/pages/page_tree_archived_node.html:91
 msgid "To restore this page, you have to restore its archived parent page."
 msgstr ""
 "Um diese Seite wiederherzustellen, müssen Sie ihre archivierte übergeordnete "
 "Seite wiederherstellen."
 
-#: templates/pages/page_tree_archived_node.html:98
+#: templates/pages/page_tree_archived_node.html:97
 msgid "This also involves non-archived subpages."
 msgstr "Dies betrifft auch nicht-archivierte Unterseiten."
 
@@ -3013,19 +3013,19 @@ msgstr "Drag & drop nicht möglich, wenn Filter aktiv sind"
 msgid "Collapse all subpages"
 msgstr "Alle Unterseiten einklappen"
 
-#: templates/pages/page_tree_node.html:120
+#: templates/pages/page_tree_node.html:119
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 
-#: templates/pages/page_tree_node.html:133
+#: templates/pages/page_tree_node.html:132
 msgid "This also involves archived subpages."
 msgstr "Dies betrifft auch archivierte Unterseiten."
 
-#: templates/pages/page_tree_node.html:147
+#: templates/pages/page_tree_node.html:146
 msgid "Copy short link"
 msgstr "Kurz-URL kopieren"
 
-#: templates/pages/page_tree_node.html:151
+#: templates/pages/page_tree_node.html:150
 msgid "You cannot copy a short link of a page which has no translation."
 msgstr "Sie können keine Kurz-URL zu einer fehlenden Übersetzung kopieren."
 
@@ -3085,43 +3085,43 @@ msgstr "Ort \"%(poi_title)s\" bearbeiten"
 msgid "Create new translation of the location"
 msgstr "Neue Übersetzung des Ortes erstellen"
 
-#: templates/pois/poi_form.html:31
+#: templates/pois/poi_form.html:30
 msgid "Create new location"
 msgstr "Neuen Ort erstellen"
 
-#: templates/pois/poi_form.html:151
+#: templates/pois/poi_form.html:150
 msgid "Address"
 msgstr "Adresse"
 
-#: templates/pois/poi_form.html:162
+#: templates/pois/poi_form.html:161
 msgid "Position"
 msgstr "Position"
 
-#: templates/pois/poi_form.html:177 templates/pois/poi_form.html:178
-#: templates/pois/poi_list_archived_row.html:58
+#: templates/pois/poi_form.html:176 templates/pois/poi_form.html:177
+#: templates/pois/poi_list_archived_row.html:57
 msgid "Restore location"
 msgstr "Ort wiederherstellen"
 
-#: templates/pois/poi_form.html:183
+#: templates/pois/poi_form.html:182
 msgid "Restore this location"
 msgstr "Diesen Ort wiederherstellen"
 
-#: templates/pois/poi_form.html:186 templates/pois/poi_form.html:187
-#: templates/pois/poi_list_row.html:92
+#: templates/pois/poi_form.html:185 templates/pois/poi_form.html:186
+#: templates/pois/poi_list_row.html:91
 msgid "Archive location"
 msgstr "Ort archivieren"
 
-#: templates/pois/poi_form.html:192
+#: templates/pois/poi_form.html:191
 msgid "Archive this location"
 msgstr "Diesen Ort archivieren"
 
-#: templates/pois/poi_form.html:198 templates/pois/poi_form.html:199
-#: templates/pois/poi_list_archived_row.html:66
-#: templates/pois/poi_list_row.html:100
+#: templates/pois/poi_form.html:197 templates/pois/poi_form.html:198
+#: templates/pois/poi_list_archived_row.html:65
+#: templates/pois/poi_list_row.html:99
 msgid "Delete location"
 msgstr "Ort löschen"
 
-#: templates/pois/poi_form.html:204
+#: templates/pois/poi_form.html:203
 msgid "Delete this location"
 msgstr "Diesen Ort löschen"
 
@@ -3129,15 +3129,15 @@ msgstr "Diesen Ort löschen"
 msgid "Archived locations"
 msgstr "Archivierte Orte"
 
-#: templates/pois/poi_list.html:65 templates/pois/poi_list_archived.html:39
+#: templates/pois/poi_list.html:64 templates/pois/poi_list_archived.html:38
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
-#: templates/pois/poi_list.html:78
+#: templates/pois/poi_list.html:77
 msgid "No locations available yet."
 msgstr "Noch keine Orte vorhanden."
 
-#: templates/pois/poi_list_archived.html:52
+#: templates/pois/poi_list_archived.html:51
 msgid "No locations archived yet."
 msgstr "Noch keine Orte archiviert."
 

--- a/src/cms/templates/events/_event_filter_form.html
+++ b/src/cms/templates/events/_event_filter_form.html
@@ -7,7 +7,6 @@
 <form method="post">
     {% csrf_token %}
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% get_language LANGUAGE_CODE as current_language %}
     <div class="flex flex-wrap p-4 items-start">
         <div class="w-1/3 pr-6">

--- a/src/cms/templates/events/_poi_query_result.html
+++ b/src/cms/templates/events/_poi_query_result.html
@@ -3,7 +3,6 @@
 {% load poi_filters %}
 {% if poi_query and region %}
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% get_language LANGUAGE_CODE as current_language %}
     <select size="{% if poi_query_result|length > 5 %}5{% else %}{{ poi_query_result|length|add:"1" }}{% endif %}" class="appearance-none absolute block w-full bg-white text-gray-800 border border-gray-500 mb-2 py-2 px-2">
         {% if create_poi_option %}

--- a/src/cms/templates/events/event_form.html
+++ b/src/cms/templates/events/event_form.html
@@ -11,7 +11,6 @@
 <form id="content_form" method="post" enctype="multipart/form-data" {% if event_form.disabled %}data-disable-poi-query{% endif %}>
     {% csrf_token %}
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% get_language LANGUAGE_CODE as current_language %}
     <div class="flex flex-wrap">
         <div class="w-4/5 flex flex-wrap flex-col justify-center mb-6">

--- a/src/cms/templates/events/event_list.html
+++ b/src/cms/templates/events/event_list.html
@@ -50,7 +50,6 @@
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.slug %}
                     {% get_language LANGUAGE_CODE as backend_language %}
                     {% if backend_language %}

--- a/src/cms/templates/events/event_list_archived.html
+++ b/src/cms/templates/events/event_list_archived.html
@@ -35,7 +35,6 @@
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.slug %}
                     {% get_language LANGUAGE_CODE as backend_language %}
                     {% if backend_language %}

--- a/src/cms/templates/events/event_list_archived_row.html
+++ b/src/cms/templates/events/event_list_archived_row.html
@@ -27,7 +27,6 @@
         </a>
     </td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.slug %}
         {% get_language LANGUAGE_CODE as backend_language %}
         {% if backend_language %}

--- a/src/cms/templates/events/event_list_row.html
+++ b/src/cms/templates/events/event_list_row.html
@@ -19,7 +19,6 @@
         </a>
     </td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.slug %}
         {% get_language LANGUAGE_CODE as backend_language %}
         {% if backend_language %}

--- a/src/cms/templates/feedback/_admin_feedback_filter_form.html
+++ b/src/cms/templates/feedback/_admin_feedback_filter_form.html
@@ -5,7 +5,6 @@
 <form method="post">
     {% csrf_token %}
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% get_language LANGUAGE_CODE as current_language %}
     <div class="flex flex-wrap p-4 pb-0 items-start">
         <div class="w-2/5 pr-6">

--- a/src/cms/templates/feedback/_region_feedback_filter_form.html
+++ b/src/cms/templates/feedback/_region_feedback_filter_form.html
@@ -5,7 +5,6 @@
 <form method="post">
     {% csrf_token %}
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% get_language LANGUAGE_CODE as current_language %}
     <div class="flex flex-wrap p-4 pb-0 items-start">
         <div class="w-2/5 pr-6">

--- a/src/cms/templates/pages/_page_filter_form.html
+++ b/src/cms/templates/pages/_page_filter_form.html
@@ -5,7 +5,6 @@
 <form method="post">
     {% csrf_token %}
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% get_language LANGUAGE_CODE as current_language %}
     <div class="flex flex-wrap p-4 items-start">
         <div class="flex flex-wrap">

--- a/src/cms/templates/pages/_page_order_table.html
+++ b/src/cms/templates/pages/_page_order_table.html
@@ -6,7 +6,6 @@
     <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white table-auto">
         <tbody>
             {% get_current_language as LANGUAGE_CODE %}
-            {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
             {% recursetree siblings %}
                 {% if node == page %}
                     <tr class="border-2 border-blue-500 hover:bg-gray-100">

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -9,7 +9,6 @@
 
 {% block content %}
 {% get_current_language as LANGUAGE_CODE %}
-{% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
 {% has_perm 'cms.edit_page' request.user page as can_edit_page %}
 <form enctype="multipart/form-data" method="post" id="content_form">
     {% csrf_token %}

--- a/src/cms/templates/pages/page_tree.html
+++ b/src/cms/templates/pages/page_tree.html
@@ -67,7 +67,6 @@
                 <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.slug %}
                     {% get_language LANGUAGE_CODE as backend_language %}
                     {% if backend_language %}

--- a/src/cms/templates/pages/page_tree_archived.html
+++ b/src/cms/templates/pages/page_tree_archived.html
@@ -26,7 +26,6 @@
                 <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.slug %}
                     {% get_language LANGUAGE_CODE as backend_language %}
                     {% if backend_language %}

--- a/src/cms/templates/pages/page_tree_archived_node.html
+++ b/src/cms/templates/pages/page_tree_archived_node.html
@@ -28,7 +28,6 @@
         </a>
     </td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.slug %}
         {% get_language LANGUAGE_CODE as backend_language %}
         {% if backend_language %}

--- a/src/cms/templates/pages/page_tree_node.html
+++ b/src/cms/templates/pages/page_tree_node.html
@@ -43,7 +43,6 @@
         </a>
     </td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.slug %}
         {% get_language LANGUAGE_CODE as backend_language %}
         {% if backend_language %}

--- a/src/cms/templates/pois/poi_form.html
+++ b/src/cms/templates/pois/poi_form.html
@@ -22,7 +22,6 @@
                         {% trans 'Create new translation of the location' %}
                     {% endif %}
                     {% get_current_language as LANGUAGE_CODE %}
-                    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
                     {% get_translation poi_form.instance LANGUAGE_CODE as backend_translation %}
                     {% if backend_translation and LANGUAGE_CODE != language.slug %}
                         ({% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}: "{{ backend_translation.title }}")

--- a/src/cms/templates/pois/poi_list.html
+++ b/src/cms/templates/pois/poi_list.html
@@ -45,7 +45,6 @@
                 <th class="text-sm text-left uppercase py-3">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.slug %}
                     {% get_language LANGUAGE_CODE as backend_language %}
                     {% if backend_language %}

--- a/src/cms/templates/pois/poi_list_archived.html
+++ b/src/cms/templates/pois/poi_list_archived.html
@@ -28,7 +28,6 @@
                 <th class="text-sm text-left uppercase py-3">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
                 {% if LANGUAGE_CODE != language.slug %}
                     {% get_language LANGUAGE_CODE as backend_language %}
                     {% if backend_language %}

--- a/src/cms/templates/pois/poi_list_archived_row.html
+++ b/src/cms/templates/pois/poi_list_archived_row.html
@@ -26,7 +26,6 @@
 		</a>
 	</td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.slug %}
         {% get_language LANGUAGE_CODE as backend_language %}
         {% if backend_language %}

--- a/src/cms/templates/pois/poi_list_row.html
+++ b/src/cms/templates/pois/poi_list_row.html
@@ -26,7 +26,6 @@
 		</a>
 	</td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% unify_language_slug LANGUAGE_CODE as LANGUAGE_CODE %}
     {% if LANGUAGE_CODE != language.slug %}
         {% get_language LANGUAGE_CODE as backend_language %}
         {% if backend_language %}

--- a/src/cms/templatetags/content_filters.py
+++ b/src/cms/templatetags/content_filters.py
@@ -79,24 +79,6 @@ def get_language(language_slug):
     return Language.objects.filter(slug=language_slug).first()
 
 
-# Unify the language slugs of backend and content languages
-@register.simple_tag
-def unify_language_slug(language_slug):
-    """
-    This tag returns the unified language slug.
-    This is used to treat British English and American English as the same language.
-
-    :param language_slug: The slug of the requested language
-    :type language_slug: str
-
-    :return: The unified slug of the requested language
-    :rtype: str
-    """
-    if language_slug == "en-gb":
-        return "en-us"
-    return language_slug
-
-
 @register.filter
 def get_int_list(data, list_name):
     """


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I noticed that PR #738 (Improve logging) got a little bit out of control, so I will split it into separate PRs.
This one is about the backend language codes. Recently, we changed our language models and used two-letter slugs for identifying languages. Since we need a mapping from backend to content languages, I propose to use "de" and "en" instead of "de-de" and "en-us" as backend languages as well.
 
### Proposed changes
<!-- Describe this PR in more detail. -->
- Adapt the backend languages to the changed content language model
- Remove unused `unify_language_slug` template tag ("en-us" and "en-gb" are both just "en" now)
- Fix language slugs in tests

