### PR TITLE
Improve models

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -353,7 +353,13 @@ contextmanager-decorators=contextlib.contextmanager
 # List of members which are set dynamically and missed by pylint inference
 # system, and so shouldn't trigger E1101 when accessed. Python regular
 # expressions are accepted.
-generated-members=template,translations,pages
+generated-members=_meta,
+                  event,
+                  imprint,
+                  pages,
+                  template,
+                  slug,
+                  translations,
 
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -126,6 +126,7 @@ nitpick_ignore = [
     ("py:class", "django.forms.models.ModelChoiceIterator"),
     ("py:class", "mptt.models.MPTTModel"),
     ("py:class", "mptt.fields.TreeForeignKey"),
+    ("py:class", "mptt.forms.TreeNodeChoiceField"),
     ("py:class", "webauthn.WebAuthnUser"),
     ("py:class", "realms.magic.unicorn"),
     ("js:func", "cms.static.js.pages.page_bulk_action.bulk_action_execute"),

--- a/src/cms/admin.py
+++ b/src/cms/admin.py
@@ -1,68 +1,9 @@
 """
 File routing to the admin region
 """
-
-
+from django.apps import apps
 from django.contrib import admin
 
-from .models import ChatMessage
-from .models import Configuration
-from .models import Event
-from .models import EventTranslation
-from .models import Offer
-from .models import OfferTemplate
-from .models import Language
-from .models import LanguageTreeNode
-from .models import Organization
-from .models import Page
-from .models import PageTranslation
-from .models import POI
-from .models import POITranslation
-from .models import PushNotificationChannel
-from .models import Region
-from .models import RecurrenceRule
-from .models import UserMfa
-from .models import UserProfile
-from .models import EventFeedback
-from .models import EventListFeedback
-from .models import ImprintPageFeedback
-from .models import MapFeedback
-from .models import OfferFeedback
-from .models import OfferListFeedback
-from .models import PageFeedback
-from .models import POIFeedback
-from .models import RegionFeedback
-from .models import SearchResultFeedback
-from .models import ImprintPage
-from .models import ImprintPageTranslation
 
-admin.site.register(ChatMessage)
-admin.site.register(Configuration)
-admin.site.register(Event)
-admin.site.register(EventTranslation)
-admin.site.register(Offer)
-admin.site.register(OfferTemplate)
-admin.site.register(Language)
-admin.site.register(LanguageTreeNode)
-admin.site.register(Organization)
-admin.site.register(Page)
-admin.site.register(PageTranslation)
-admin.site.register(POI)
-admin.site.register(POITranslation)
-admin.site.register(PushNotificationChannel)
-admin.site.register(Region)
-admin.site.register(RecurrenceRule)
-admin.site.register(UserMfa)
-admin.site.register(UserProfile)
-admin.site.register(EventFeedback)
-admin.site.register(EventListFeedback)
-admin.site.register(ImprintPageFeedback)
-admin.site.register(MapFeedback)
-admin.site.register(OfferFeedback)
-admin.site.register(OfferListFeedback)
-admin.site.register(PageFeedback)
-admin.site.register(POIFeedback)
-admin.site.register(RegionFeedback)
-admin.site.register(SearchResultFeedback)
-admin.site.register(ImprintPage)
-admin.site.register(ImprintPageTranslation)
+for model in apps.get_app_config("cms").get_models():
+    admin.site.register(model)

--- a/src/cms/forms/feedback/region_feedback_filter_form.py
+++ b/src/cms/forms/feedback/region_feedback_filter_form.py
@@ -4,7 +4,6 @@ from django.utils.translation import ugettext_lazy as _
 
 from ...constants import feedback_ratings, feedback_read_status
 from ...models import Feedback, Language
-from ..language_tree.language_tree_node_form import LanguageField
 
 
 class RegionFeedbackFilterForm(forms.Form):
@@ -12,7 +11,7 @@ class RegionFeedbackFilterForm(forms.Form):
     Form for filtering feedback objects
     """
 
-    language = LanguageField(
+    language = forms.ModelChoiceField(
         Language.objects.all(),
         label=_("Language"),
         empty_label=_("All languages"),

--- a/src/cms/forms/language_tree/language_tree_node_form.py
+++ b/src/cms/forms/language_tree/language_tree_node_form.py
@@ -10,15 +10,6 @@ from ...models import Language, LanguageTreeNode
 logger = logging.getLogger(__name__)
 
 
-class LanguageField(forms.ModelChoiceField):
-    """
-    Form field helper class to overwrite the label function (which would otherwise call __str__)
-    """
-
-    def label_from_instance(self, obj):
-        return obj.translated_name
-
-
 class LanguageTreeNodeForm(CustomModelForm):
     """
     Form for creating and modifying language tree node objects
@@ -34,11 +25,6 @@ class LanguageTreeNodeForm(CustomModelForm):
         model = LanguageTreeNode
         #: The fields of the model which should be handled by this form
         fields = ["language", "parent", "visible", "active"]
-        #: The custom field classes to be used in this form
-        field_classes = {
-            "language": LanguageField,
-            "parent": LanguageField,
-        }
 
     def __init__(self, *args, **kwargs):
 

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-16 17:40+0000\n"
+"POT-Creation-Date: 2021-03-16 17:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -227,12 +227,13 @@ msgstr "Einmalig stattfindende Veranstaltungen"
 msgid "Active"
 msgstr "Aktiv"
 
-#: constants/region_status.py:17 forms/pages/page_form.py:107
+#: constants/region_status.py:17 models/regions/region.py:317
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: constants/region_status.py:18 forms/pages/page_form.py:83
-#: forms/pages/page_form.py:110 templates/pages/page_form.html:152
+#: constants/region_status.py:18 models/pages/page.py:190
+#: models/pages/page_translation.py:256 models/regions/region.py:320
+#: templates/pages/page_form.html:152
 #: templates/pages/page_tree_archived_node.html:13
 msgid "Archived"
 msgstr "Archiviert"
@@ -417,7 +418,7 @@ msgstr "Das Ende der Wiederholung muss nach dem Veranstaltungsbeginn sein"
 msgid "All regions"
 msgstr "Alle Regionen"
 
-#: forms/feedback/region_feedback_filter_form.py:17
+#: forms/feedback/region_feedback_filter_form.py:16
 #: templates/feedback/admin_feedback_list.html:32
 #: templates/feedback/region_feedback_list.html:32
 #: templates/language_tree/language_tree.html:31
@@ -425,21 +426,21 @@ msgstr "Alle Regionen"
 msgid "Language"
 msgstr "Sprache"
 
-#: forms/feedback/region_feedback_filter_form.py:18
+#: forms/feedback/region_feedback_filter_form.py:17
 msgid "All languages"
 msgstr "Alle Sprachen"
 
-#: forms/feedback/region_feedback_filter_form.py:22
+#: forms/feedback/region_feedback_filter_form.py:21
 msgid "All categories"
 msgstr "Alle Kategorien"
 
-#: forms/feedback/region_feedback_filter_form.py:27
+#: forms/feedback/region_feedback_filter_form.py:26
 #: templates/feedback/admin_feedback_list.html:30
 #: templates/feedback/region_feedback_list.html:30
 msgid "Category"
 msgstr "Kategorie"
 
-#: forms/feedback/region_feedback_filter_form.py:31
+#: forms/feedback/region_feedback_filter_form.py:30
 #: templates/events/event_form.html:120 templates/events/event_list.html:50
 #: templates/events/event_list_archived.html:35
 #: templates/imprint/imprint_form.html:105
@@ -455,7 +456,7 @@ msgstr "Kategorie"
 msgid "Status"
 msgstr "Status"
 
-#: forms/feedback/region_feedback_filter_form.py:38
+#: forms/feedback/region_feedback_filter_form.py:37
 #: templates/dashboard/admin_dashboard.html:31
 #: templates/feedback/admin_feedback_list.html:34
 #: templates/feedback/admin_feedback_list.html:35
@@ -464,15 +465,15 @@ msgstr "Status"
 msgid "Rating"
 msgstr "Bewertung"
 
-#: forms/feedback/region_feedback_filter_form.py:45
+#: forms/feedback/region_feedback_filter_form.py:44
 msgid "From"
 msgstr "Von"
 
-#: forms/feedback/region_feedback_filter_form.py:53
+#: forms/feedback/region_feedback_filter_form.py:52
 msgid "To"
 msgstr "Bis"
 
-#: forms/language_tree/language_tree_node_form.py:93
+#: forms/language_tree/language_tree_node_form.py:79
 msgid ""
 "This region has already a default language.Please specify a source language "
 "for this language."
@@ -521,20 +522,20 @@ msgid "sender"
 msgstr "Absender"
 
 #: models/chat/chat_message.py:44 models/pois/poi_translation.py:47
-#: models/push_notifications/push_notification_translation.py:19
+#: models/push_notifications/push_notification_translation.py:22
 msgid "content"
 msgstr "Inhalt"
 
 #: models/chat/chat_message.py:47
-#: models/push_notifications/push_notification.py:36
+#: models/push_notifications/push_notification.py:37
 msgid "sent date"
 msgstr "Sendedatum"
 
-#: models/chat/chat_message.py:69
+#: models/chat/chat_message.py:77
 msgid "chat message"
 msgstr "Chat-Nachricht"
 
-#: models/chat/chat_message.py:71
+#: models/chat/chat_message.py:79
 msgid "chat messages"
 msgstr "Chat-Nachrichten"
 
@@ -547,47 +548,47 @@ msgid "value"
 msgstr "Wert"
 
 #: models/config/configuration.py:19 models/events/event_translation.py:75
-#: models/feedback/feedback.py:58 models/languages/language.py:55
+#: models/feedback/feedback.py:58 models/languages/language.py:56
 #: models/languages/language_tree_node.py:51 models/offers/offer.py:34
 #: models/offers/offer_template.py:56 models/pages/abstract_base_page.py:19
 #: models/pages/abstract_base_page_translation.py:46
 #: models/pois/poi_translation.py:71
-#: models/push_notifications/push_notification.py:41
-#: models/push_notifications/push_notification_translation.py:35
-#: models/regions/region.py:101 models/users/organization.py:28
+#: models/push_notifications/push_notification.py:42
+#: models/push_notifications/push_notification_translation.py:38
+#: models/regions/region.py:106 models/users/organization.py:28
 #: models/users/user_mfa.py:37
 msgid "creation date"
 msgstr "Erstellungsdatum"
 
 #: models/config/configuration.py:23 models/events/event_translation.py:79
-#: models/languages/language.py:59 models/languages/language_tree_node.py:55
+#: models/languages/language.py:60 models/languages/language_tree_node.py:55
 #: models/offers/offer.py:37 models/offers/offer_template.py:60
 #: models/pages/abstract_base_page.py:22
 #: models/pages/abstract_base_page_translation.py:50
 #: models/pois/poi_translation.py:75
-#: models/push_notifications/push_notification.py:45
-#: models/push_notifications/push_notification_translation.py:39
-#: models/regions/region.py:105 models/users/organization.py:32
+#: models/push_notifications/push_notification.py:46
+#: models/push_notifications/push_notification_translation.py:42
+#: models/regions/region.py:110 models/users/organization.py:32
 msgid "modification date"
 msgstr "Änderungsdatum"
 
-#: models/config/configuration.py:28
+#: models/config/configuration.py:48
 msgid "configuration"
 msgstr "Einstellung"
 
-#: models/config/configuration.py:30
+#: models/config/configuration.py:50
 msgid "configurations"
 msgstr "Einstellungen"
 
 #: models/events/event.py:23 models/feedback/feedback.py:22
 #: models/languages/language_tree_node.py:37 models/offers/offer.py:24
-#: models/pages/imprint_page.py:21 models/pages/page.py:40
-#: models/pois/poi.py:18 models/push_notifications/push_notification.py:17
-#: models/regions/region.py:312
+#: models/pages/imprint_page.py:21 models/pages/page.py:43
+#: models/pois/poi.py:18 models/push_notifications/push_notification.py:18
+#: models/regions/region.py:336
 msgid "region"
 msgstr "Region"
 
-#: models/events/event.py:31 models/pois/poi.py:119
+#: models/events/event.py:31 models/pois/poi.py:139
 #: models/pois/poi_translation.py:35
 msgid "location"
 msgstr "Ort"
@@ -608,11 +609,11 @@ msgstr "End-Uhrzeit"
 msgid "end time"
 msgstr "End-Datum"
 
-#: models/events/event.py:43 models/events/recurrence_rule.py:68
+#: models/events/event.py:43 models/events/recurrence_rule.py:91
 msgid "recurrence rule"
 msgstr "Wiederholungs-Regel"
 
-#: models/events/event.py:49 models/pages/page.py:34 models/pois/poi.py:36
+#: models/events/event.py:49 models/pages/page.py:37 models/pois/poi.py:36
 msgid "icon"
 msgstr "Icon"
 
@@ -620,30 +621,30 @@ msgstr "Icon"
 msgid "archived"
 msgstr "archiviert"
 
-#: models/events/event.py:229 models/events/event_translation.py:23
+#: models/events/event.py:249 models/events/event_translation.py:23
 msgid "event"
 msgstr "Veranstaltung"
 
-#: models/events/event.py:231
+#: models/events/event.py:251
 msgid "events"
 msgstr "Veranstaltungen"
 
 #: models/events/event_translation.py:29 models/pois/poi_translation.py:24
-#: models/regions/region.py:34
+#: models/regions/region.py:39
 msgid "URL parameter"
 msgstr "URL-Parameter"
 
 #: models/events/event_translation.py:31 models/offers/offer_template.py:23
-#: models/pages/page_translation.py:29 models/pois/poi_translation.py:26
+#: models/pages/page_translation.py:32 models/pois/poi_translation.py:26
 msgid "String identifier without spaces and special characters."
 msgstr "Bezeichner ohne Leerzeichen und Sonderzeichen."
 
 #: models/events/event_translation.py:32 models/offers/offer_template.py:24
-#: models/pages/page_translation.py:30 models/pois/poi_translation.py:27
+#: models/pages/page_translation.py:33 models/pois/poi_translation.py:27
 msgid "Unique per region and language."
 msgstr "Eindeutig pro Region und Sprache."
 
-#: models/events/event_translation.py:33 models/pages/page_translation.py:31
+#: models/events/event_translation.py:33 models/pages/page_translation.py:34
 #: models/pois/poi_translation.py:28
 msgid "Leave blank to generate unique parameter from title."
 msgstr ""
@@ -652,12 +653,12 @@ msgstr ""
 
 #: models/events/event_translation.py:41
 #: models/pages/abstract_base_page_translation.py:27
-#: models/pois/poi_translation.py:42 models/regions/region.py:45
+#: models/pois/poi_translation.py:42 models/regions/region.py:50
 msgid "status"
 msgstr "Status"
 
 #: models/events/event_translation.py:43 models/pois/poi_translation.py:19
-#: models/push_notifications/push_notification_translation.py:14
+#: models/push_notifications/push_notification_translation.py:17
 msgid "title"
 msgstr "Titel"
 
@@ -666,10 +667,10 @@ msgid "description"
 msgstr "Beschreibung"
 
 #: models/events/event_translation.py:49 models/feedback/feedback.py:28
-#: models/languages/language.py:92 models/languages/language_tree_node.py:23
+#: models/languages/language.py:106 models/languages/language_tree_node.py:23
 #: models/pages/imprint_page_translation.py:32
-#: models/pages/page_translation.py:44 models/pois/poi_translation.py:52
-#: models/push_notifications/push_notification_translation.py:25
+#: models/pages/page_translation.py:47 models/pois/poi_translation.py:52
+#: models/push_notifications/push_notification_translation.py:28
 msgid "language"
 msgstr "Sprache"
 
@@ -709,39 +710,39 @@ msgstr ""
 
 #: models/events/event_translation.py:71
 #: models/pages/imprint_page_translation.py:39
-#: models/pages/page_translation.py:51 models/pois/poi_translation.py:82
+#: models/pages/page_translation.py:54 models/pois/poi_translation.py:82
 msgid "creator"
 msgstr "Ersteller"
 
-#: models/events/event_translation.py:303 models/feedback/event_feedback.py:18
+#: models/events/event_translation.py:314 models/feedback/event_feedback.py:18
 msgid "event translation"
 msgstr "Veranstaltungs-Übersetzung"
 
-#: models/events/event_translation.py:305
+#: models/events/event_translation.py:316
 msgid "event translations"
 msgstr "Veranstaltungs-Übersetzungen"
 
-#: models/events/recurrence_rule.py:19
+#: models/events/recurrence_rule.py:20
 msgid "frequency"
 msgstr "Häufigkeit"
 
-#: models/events/recurrence_rule.py:20
+#: models/events/recurrence_rule.py:21
 msgid "How often the event recurs"
 msgstr "Wie oft sich die Veranstaltung wiederholt"
 
-#: models/events/recurrence_rule.py:25
+#: models/events/recurrence_rule.py:26
 msgid "Repeat every ... time(s)"
 msgstr "Jedes ...-te Mal wiederholen"
 
-#: models/events/recurrence_rule.py:26
+#: models/events/recurrence_rule.py:27
 msgid "The interval in which the event recurs."
 msgstr "Das Intervall, in dem sich das Ereignis wiederholt."
 
-#: models/events/recurrence_rule.py:32
+#: models/events/recurrence_rule.py:33
 msgid "weekdays"
 msgstr "Wochentage"
 
-#: models/events/recurrence_rule.py:34
+#: models/events/recurrence_rule.py:35
 msgid ""
 "If the frequency is weekly, this field determines on which days the event "
 "takes place"
@@ -749,11 +750,11 @@ msgstr ""
 "Wenn die Häufigkeit wöchentlich ist, bestimmt dieses Feld, an welchen Tagen "
 "die Veranstaltung stattfindet"
 
-#: models/events/recurrence_rule.py:42
+#: models/events/recurrence_rule.py:43
 msgid "weekday"
 msgstr "Wochentag"
 
-#: models/events/recurrence_rule.py:44
+#: models/events/recurrence_rule.py:45
 msgid ""
 "If the frequency is monthly, this field determines on which days the event "
 "takes place"
@@ -761,11 +762,11 @@ msgstr ""
 "Wenn die Häufigkeit monatlich ist, bestimmt dieses Feld, an welchen Tagen "
 "die Veranstaltung stattfindet"
 
-#: models/events/recurrence_rule.py:52
+#: models/events/recurrence_rule.py:53
 msgid "week"
 msgstr "Woche"
 
-#: models/events/recurrence_rule.py:54
+#: models/events/recurrence_rule.py:55
 msgid ""
 "If the frequency is monthly, this field determines on which week of the "
 "month the event takes place"
@@ -773,11 +774,11 @@ msgstr ""
 "Wenn die Häufigkeit monatlich ist, bestimmt dieses Feld, in welcher Woche "
 "des Monats das Ereignis stattfindet"
 
-#: models/events/recurrence_rule.py:60
+#: models/events/recurrence_rule.py:61
 msgid "recurrence end date"
 msgstr "Enddatum der Wiederholung"
 
-#: models/events/recurrence_rule.py:62
+#: models/events/recurrence_rule.py:63
 msgid ""
 "If the recurrence is not for an indefinite period, this field contains the "
 "end date"
@@ -785,7 +786,11 @@ msgstr ""
 "Wenn die Wiederholung nicht auf unbestimmte Zeit erfolgt, enthält dieses "
 "Feld das Enddatum"
 
-#: models/events/recurrence_rule.py:70
+#: models/events/recurrence_rule.py:75
+msgid "Recurrence rule of \"{}\" ({})"
+msgstr "Wiederholungs-Regel von \"{}\" ({})"
+
+#: models/events/recurrence_rule.py:93
 msgid "recurrence rules"
 msgstr "Wiederholungs-Regeln"
 
@@ -834,16 +839,16 @@ msgstr "Der Benutzer, der dieses Feedback als gelesen markiert hat."
 msgid "If the feedback is unread, this field is empty."
 msgstr "Wenn das Feedback ungelesen ist, ist dieses Feld leer."
 
-#: models/feedback/feedback.py:162 models/feedback/feedback.py:164
+#: models/feedback/feedback.py:187 models/feedback/feedback.py:189
 msgid "feedback"
 msgstr "Feedback"
 
-#: models/feedback/imprint_page_feedback.py:25 templates/_base.html:208
+#: models/feedback/imprint_page_feedback.py:24 templates/_base.html:208
 msgid "Imprint"
 msgstr "Impressum"
 
-#: models/feedback/imprint_page_feedback.py:57
-#: models/feedback/imprint_page_feedback.py:59
+#: models/feedback/imprint_page_feedback.py:56
+#: models/feedback/imprint_page_feedback.py:58
 msgid "imprint feedback"
 msgstr "Impressums-Feedback"
 
@@ -856,7 +861,7 @@ msgstr "Orte auf Karte"
 msgid "map feedback"
 msgstr "Karten-Feedback"
 
-#: models/feedback/offer_feedback.py:18 models/offers/offer.py:106
+#: models/feedback/offer_feedback.py:18 models/offers/offer.py:126
 msgid "offer"
 msgstr "Angebot"
 
@@ -874,8 +879,8 @@ msgid "offer list feedback"
 msgstr "Angebotslisten-Feedback"
 
 #: models/feedback/page_feedback.py:18
-#: models/pages/abstract_base_page_translation.py:304
-#: models/pages/page_translation.py:246
+#: models/pages/abstract_base_page_translation.py:330
+#: models/pages/page_translation.py:262
 msgid "page translation"
 msgstr "Seiten-Übersetzung"
 
@@ -883,7 +888,7 @@ msgstr "Seiten-Übersetzung"
 msgid "page feedback"
 msgstr "Seiten-Feedback"
 
-#: models/feedback/poi_feedback.py:18 models/pois/poi_translation.py:295
+#: models/feedback/poi_feedback.py:18 models/pois/poi_translation.py:315
 msgid "location translation"
 msgstr "Orts-Übersetzung"
 
@@ -908,24 +913,24 @@ msgstr "Suchergebnisse für {}"
 msgid "search result feedback"
 msgstr "Suchergebnis-Feedback"
 
-#: models/languages/language.py:19
+#: models/languages/language.py:20
 msgid "Language Slug"
 msgstr "Sprach-Slug"
 
-#: models/languages/language.py:21
+#: models/languages/language.py:22
 msgid ""
 "Unique string identifier used in URLs without spaces and special characters."
 msgstr "Eindeutiger Bezeichner für URLs, ohne Leerzeichen und Sonderzeichen."
 
-#: models/languages/language.py:32 templates/languages/language_list.html:28
+#: models/languages/language.py:33 templates/languages/language_list.html:28
 msgid "BCP47 Tag"
 msgstr "BCP47 Tag"
 
-#: models/languages/language.py:34
+#: models/languages/language.py:35
 msgid "Language identifier without spaces and special characters."
 msgstr "Sprachenbezeichner ohne Leerzeichen und Sonderzeichen."
 
-#: models/languages/language.py:36
+#: models/languages/language.py:37
 msgid ""
 "This field usually contains a combination of subtags from the IANA Subtag "
 "Registry."
@@ -933,31 +938,31 @@ msgstr ""
 "Dieses Feld enthält normalerweise eine Kombination mehrerer Subtags aus der "
 "IANA Subtag Registry."
 
-#: models/languages/language.py:41
+#: models/languages/language.py:42
 msgid "native name"
 msgstr "nativer Name"
 
-#: models/languages/language.py:44
+#: models/languages/language.py:45
 msgid "name in English"
 msgstr "Name auf Englisch"
 
-#: models/languages/language.py:51
+#: models/languages/language.py:52
 msgid "text direction"
 msgstr "Schreibrichtung"
 
-#: models/languages/language.py:64
+#: models/languages/language.py:65
 msgid "\"Table of contents\" in this language"
 msgstr "\"Inhaltsverzeichnis\" in dieser Sprache"
 
-#: models/languages/language.py:66
+#: models/languages/language.py:67
 msgid "The native name for \"Table of contents\" in this language."
 msgstr "Der native Name für \"Inhaltsverzeichnis\" in dieser Sprache."
 
-#: models/languages/language.py:67
+#: models/languages/language.py:68
 msgid "This is used in exported PDFs."
 msgstr "Dies wird in exportierten PDFs verwendet."
 
-#: models/languages/language.py:94
+#: models/languages/language.py:108
 msgid "languages"
 msgstr "Sprachen"
 
@@ -982,15 +987,15 @@ msgid "Defined if content in this language can be created or edited"
 msgstr ""
 "Definiert ob Inhalte in der Sprache bearbeitet oder erstellt werden können"
 
-#: models/languages/language_tree_node.py:171
+#: models/languages/language_tree_node.py:182
 msgid "language tree node"
 msgstr "Sprach-Knoten"
 
-#: models/languages/language_tree_node.py:173
+#: models/languages/language_tree_node.py:184
 msgid "language tree nodes"
 msgstr "Sprach-Knoten"
 
-#: models/media/document.py:15 models/media/document.py:52
+#: models/media/document.py:15 models/media/document.py:63
 msgid "document"
 msgstr "Dokument"
 
@@ -1006,7 +1011,7 @@ msgstr "Upload-Datum"
 msgid "The date and time when the document was uploaded"
 msgstr "Das Datum und die Uhrzeit, zu der das Dokument hochgeladen wurde"
 
-#: models/media/document.py:54
+#: models/media/document.py:65
 msgid "documents"
 msgstr "Dokumente"
 
@@ -1014,13 +1019,13 @@ msgstr "Dokumente"
 msgid "template"
 msgstr "Vorlage"
 
-#: models/offers/offer.py:108
+#: models/offers/offer.py:128
 msgid "offers"
 msgstr "Angebote"
 
 #: models/offers/offer_template.py:16
 #: models/push_notifications/push_notification_channel.py:10
-#: models/regions/region.py:18 models/users/organization.py:11
+#: models/regions/region.py:23 models/users/organization.py:11
 #: models/users/user_mfa.py:17
 msgid "name"
 msgstr "Name"
@@ -1029,7 +1034,7 @@ msgstr "Name"
 msgid "slug"
 msgstr "URL-Parameter"
 
-#: models/offers/offer_template.py:25 models/regions/region.py:37
+#: models/offers/offer_template.py:25 models/regions/region.py:42
 msgid "Leave blank to generate unique parameter from name"
 msgstr ""
 "Dieses Feld freilassen, um einen eindeutigen Alias aus dem Namen zu "
@@ -1056,7 +1061,7 @@ msgstr "POST-Parameter"
 msgid "Additional POST data for retrieving the URL."
 msgstr "Zusätzliche POST-Daten zum Abrufen der URL."
 
-#: models/offers/offer_template.py:40 models/regions/region.py:62
+#: models/offers/offer_template.py:40 models/regions/region.py:67
 msgid "Specify as JSON."
 msgstr "Als JSON angeben."
 
@@ -1072,11 +1077,11 @@ msgstr ""
 "Ob und wie die Postleitzahl der Region in die URL oder POST-Daten eingefügt "
 "werden soll"
 
-#: models/offers/offer_template.py:74
+#: models/offers/offer_template.py:85
 msgid "offer template"
 msgstr "Angebots-Vorlage"
 
-#: models/offers/offer_template.py:76
+#: models/offers/offer_template.py:87
 msgid "offer templates"
 msgstr "Angebots-Vorlagen"
 
@@ -1088,12 +1093,12 @@ msgstr "explizit archiviert"
 msgid "Whether or not the page is explicitly archived"
 msgstr "Ob die Seite explizit archiviert ist oder nicht"
 
-#: models/pages/abstract_base_page.py:139 models/pages/page.py:172
-#: models/pages/page_translation.py:38
+#: models/pages/abstract_base_page.py:145 models/pages/page.py:196
+#: models/pages/page_translation.py:41
 msgid "page"
 msgstr "Seite"
 
-#: models/pages/abstract_base_page.py:141 models/pages/page.py:174
+#: models/pages/abstract_base_page.py:147 models/pages/page.py:198
 msgid "pages"
 msgstr "Seiten"
 
@@ -1109,8 +1114,8 @@ msgstr "Inhalt der Seite"
 msgid "version"
 msgstr "Version"
 
-#: models/pages/abstract_base_page_translation.py:306
-#: models/pages/page_translation.py:248
+#: models/pages/abstract_base_page_translation.py:332
+#: models/pages/page_translation.py:264
 msgid "page translations"
 msgstr "Seiten-Übersetzungen"
 
@@ -1122,34 +1127,34 @@ msgstr "Impressum"
 msgid "imprints"
 msgstr "Impressen"
 
-#: models/pages/imprint_page_translation.py:94
+#: models/pages/imprint_page_translation.py:82
 msgid "imprint translation"
 msgstr "Impressums-Übersetzung"
 
-#: models/pages/imprint_page_translation.py:96
+#: models/pages/imprint_page_translation.py:84
 msgid "imprint translations"
 msgstr "Impressums-Übersetzungen"
 
-#: models/pages/page.py:28
+#: models/pages/page.py:31
 msgid "parent page"
 msgstr "übergeordnete Seite"
 
-#: models/pages/page.py:48
+#: models/pages/page.py:51
 msgid "mirrored page"
 msgstr "eingebettete Seite"
 
-#: models/pages/page.py:50
+#: models/pages/page.py:53
 msgid ""
 "If the page embeds live content from another page, it is referenced here."
 msgstr ""
 "Wenn die Seite Live-Inhalte von einer anderen Seite einbettet, wird hier auf "
 "sie verwiesen."
 
-#: models/pages/page.py:57
+#: models/pages/page.py:60
 msgid "Position of mirrored page"
 msgstr "Position der gespiegelten Seite"
 
-#: models/pages/page.py:59
+#: models/pages/page.py:62
 msgid ""
 "If a mirrored page is set, this field determines whether the live content is "
 "embedded before the content of this page or after."
@@ -1157,17 +1162,17 @@ msgstr ""
 "Wenn eine gespiegelte Seite eingestellt ist, bestimmt dieses Feld, ob der "
 "Live-Inhalt vor oder nach dem Inhalt dieser Seite eingebettet wird."
 
-#: models/pages/page.py:66
+#: models/pages/page.py:69
 msgid "editors"
 msgstr "Bearbeiter"
 
-#: models/pages/page.py:68
+#: models/pages/page.py:71
 msgid "A list of users who have the permission to edit this specific page."
 msgstr ""
 "Eine Liste von Benutzern, die die Berechtigung haben, diese bestimmte Seite "
 "zu editieren."
 
-#: models/pages/page.py:70
+#: models/pages/page.py:73
 msgid ""
 "Only has effect if these users do not have the permission to edit pages "
 "anyway."
@@ -1175,17 +1180,17 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: models/pages/page.py:78
+#: models/pages/page.py:81
 msgid "publishers"
 msgstr "Veröffentlicher"
 
-#: models/pages/page.py:80
+#: models/pages/page.py:83
 msgid "A list of users who have the permission to publish this specific page."
 msgstr ""
 "Eine Liste von Benutzern, die die Berechtigung haben, diese bestimmte Seite "
 "zu veröffentlichen."
 
-#: models/pages/page.py:82
+#: models/pages/page.py:85
 msgid ""
 "Only has effect if these users do not have the permission to publish pages "
 "anyway."
@@ -1193,18 +1198,18 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu veröffentlichen."
 
-#: models/pages/page.py:92
+#: models/pages/page.py:95
 msgid "responsible organization"
 msgstr "zuständige Organisation"
 
-#: models/pages/page.py:94
+#: models/pages/page.py:97
 msgid ""
 "This allows all members of the organization to edit and publish this page."
 msgstr ""
 "Dies erlaubt allen Mitgliedern der Organisation diese Seite zu bearbeiten "
 "und veröffentlichen"
 
-#: models/pages/page_translation.py:27
+#: models/pages/page_translation.py:30
 msgid "Page link"
 msgstr "Seitenlink"
 
@@ -1212,7 +1217,7 @@ msgstr "Seitenlink"
 msgid "street and house number"
 msgstr "Straße und Hausnummer"
 
-#: models/pois/poi.py:23 models/regions/region.py:93
+#: models/pois/poi.py:23 models/regions/region.py:98
 msgid "postal code"
 msgstr "Postleitzahl"
 
@@ -1224,7 +1229,7 @@ msgstr "Stadt"
 msgid "country"
 msgstr "Land"
 
-#: models/pois/poi.py:27 models/regions/region.py:85
+#: models/pois/poi.py:27 models/regions/region.py:90
 msgid "latitude"
 msgstr "Geographische Breite"
 
@@ -1232,7 +1237,7 @@ msgstr "Geographische Breite"
 msgid "The latitude coordinate"
 msgstr "Die Breitengrad-Koordinate"
 
-#: models/pois/poi.py:30 models/regions/region.py:90
+#: models/pois/poi.py:30 models/regions/region.py:95
 msgid "longitude"
 msgstr "Geographische Länge"
 
@@ -1244,7 +1249,7 @@ msgstr "Die Längengrad-Koordinate"
 msgid "Whether or not the location is read-only and hidden in the API."
 msgstr "Ob der Ort schreibgeschützt und in der API verborgen ist oder nicht."
 
-#: models/pois/poi.py:121
+#: models/pois/poi.py:141
 msgid "locations"
 msgstr "Orte"
 
@@ -1260,144 +1265,144 @@ msgstr ""
 "Kreuzen Sie an, wenn diese Änderung keine Aktualisierung der Übersetzungen "
 "in anderen Sprachen erfordert."
 
-#: models/pois/poi_translation.py:297
+#: models/pois/poi_translation.py:317
 msgid "location translations"
 msgstr "Orts-Übersetzungen"
 
-#: models/push_notifications/push_notification.py:23
+#: models/push_notifications/push_notification.py:24
 msgid "channel"
 msgstr "Kanal"
 
-#: models/push_notifications/push_notification.py:27
+#: models/push_notifications/push_notification.py:28
 msgid "draft"
 msgstr "Entwurf"
 
-#: models/push_notifications/push_notification.py:29
+#: models/push_notifications/push_notification.py:30
 msgid "Whether or not the push notification is a draft (drafts cannot be sent)"
 msgstr ""
 "Ob die Push-Benachrichtigung ein Entwurf ist oder nicht (Entwürfe können "
 "nicht gesendet werden)"
 
-#: models/push_notifications/push_notification.py:37
+#: models/push_notifications/push_notification.py:38
 msgid "The date and time when the push notification was sent."
 msgstr "Datum und Uhrzeit, als die Push-Benachrichtigung gesendet wurde"
 
-#: models/push_notifications/push_notification.py:51
+#: models/push_notifications/push_notification.py:52
 msgid "mode"
 msgstr "Modus"
 
-#: models/push_notifications/push_notification.py:53
+#: models/push_notifications/push_notification.py:54
 msgid ""
 "Sets behavior for dealing with not existing push notification translations"
 msgstr ""
 "Legt das Verhalten für den Umgang mit nicht vorhandenen Übersetzungen von "
 "Push-Benachrichtigungen fest"
 
-#: models/push_notifications/push_notification.py:71
-#: models/push_notifications/push_notification_translation.py:31
+#: models/push_notifications/push_notification.py:85
+#: models/push_notifications/push_notification_translation.py:34
 msgid "push notification"
 msgstr "Push-Benachrichtigung"
 
-#: models/push_notifications/push_notification.py:73
+#: models/push_notifications/push_notification.py:87
 msgid "push notifications"
 msgstr "Push-Benachrichtigungen"
 
-#: models/push_notifications/push_notification_channel.py:23
+#: models/push_notifications/push_notification_channel.py:34
 msgid "push notification channel"
 msgstr "Push-Benachrichtigungskanal"
 
-#: models/push_notifications/push_notification_channel.py:25
-#: models/regions/region.py:79
+#: models/push_notifications/push_notification_channel.py:36
+#: models/regions/region.py:84
 msgid "push notification channels"
 msgstr "Push-Benachrichtigungskanäle"
 
-#: models/push_notifications/push_notification_translation.py:53
+#: models/push_notifications/push_notification_translation.py:67
 msgid "push notification translation"
 msgstr "Push-Benachrichtigungs-Übersetzung"
 
-#: models/push_notifications/push_notification_translation.py:55
+#: models/push_notifications/push_notification_translation.py:69
 msgid "push notification translations"
 msgstr "Push-Benachrichtigungs-Übersetzungen"
 
-#: models/regions/region.py:24
+#: models/regions/region.py:29
 msgid "community identification number"
 msgstr "Amtlicher Gemeindeschlüssel"
 
-#: models/regions/region.py:26
+#: models/regions/region.py:31
 msgid ""
 "Number sequence for identifying politically independent administrative units"
 msgstr ""
 "Ziffernfolge zur Identifizierung politisch selbständiger Verwaltungseinheiten"
 
-#: models/regions/region.py:36 models/users/organization.py:17
+#: models/regions/region.py:41 models/users/organization.py:17
 msgid "Unique string identifier without spaces and special characters."
 msgstr "Eindeutiger Bezeichner ohne Leerzeichen und Sonderzeichen."
 
-#: models/regions/region.py:54
+#: models/regions/region.py:59
 msgid "administrative division"
 msgstr "Verwaltungseinheit"
 
-#: models/regions/region.py:58
+#: models/regions/region.py:63
 msgid "aliases"
 msgstr "Aliasnamen"
 
-#: models/regions/region.py:60
+#: models/regions/region.py:65
 msgid "E.g. smaller municipalities in that area."
 msgstr "Z.B. kleinere Gemeinden in der Region."
 
-#: models/regions/region.py:61
+#: models/regions/region.py:66
 msgid "If empty, the CMS will try to fill this automatically."
 msgstr "Wird, wenn leer, automatisch vom CMS befüllt."
 
-#: models/regions/region.py:68
+#: models/regions/region.py:73
 msgid "activate events"
 msgstr "Veranstaltungen aktivieren"
 
-#: models/regions/region.py:69
+#: models/regions/region.py:74
 msgid "Whether or not events are enabled in the region"
 msgstr "Ob Ereignisse in der Region aktiviert sind oder nicht"
 
-#: models/regions/region.py:73
+#: models/regions/region.py:78
 msgid "activate push notifications"
 msgstr "Push-Benachrichtigungen aktivieren"
 
-#: models/regions/region.py:74
+#: models/regions/region.py:79
 msgid "Whether or not push notifications are enabled in the region"
 msgstr "Ob Push-Benachrichtigungen in der Region aktiviert sind oder nicht"
 
-#: models/regions/region.py:80
+#: models/regions/region.py:85
 msgid "Enter multiple channels separated by commas."
 msgstr "Mehrere Kanäle mit Kommata getrennt eingeben."
 
-#: models/regions/region.py:86
+#: models/regions/region.py:91
 msgid "The latitude coordinate of an approximate center of the region"
 msgstr "Die Breitengrad-Koordinate eines ungefähren Mittelpunkts der Region"
 
-#: models/regions/region.py:91
+#: models/regions/region.py:96
 msgid "The longitude coordinate of an approximate center of the region"
 msgstr "Die Längengrad-Koordinate eines ungefähren Mittelpunkts der Region"
 
-#: models/regions/region.py:96
+#: models/regions/region.py:101
 msgid "email address of the administrator"
 msgstr "E-Mail-Adresse des Administrators"
 
-#: models/regions/region.py:110
+#: models/regions/region.py:115
 msgid "activate statistics"
 msgstr "Statistiken aktivieren"
 
-#: models/regions/region.py:111
+#: models/regions/region.py:116
 msgid "Whether or not statistics are enabled for the region"
 msgstr "Ob Statistiken für die Region aktiviert sind oder nicht"
 
-#: models/regions/region.py:114
+#: models/regions/region.py:119
 msgid "Matomo URL"
 msgstr "Matomo-URL"
 
-#: models/regions/region.py:120
+#: models/regions/region.py:125
 msgid "Matomo authentication token"
 msgstr "Matomo Authentifizierungs-Token"
 
-#: models/regions/region.py:122
+#: models/regions/region.py:127
 msgid ""
 "The secret Matomo access token of the region is used to authenticate in API "
 "requests"
@@ -1405,21 +1410,21 @@ msgstr ""
 "Das geheime Matomo-Zugangs-Token der Region wird zur Authentifizierung bei "
 "API-Anfragen verwendet"
 
-#: models/regions/region.py:127
+#: models/regions/region.py:132
 msgid "activate SSL verification for Matomo"
 msgstr "SSL-Verifikation für Matomo aktivieren"
 
-#: models/regions/region.py:129
+#: models/regions/region.py:134
 msgid "Don't allow invalid SSL-certificates when interacting with Matomo API"
 msgstr ""
 "Erlaube keine ungültigen SSL-Zertifikate bei der Interaktion mit der Matomo "
 "API"
 
-#: models/regions/region.py:135
+#: models/regions/region.py:140
 msgid "activate page-specific permissions"
 msgstr "Seiten-spezifische-Berechtigungen aktivieren"
 
-#: models/regions/region.py:137
+#: models/regions/region.py:142
 msgid ""
 "This allows individual users to be granted the right to edit or publish a "
 "specific page."
@@ -1427,30 +1432,30 @@ msgstr ""
 "Damit kann einzelnen Benutzern das Recht zum Bearbeiten oder Veröffentlichen "
 "einer bestimmten Seite eingeräumt werden."
 
-#: models/regions/region.py:145 models/users/organization.py:23
+#: models/regions/region.py:150 models/users/organization.py:23
 msgid "logo"
 msgstr "Logo"
 
-#: models/regions/region.py:150
+#: models/regions/region.py:155
 msgid "activate author chat"
 msgstr "Autoren-Chat aktivieren"
 
-#: models/regions/region.py:152
+#: models/regions/region.py:157
 msgid ""
 "This gives all users of this region access to the cross-regional author chat."
 msgstr ""
 "Dies gewährt allen Benutzern dieser Region Zugang zum überregionalen Autoren-"
 "Chat."
 
-#: models/regions/region.py:314 models/users/user_profile.py:30
+#: models/regions/region.py:338 models/users/user_profile.py:30
 msgid "regions"
 msgstr "Regionen"
 
-#: models/users/organization.py:46 models/users/user_profile.py:38
+#: models/users/organization.py:57 models/users/user_profile.py:38
 msgid "organization"
 msgstr "Organisation"
 
-#: models/users/organization.py:48
+#: models/users/organization.py:59
 msgid "organizations"
 msgstr "Organisationen"
 
@@ -1478,11 +1483,11 @@ msgstr "Token zur Verhinderung von Replay-Attacken."
 msgid "last date of use"
 msgstr "Letztes Datum der Verwendung"
 
-#: models/users/user_mfa.py:51
+#: models/users/user_mfa.py:64
 msgid "multi-factor authentication key"
 msgstr "Multi-Faktor-Authentifizierungsschlüssel"
 
-#: models/users/user_mfa.py:53
+#: models/users/user_mfa.py:66
 msgid "multi-factor authentication keys"
 msgstr "Multi-Faktor-Authentifizierungsschlüssel"
 
@@ -1511,11 +1516,11 @@ msgstr ""
 "seitenbasierte Berechtigungen, Nicht-Übersetzen-Tag und wiederkehrende "
 "Veranstaltungen"
 
-#: models/users/user_profile.py:113
+#: models/users/user_profile.py:124
 msgid "user profile"
 msgstr "Benutzerprofil"
 
-#: models/users/user_profile.py:115
+#: models/users/user_profile.py:126
 msgid "user profiles"
 msgstr "Benutzerprofile"
 

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-16 17:00+0000\n"
+"POT-Creation-Date: 2021-03-16 17:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -18,8 +18,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: constants/administrative_division.py:38 templates/events/event_form.html:253
-#: templates/pois/poi_list.html:65 templates/pois/poi_list_archived.html:39
+#: constants/administrative_division.py:38 templates/events/event_form.html:252
+#: templates/pois/poi_list.html:63 templates/pois/poi_list_archived.html:37
 msgid "City"
 msgstr "Stadt"
 
@@ -232,7 +232,7 @@ msgid "Hidden"
 msgstr "Versteckt"
 
 #: constants/region_status.py:18 forms/pages/page_form.py:83
-#: forms/pages/page_form.py:110 templates/pages/page_form.html:153
+#: forms/pages/page_form.py:110 templates/pages/page_form.html:152
 #: templates/pages/page_tree_archived_node.html:13
 msgid "Archived"
 msgstr "Archiviert"
@@ -257,46 +257,46 @@ msgstr "Links nach Rechts"
 msgid "Right to left"
 msgstr "Rechts nach Links"
 
-#: constants/translation_status.py:10 templates/events/event_form.html:70
-#: templates/events/event_form.html:99
-#: templates/events/event_list_archived_row.html:61
-#: templates/events/event_list_row.html:53
+#: constants/translation_status.py:10 templates/events/event_form.html:69
+#: templates/events/event_form.html:98
+#: templates/events/event_list_archived_row.html:58
+#: templates/events/event_list_row.html:50
 #: templates/imprint/imprint_form.html:53
 #: templates/imprint/imprint_form.html:82 templates/imprint/imprint_sbs.html:46
-#: templates/imprint/imprint_sbs.html:101 templates/pages/page_form.html:76
-#: templates/pages/page_form.html:98 templates/pages/page_form.html:117
+#: templates/imprint/imprint_sbs.html:101 templates/pages/page_form.html:75
+#: templates/pages/page_form.html:97 templates/pages/page_form.html:116
 #: templates/pages/page_sbs.html:53 templates/pages/page_sbs.html:112
-#: templates/pages/page_tree_archived_node.html:62
-#: templates/pages/page_tree_node.html:88 templates/pois/poi_form.html:59
-#: templates/pois/poi_form.html:88 templates/pois/poi_list_row.html:60
+#: templates/pages/page_tree_archived_node.html:59
+#: templates/pages/page_tree_node.html:78 templates/pois/poi_form.html:58
+#: templates/pois/poi_form.html:87 templates/pois/poi_list_row.html:57
 msgid "Translation up-to-date"
 msgstr "Übersetzung ist aktuell"
 
-#: constants/translation_status.py:11 templates/events/event_form.html:75
-#: templates/events/event_form.html:104
-#: templates/events/event_list_archived_row.html:66
-#: templates/events/event_list_row.html:58
+#: constants/translation_status.py:11 templates/events/event_form.html:74
+#: templates/events/event_form.html:103
+#: templates/events/event_list_archived_row.html:63
+#: templates/events/event_list_row.html:55
 #: templates/imprint/imprint_form.html:58
-#: templates/imprint/imprint_form.html:87 templates/pages/page_form.html:81
-#: templates/pages/page_form.html:122
-#: templates/pages/page_tree_archived_node.html:67
-#: templates/pages/page_tree_node.html:93 templates/pois/poi_form.html:64
-#: templates/pois/poi_form.html:93 templates/pois/poi_list_row.html:65
+#: templates/imprint/imprint_form.html:87 templates/pages/page_form.html:80
+#: templates/pages/page_form.html:121
+#: templates/pages/page_tree_archived_node.html:64
+#: templates/pages/page_tree_node.html:83 templates/pois/poi_form.html:63
+#: templates/pois/poi_form.html:92 templates/pois/poi_list_row.html:62
 msgid "Translation missing"
 msgstr "Übersetzung fehlt"
 
-#: constants/translation_status.py:12 templates/events/event_form.html:62
-#: templates/events/event_form.html:91
-#: templates/events/event_list_archived_row.html:57
-#: templates/events/event_list_row.html:49
+#: constants/translation_status.py:12 templates/events/event_form.html:61
+#: templates/events/event_form.html:90
+#: templates/events/event_list_archived_row.html:54
+#: templates/events/event_list_row.html:46
 #: templates/imprint/imprint_form.html:45
 #: templates/imprint/imprint_form.html:74 templates/imprint/imprint_sbs.html:38
-#: templates/imprint/imprint_sbs.html:93 templates/pages/page_form.html:68
-#: templates/pages/page_form.html:94 templates/pages/page_form.html:109
+#: templates/imprint/imprint_sbs.html:93 templates/pages/page_form.html:67
+#: templates/pages/page_form.html:93 templates/pages/page_form.html:108
 #: templates/pages/page_sbs.html:45 templates/pages/page_sbs.html:104
-#: templates/pages/page_tree_archived_node.html:58
-#: templates/pages/page_tree_node.html:84 templates/pois/poi_form.html:51
-#: templates/pois/poi_form.html:80 templates/pois/poi_list_row.html:56
+#: templates/pages/page_tree_archived_node.html:55
+#: templates/pages/page_tree_node.html:74 templates/pois/poi_form.html:50
+#: templates/pois/poi_form.html:79 templates/pois/poi_list_row.html:53
 msgid "Translation outdated"
 msgstr "Übersetzung ist veraltet"
 
@@ -440,16 +440,16 @@ msgid "Category"
 msgstr "Kategorie"
 
 #: forms/feedback/region_feedback_filter_form.py:31
-#: templates/events/event_form.html:121 templates/events/event_list.html:50
+#: templates/events/event_form.html:120 templates/events/event_list.html:50
 #: templates/events/event_list_archived.html:35
 #: templates/imprint/imprint_form.html:105
 #: templates/imprint/imprint_revisions.html:42
 #: templates/imprint/imprint_sbs.html:58 templates/imprint/imprint_sbs.html:121
-#: templates/imprint/imprint_sbs.html:136 templates/pages/page_form.html:151
+#: templates/imprint/imprint_sbs.html:136 templates/pages/page_form.html:150
 #: templates/pages/page_revisions.html:44 templates/pages/page_sbs.html:65
 #: templates/pages/page_sbs.html:132 templates/pages/page_sbs.html:137
 #: templates/pages/page_tree.html:67 templates/pages/page_tree_archived.html:26
-#: templates/pois/poi_form.html:110 templates/pois/poi_list.html:45
+#: templates/pois/poi_form.html:109 templates/pois/poi_list.html:45
 #: templates/pois/poi_list_archived.html:28
 #: templates/regions/region_list.html:32
 msgid "Status"
@@ -587,7 +587,7 @@ msgstr "Einstellungen"
 msgid "region"
 msgstr "Region"
 
-#: models/events/event.py:31 models/pois/poi.py:102
+#: models/events/event.py:31 models/pois/poi.py:119
 #: models/pois/poi_translation.py:35
 msgid "location"
 msgstr "Ort"
@@ -620,11 +620,11 @@ msgstr "Icon"
 msgid "archived"
 msgstr "archiviert"
 
-#: models/events/event.py:212 models/events/event_translation.py:23
+#: models/events/event.py:229 models/events/event_translation.py:23
 msgid "event"
 msgstr "Veranstaltung"
 
-#: models/events/event.py:214
+#: models/events/event.py:231
 msgid "events"
 msgstr "Veranstaltungen"
 
@@ -875,7 +875,7 @@ msgstr "Angebotslisten-Feedback"
 
 #: models/feedback/page_feedback.py:18
 #: models/pages/abstract_base_page_translation.py:304
-#: models/pages/page_translation.py:244
+#: models/pages/page_translation.py:246
 msgid "page translation"
 msgstr "Seiten-Übersetzung"
 
@@ -1088,12 +1088,12 @@ msgstr "explizit archiviert"
 msgid "Whether or not the page is explicitly archived"
 msgstr "Ob die Seite explizit archiviert ist oder nicht"
 
-#: models/pages/abstract_base_page.py:145 models/pages/page.py:172
+#: models/pages/abstract_base_page.py:139 models/pages/page.py:172
 #: models/pages/page_translation.py:38
 msgid "page"
 msgstr "Seite"
 
-#: models/pages/abstract_base_page.py:147 models/pages/page.py:174
+#: models/pages/abstract_base_page.py:141 models/pages/page.py:174
 msgid "pages"
 msgstr "Seiten"
 
@@ -1110,7 +1110,7 @@ msgid "version"
 msgstr "Version"
 
 #: models/pages/abstract_base_page_translation.py:306
-#: models/pages/page_translation.py:246
+#: models/pages/page_translation.py:248
 msgid "page translations"
 msgstr "Seiten-Übersetzungen"
 
@@ -1244,7 +1244,7 @@ msgstr "Die Längengrad-Koordinate"
 msgid "Whether or not the location is read-only and hidden in the API."
 msgstr "Ob der Ort schreibgeschützt und in der API verborgen ist oder nicht."
 
-#: models/pois/poi.py:104
+#: models/pois/poi.py:121
 msgid "locations"
 msgstr "Orte"
 
@@ -1700,20 +1700,18 @@ msgid "Translations up-to-date"
 msgstr "Aktuelle Übersetzungen"
 
 #: templates/analytics/translation_coverage.html:46
-#: templates/events/event_form.html:66 templates/events/event_form.html:95
-#: templates/events/event_list_archived_row.html:53
-#: templates/events/event_list_row.html:45
+#: templates/events/event_form.html:65 templates/events/event_form.html:94
+#: templates/events/event_list_archived_row.html:50
+#: templates/events/event_list_row.html:42
 #: templates/imprint/imprint_form.html:49
 #: templates/imprint/imprint_form.html:78 templates/imprint/imprint_sbs.html:42
-#: templates/imprint/imprint_sbs.html:97 templates/pages/page_form.html:72
-#: templates/pages/page_form.html:113 templates/pages/page_sbs.html:49
+#: templates/imprint/imprint_sbs.html:97 templates/pages/page_form.html:71
+#: templates/pages/page_form.html:112 templates/pages/page_sbs.html:49
 #: templates/pages/page_sbs.html:108
-#: templates/pages/page_tree_archived_node.html:54
-#: templates/pages/page_tree_node.html:57
-#: templates/pages/page_tree_node.html:64
-#: templates/pages/page_tree_node.html:80
-#: templates/pages/page_tree_node.html:99 templates/pois/poi_form.html:55
-#: templates/pois/poi_form.html:84 templates/pois/poi_list_row.html:52
+#: templates/pages/page_tree_archived_node.html:51
+#: templates/pages/page_tree_node.html:70
+#: templates/pages/page_tree_node.html:89 templates/pois/poi_form.html:54
+#: templates/pois/poi_form.html:83 templates/pois/poi_list_row.html:49
 msgid "Currently in translation"
 msgstr "Wird derzeit übersetzt"
 
@@ -1944,15 +1942,15 @@ msgid "Not after"
 msgstr "Nicht nach"
 
 #: templates/events/_event_filter_form.html:34
-#: templates/events/event_form.html:317 templates/imprint/imprint_form.html:222
-#: templates/imprint/imprint_sbs.html:163 templates/pages/page_form.html:422
-#: templates/pages/page_sbs.html:173 templates/pois/poi_form.html:219
+#: templates/events/event_form.html:316 templates/imprint/imprint_form.html:222
+#: templates/imprint/imprint_sbs.html:163 templates/pages/page_form.html:421
+#: templates/pages/page_sbs.html:173 templates/pois/poi_form.html:218
 msgid "Location"
 msgstr "Ort"
 
 #: templates/events/_event_filter_form.html:35
-#: templates/events/event_list.html:68
-#: templates/events/event_list_archived.html:53
+#: templates/events/event_list.html:66
+#: templates/events/event_list_archived.html:51
 msgid "Event location"
 msgstr "Veranstaltungsort"
 
@@ -2001,168 +1999,168 @@ msgstr "Ort mit Titel \"%(poi_query)s\" erstellen"
 msgid "Edit event \"%(event_title)s\""
 msgstr "Event \"%(event_title)s\" bearbeiten"
 
-#: templates/events/event_form.html:26 templates/events/event_list.html:51
-#: templates/events/event_list.html:56
+#: templates/events/event_form.html:25 templates/events/event_list.html:51
+#: templates/events/event_list.html:55
 #: templates/events/event_list_archived.html:36
-#: templates/events/event_list_archived.html:41
-#: templates/pages/page_form.html:26 templates/pages/page_tree.html:68
-#: templates/pages/page_tree.html:73 templates/pages/page_tree_archived.html:27
-#: templates/pages/page_tree_archived.html:32 templates/pois/poi_form.html:27
-#: templates/pois/poi_list.html:46 templates/pois/poi_list.html:51
+#: templates/events/event_list_archived.html:40
+#: templates/pages/page_form.html:25 templates/pages/page_tree.html:68
+#: templates/pages/page_tree.html:72 templates/pages/page_tree_archived.html:27
+#: templates/pages/page_tree_archived.html:31 templates/pois/poi_form.html:26
+#: templates/pois/poi_list.html:46 templates/pois/poi_list.html:50
 #: templates/pois/poi_list_archived.html:29
-#: templates/pois/poi_list_archived.html:34
+#: templates/pois/poi_list_archived.html:33
 msgid "Title in"
 msgstr "Titel auf"
 
-#: templates/events/event_form.html:30
+#: templates/events/event_form.html:29
 msgid "Create new event translation"
 msgstr "Neue Event-Übersetzung erstellen"
 
-#: templates/events/event_form.html:33
+#: templates/events/event_form.html:32
 msgid "Create new event"
 msgstr "Veranstaltung erstellen"
 
-#: templates/events/event_form.html:41 templates/imprint/imprint_form.html:29
-#: templates/imprint/imprint_sbs.html:25 templates/pages/page_form.html:40
-#: templates/pages/page_sbs.html:26 templates/pois/poi_form.html:36
+#: templates/events/event_form.html:40 templates/imprint/imprint_form.html:29
+#: templates/imprint/imprint_sbs.html:25 templates/pages/page_form.html:39
+#: templates/pages/page_sbs.html:26 templates/pois/poi_form.html:35
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
 
-#: templates/events/event_form.html:44 templates/imprint/imprint_form.html:30
-#: templates/imprint/imprint_sbs.html:26 templates/pages/page_form.html:48
-#: templates/pages/page_sbs.html:30 templates/pois/poi_form.html:37
+#: templates/events/event_form.html:43 templates/imprint/imprint_form.html:30
+#: templates/imprint/imprint_sbs.html:26 templates/pages/page_form.html:47
+#: templates/pages/page_sbs.html:30 templates/pois/poi_form.html:36
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: templates/events/event_form.html:46 templates/pages/page_form.html:51
+#: templates/events/event_form.html:45 templates/pages/page_form.html:50
 #: templates/pages/page_sbs.html:32
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
-#: templates/events/event_form.html:80 templates/imprint/imprint_form.html:63
-#: templates/imprint/imprint_sbs.html:106 templates/pages/page_form.html:86
-#: templates/pages/page_sbs.html:117 templates/pois/poi_form.html:69
+#: templates/events/event_form.html:79 templates/imprint/imprint_form.html:63
+#: templates/imprint/imprint_sbs.html:106 templates/pages/page_form.html:85
+#: templates/pages/page_sbs.html:117 templates/pois/poi_form.html:68
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
 
-#: templates/events/event_form.html:119
+#: templates/events/event_form.html:118
 #: templates/events/event_list_archived.html:34
 #: templates/imprint/imprint_sbs.html:56 templates/imprint/imprint_sbs.html:119
-#: templates/imprint/imprint_sbs.html:134 templates/pages/page_form.html:135
+#: templates/imprint/imprint_sbs.html:134 templates/pages/page_form.html:134
 #: templates/pages/page_sbs.html:63 templates/pages/page_sbs.html:130
-#: templates/pages/page_sbs.html:135 templates/pois/poi_form.html:108
+#: templates/pages/page_sbs.html:135 templates/pois/poi_form.html:107
 #: templates/pois/poi_list.html:44 templates/pois/poi_list_archived.html:27
 msgid "Version"
 msgstr "Version"
 
-#: templates/events/event_form.html:141 templates/imprint/imprint_form.html:122
-#: templates/imprint/imprint_sbs.html:147 templates/pages/page_form.html:224
-#: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:129
+#: templates/events/event_form.html:140 templates/imprint/imprint_form.html:122
+#: templates/imprint/imprint_sbs.html:147 templates/pages/page_form.html:223
+#: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:128
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
-#: templates/events/event_form.html:154 templates/imprint/imprint_form.html:167
-#: templates/pois/poi_form.html:142
+#: templates/events/event_form.html:153 templates/imprint/imprint_form.html:167
+#: templates/pois/poi_form.html:141
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
 
-#: templates/events/event_form.html:186
+#: templates/events/event_form.html:185
 msgid "Recurrence"
 msgstr "Wiederholung"
 
-#: templates/events/event_form.html:232
+#: templates/events/event_form.html:231
 msgid "Where"
 msgstr "Wo"
 
-#: templates/events/event_form.html:235
+#: templates/events/event_form.html:234
 msgid "Name of event location"
 msgstr "Name des Veranstaltungsortes"
 
-#: templates/events/event_form.html:239
+#: templates/events/event_form.html:238
 msgid "Remove location from event"
 msgstr "Veranstaltungsort von Veranstaltung entfernen"
 
-#: templates/events/event_form.html:248
+#: templates/events/event_form.html:247
 msgid ""
 "Create an event location or start typing the name of an existing location"
 msgstr ""
 "Erstelle einen Veranstaltungsort oder beginne den Namen eines bestehenden "
 "Veranstaltungsortes einzutippen"
 
-#: templates/events/event_form.html:251 templates/pois/poi_list.html:63
-#: templates/pois/poi_list_archived.html:37
+#: templates/events/event_form.html:250 templates/pois/poi_list.html:61
+#: templates/pois/poi_list_archived.html:35
 msgid "Street"
 msgstr "Straße"
 
-#: templates/events/event_form.html:255 templates/pois/poi_list.html:66
-#: templates/pois/poi_list_archived.html:40
+#: templates/events/event_form.html:254 templates/pois/poi_list.html:64
+#: templates/pois/poi_list_archived.html:38
 msgid "Country"
 msgstr "Land"
 
-#: templates/events/event_form.html:258
+#: templates/events/event_form.html:257
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:267
-#: templates/events/event_list_archived_row.html:96
+#: templates/events/event_form.html:266
+#: templates/events/event_list_archived_row.html:93
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:274
+#: templates/events/event_form.html:273
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:277 templates/events/event_list_row.html:91
+#: templates/events/event_form.html:276 templates/events/event_list_row.html:88
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
-#: templates/events/event_form.html:284
+#: templates/events/event_form.html:283
 msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
-#: templates/events/event_form.html:290
-#: templates/events/event_list_archived_row.html:105
-#: templates/events/event_list_row.html:100
+#: templates/events/event_form.html:289
+#: templates/events/event_list_archived_row.html:102
+#: templates/events/event_list_row.html:97
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
-#: templates/events/event_form.html:297
+#: templates/events/event_form.html:296
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
-#: templates/events/event_form.html:316 templates/imprint/imprint_form.html:221
-#: templates/imprint/imprint_sbs.html:162 templates/pages/page_form.html:421
-#: templates/pages/page_sbs.html:172 templates/pois/poi_form.html:218
+#: templates/events/event_form.html:315 templates/imprint/imprint_form.html:221
+#: templates/imprint/imprint_sbs.html:162 templates/pages/page_form.html:420
+#: templates/pages/page_sbs.html:172 templates/pois/poi_form.html:217
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/events/event_form.html:319 templates/imprint/imprint_form.html:224
-#: templates/imprint/imprint_sbs.html:165 templates/pages/page_form.html:424
-#: templates/pages/page_sbs.html:175 templates/pois/poi_form.html:221
+#: templates/events/event_form.html:318 templates/imprint/imprint_form.html:224
+#: templates/imprint/imprint_sbs.html:165 templates/pages/page_form.html:423
+#: templates/pages/page_sbs.html:175 templates/pois/poi_form.html:220
 msgid "Link"
 msgstr "Link"
 
-#: templates/events/event_form.html:321 templates/imprint/imprint_form.html:226
-#: templates/imprint/imprint_sbs.html:167 templates/pages/page_form.html:426
-#: templates/pages/page_sbs.html:177 templates/pois/poi_form.html:223
+#: templates/events/event_form.html:320 templates/imprint/imprint_form.html:226
+#: templates/imprint/imprint_sbs.html:167 templates/pages/page_form.html:425
+#: templates/pages/page_sbs.html:177 templates/pois/poi_form.html:222
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/events/event_form.html:323 templates/imprint/imprint_form.html:228
-#: templates/imprint/imprint_sbs.html:169 templates/pages/page_form.html:428
-#: templates/pages/page_sbs.html:179 templates/pois/poi_form.html:225
+#: templates/events/event_form.html:322 templates/imprint/imprint_form.html:228
+#: templates/imprint/imprint_sbs.html:169 templates/pages/page_form.html:427
+#: templates/pages/page_sbs.html:179 templates/pois/poi_form.html:224
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/events/event_form.html:325 templates/imprint/imprint_form.html:230
-#: templates/imprint/imprint_sbs.html:171 templates/pages/page_form.html:430
-#: templates/pages/page_sbs.html:181 templates/pois/poi_form.html:227
+#: templates/events/event_form.html:324 templates/imprint/imprint_form.html:230
+#: templates/imprint/imprint_sbs.html:171 templates/pages/page_form.html:429
+#: templates/pages/page_sbs.html:181 templates/pois/poi_form.html:226
 msgid "Email"
 msgstr "Email"
 
-#: templates/events/event_form.html:327 templates/imprint/imprint_form.html:232
-#: templates/imprint/imprint_sbs.html:173 templates/pages/page_form.html:432
-#: templates/pages/page_sbs.html:183 templates/pois/poi_form.html:229
+#: templates/events/event_form.html:326 templates/imprint/imprint_form.html:232
+#: templates/imprint/imprint_sbs.html:173 templates/pages/page_form.html:431
+#: templates/pages/page_sbs.html:183 templates/pois/poi_form.html:228
 msgid "Hint"
 msgstr "Tipp"
 
@@ -2176,33 +2174,33 @@ msgstr "Archivierte Veranstaltungen"
 msgid "Filter events"
 msgstr "Veranstaltungen filtern"
 
-#: templates/events/event_list.html:69
-#: templates/events/event_list_archived.html:54
+#: templates/events/event_list.html:67
+#: templates/events/event_list_archived.html:52
 msgid "Start"
 msgstr "Beginn"
 
-#: templates/events/event_list.html:70
-#: templates/events/event_list_archived.html:55
+#: templates/events/event_list.html:68
+#: templates/events/event_list_archived.html:53
 msgid "End"
 msgstr "Ende"
 
-#: templates/events/event_list.html:71
-#: templates/events/event_list_archived.html:56
+#: templates/events/event_list.html:69
+#: templates/events/event_list_archived.html:54
 #: templates/languages/language_list.html:32
 #: templates/offer_templates/offer_template_list.html:29
 #: templates/organizations/organization_list.html:27
-#: templates/pages/page_tree.html:86 templates/pages/page_tree_archived.html:44
-#: templates/pois/poi_list.html:67 templates/pois/poi_list_archived.html:41
+#: templates/pages/page_tree.html:84 templates/pages/page_tree_archived.html:42
+#: templates/pois/poi_list.html:65 templates/pois/poi_list_archived.html:39
 #: templates/roles/list.html:25
 msgid "Options"
 msgstr "Optionen"
 
-#: templates/events/event_list.html:85
-#: templates/events/event_list_archived.html:70
+#: templates/events/event_list.html:83
+#: templates/events/event_list_archived.html:68
 msgid "No events found with these filters."
 msgstr "Keine Veranstaltungen mit diesem Filter gefunden."
 
-#: templates/events/event_list.html:87
+#: templates/events/event_list.html:85
 msgid "No events available yet."
 msgstr "Noch keine Veranstaltungen vorhanden."
 
@@ -2211,30 +2209,30 @@ msgstr "Noch keine Veranstaltungen vorhanden."
 msgid "ID"
 msgstr "ID"
 
-#: templates/events/event_list_archived.html:72
+#: templates/events/event_list_archived.html:70
 msgid "No events archived yet."
 msgstr "Noch keine Veranstaltungen archiviert."
 
 #: templates/events/event_list_archived_row.html:25
-#: templates/events/event_list_archived_row.html:39
+#: templates/events/event_list_archived_row.html:37
 #: templates/events/event_list_row.html:17
-#: templates/events/event_list_row.html:31
+#: templates/events/event_list_row.html:29
 #: templates/pages/page_tree_archived_node.html:26
-#: templates/pages/page_tree_archived_node.html:40
+#: templates/pages/page_tree_archived_node.html:38
 #: templates/pages/page_tree_node.html:41
-#: templates/pages/page_tree_node.html:60
+#: templates/pages/page_tree_node.html:54
 #: templates/pois/poi_list_archived_row.html:24
-#: templates/pois/poi_list_archived_row.html:38
-#: templates/pois/poi_list_row.html:24 templates/pois/poi_list_row.html:38
+#: templates/pois/poi_list_archived_row.html:36
+#: templates/pois/poi_list_row.html:24 templates/pois/poi_list_row.html:36
 msgid "Translation not available"
 msgstr "Übersetzung nicht verfügbar"
 
-#: templates/events/event_list_archived_row.html:80
-#: templates/events/event_list_row.html:72
+#: templates/events/event_list_archived_row.html:77
+#: templates/events/event_list_row.html:69
 msgid "Not specified"
 msgstr "Nicht festgelegt"
 
-#: templates/events/event_list_row.html:88
+#: templates/events/event_list_row.html:85
 msgid "Edit event"
 msgstr "Veranstaltung bearbeiten"
 
@@ -2284,7 +2282,7 @@ msgstr "Noch kein technisches Feedback vorhanden."
 
 #: templates/feedback/admin_feedback_list.html:128
 #: templates/feedback/region_feedback_list.html:122
-#: templates/pages/page_tree.html:116
+#: templates/pages/page_tree.html:114
 msgid "Select bulk action"
 msgstr "Mehrfachaktion auswählen"
 
@@ -2306,7 +2304,7 @@ msgstr "Löschen"
 
 #: templates/feedback/admin_feedback_list.html:139
 #: templates/feedback/region_feedback_list.html:133
-#: templates/pages/page_tree.html:131
+#: templates/pages/page_tree.html:129
 msgid "Execute"
 msgstr "Ausführen"
 
@@ -2319,7 +2317,7 @@ msgid "No feedback available yet."
 msgstr "Noch kein Feedback vorhanden."
 
 #: templates/generic_confirmation_dialog.html:11
-#: templates/pages/page_form.html:172
+#: templates/pages/page_form.html:171
 msgid "Warning"
 msgstr "Warnung"
 
@@ -2387,13 +2385,13 @@ msgstr "Permalink"
 #: templates/imprint/imprint_form.html:114
 #: templates/imprint/imprint_sbs.html:62 templates/imprint/imprint_sbs.html:67
 #: templates/imprint/imprint_sbs.html:125
-#: templates/imprint/imprint_sbs.html:130 templates/pages/page_form.html:166
+#: templates/imprint/imprint_sbs.html:130 templates/pages/page_form.html:165
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
 #: templates/imprint/imprint_form.html:112
 #: templates/imprint/imprint_sbs.html:65 templates/imprint/imprint_sbs.html:128
-#: templates/imprint/imprint_sbs.html:140 templates/pages/page_form.html:164
+#: templates/imprint/imprint_sbs.html:140 templates/pages/page_form.html:163
 msgid "Short URL"
 msgstr "Kurz-URL"
 
@@ -2401,7 +2399,7 @@ msgstr "Kurz-URL"
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: templates/imprint/imprint_form.html:143 templates/pages/page_form.html:394
+#: templates/imprint/imprint_form.html:143 templates/pages/page_form.html:393
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
@@ -2620,7 +2618,7 @@ msgstr "Erstellt"
 
 #: templates/languages/language_list.html:31
 #: templates/offer_templates/offer_template_list.html:27
-#: templates/pages/page_tree.html:85 templates/regions/region_list.html:31
+#: templates/pages/page_tree.html:83 templates/regions/region_list.html:31
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
@@ -2699,7 +2697,7 @@ msgstr "Angebots-Vorlagen verwalten"
 msgid "Active since"
 msgstr "Aktiv seit"
 
-#: templates/offers/offer_list.html:33 templates/pages/page_form.html:304
+#: templates/offers/offer_list.html:33 templates/pages/page_form.html:303
 #: templates/regions/region_list.html:33 templates/settings/user.html:59
 msgid "Actions"
 msgstr "Aktionen"
@@ -2785,60 +2783,60 @@ msgstr "Erlaubnis zum Veröffentlichen erteilen"
 msgid "Edit page \"%(page_title)s\""
 msgstr "Seite \"%(page_title)s\" bearbeiten"
 
-#: templates/pages/page_form.html:30
+#: templates/pages/page_form.html:29
 msgid "Create new translation"
 msgstr "Neue Übersetzung erstellen"
 
-#: templates/pages/page_form.html:33
+#: templates/pages/page_form.html:32
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: templates/pages/page_form.html:46
+#: templates/pages/page_form.html:45
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: templates/pages/page_form.html:138
+#: templates/pages/page_form.html:137
 msgid "Show versions"
 msgstr "Versionen anzeigen"
 
-#: templates/pages/page_form.html:155
+#: templates/pages/page_form.html:154
 #: templates/pages/page_tree_archived_node.html:17
 msgid "Archived, because a parent page is archived"
 msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 
-#: templates/pages/page_form.html:173
+#: templates/pages/page_form.html:172
 msgid "Translation in progress"
 msgstr "Übersetzung wird durchgeführt"
 
-#: templates/pages/page_form.html:181
+#: templates/pages/page_form.html:180
 msgid "Abort translation process"
 msgstr "Übersetzungsprozess abbrechen"
 
-#: templates/pages/page_form.html:218
+#: templates/pages/page_form.html:217
 msgid "Minor edit"
 msgstr "Geringfügige Änderung"
 
-#: templates/pages/page_form.html:234
+#: templates/pages/page_form.html:233
 msgid "Settings of the page"
 msgstr "Einstellungen der Seite"
 
-#: templates/pages/page_form.html:241
+#: templates/pages/page_form.html:240
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page_form.html:251
+#: templates/pages/page_form.html:250
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: templates/pages/page_form.html:256
+#: templates/pages/page_form.html:255
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:275
+#: templates/pages/page_form.html:274
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:276
+#: templates/pages/page_form.html:275
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -2846,17 +2844,17 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:312 templates/pages/page_form.html:313
-#: templates/pages/page_form.html:321
-#: templates/pages/page_tree_archived_node.html:83
+#: templates/pages/page_form.html:311 templates/pages/page_form.html:312
+#: templates/pages/page_form.html:320
+#: templates/pages/page_tree_archived_node.html:80
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:318
+#: templates/pages/page_form.html:317
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:324
+#: templates/pages/page_form.html:323
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -2867,28 +2865,28 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
-#: templates/pages/page_form.html:337 templates/pages/page_form.html:338
-#: templates/pages/page_tree_node.html:123
+#: templates/pages/page_form.html:336 templates/pages/page_form.html:337
+#: templates/pages/page_tree_node.html:113
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:344
+#: templates/pages/page_form.html:343
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:350 templates/pages/page_form.html:368
-#: templates/pages/page_tree_archived_node.html:101
-#: templates/pages/page_tree_node.html:136
+#: templates/pages/page_form.html:349 templates/pages/page_form.html:367
+#: templates/pages/page_tree_archived_node.html:98
+#: templates/pages/page_tree_node.html:126
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:354
-#: templates/pages/page_tree_archived_node.html:97
-#: templates/pages/page_tree_node.html:132 views/pages/page_actions.py:212
+#: templates/pages/page_form.html:353
+#: templates/pages/page_tree_archived_node.html:94
+#: templates/pages/page_tree_node.html:122 views/pages/page_actions.py:212
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:355
+#: templates/pages/page_form.html:354
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -2899,15 +2897,15 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: templates/pages/page_form.html:374
+#: templates/pages/page_form.html:373
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: templates/pages/page_form.html:387
+#: templates/pages/page_form.html:386
 msgid "Translator view"
 msgstr "Übersetzeransicht"
 
-#: templates/pages/page_form.html:408
+#: templates/pages/page_form.html:407
 msgid "Show translator view"
 msgstr "Übersetzeransicht anzeigen"
 
@@ -2951,27 +2949,27 @@ msgstr "Sie können Seiten nur in der Standard-Sprache anlegen"
 msgid "Hierarchy"
 msgstr "Hierarchie"
 
-#: templates/pages/page_tree.html:106
+#: templates/pages/page_tree.html:104
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
-#: templates/pages/page_tree.html:117
+#: templates/pages/page_tree.html:115
 msgid "Archive pages"
 msgstr "Seiten archivieren"
 
-#: templates/pages/page_tree.html:118
+#: templates/pages/page_tree.html:116
 msgid "Export as PDF"
 msgstr "Als PDF Exportieren"
 
-#: templates/pages/page_tree.html:122
+#: templates/pages/page_tree.html:120
 msgid "Export XLIFF for translation to"
 msgstr "Exportiere XLIFF für Übersetzung nach"
 
-#: templates/pages/page_tree.html:137
+#: templates/pages/page_tree.html:135
 msgid "Upload XLIFF File"
 msgstr "XLIFF-Datei hochladen"
 
-#: templates/pages/page_tree.html:147
+#: templates/pages/page_tree.html:145
 msgid "Upload"
 msgstr "Hochladen"
 
@@ -2979,7 +2977,7 @@ msgstr "Hochladen"
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: templates/pages/page_tree_archived.html:59
+#: templates/pages/page_tree_archived.html:57
 msgid "No pages archived yet."
 msgstr "Noch keine Seiten archiviert."
 
@@ -2998,18 +2996,18 @@ msgstr ""
 "Diese Seite ist archiviert, weil eine ihrer übergeordneten Seiten archiviert "
 "ist."
 
-#: templates/pages/page_tree_archived_node.html:79
-#: templates/pages/page_tree_node.html:116
+#: templates/pages/page_tree_archived_node.html:76
+#: templates/pages/page_tree_node.html:106
 msgid "View page"
 msgstr "Seite ansehen"
 
-#: templates/pages/page_tree_archived_node.html:91
+#: templates/pages/page_tree_archived_node.html:88
 msgid "To restore this page, you have to restore its archived parent page."
 msgstr ""
 "Um diese Seite wiederherzustellen, müssen Sie ihre archivierte übergeordnete "
 "Seite wiederherstellen."
 
-#: templates/pages/page_tree_archived_node.html:97
+#: templates/pages/page_tree_archived_node.html:94
 msgid "This also involves non-archived subpages."
 msgstr "Dies betrifft auch nicht-archivierte Unterseiten."
 
@@ -3025,19 +3023,19 @@ msgstr "Drag & drop nicht möglich, wenn Filter aktiv sind"
 msgid "Collapse all subpages"
 msgstr "Alle Unterseiten einklappen"
 
-#: templates/pages/page_tree_node.html:119
+#: templates/pages/page_tree_node.html:109
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 
-#: templates/pages/page_tree_node.html:132
+#: templates/pages/page_tree_node.html:122
 msgid "This also involves archived subpages."
 msgstr "Dies betrifft auch archivierte Unterseiten."
 
-#: templates/pages/page_tree_node.html:146
+#: templates/pages/page_tree_node.html:136
 msgid "Copy short link"
 msgstr "Kurz-URL kopieren"
 
-#: templates/pages/page_tree_node.html:150
+#: templates/pages/page_tree_node.html:140
 msgid "You cannot copy a short link of a page which has no translation."
 msgstr "Sie können keine Kurz-URL zu einer fehlenden Übersetzung kopieren."
 
@@ -3097,43 +3095,43 @@ msgstr "Ort \"%(poi_title)s\" bearbeiten"
 msgid "Create new translation of the location"
 msgstr "Neue Übersetzung des Ortes erstellen"
 
-#: templates/pois/poi_form.html:30
+#: templates/pois/poi_form.html:29
 msgid "Create new location"
 msgstr "Neuen Ort erstellen"
 
-#: templates/pois/poi_form.html:150
+#: templates/pois/poi_form.html:149
 msgid "Address"
 msgstr "Adresse"
 
-#: templates/pois/poi_form.html:161
+#: templates/pois/poi_form.html:160
 msgid "Position"
 msgstr "Position"
 
-#: templates/pois/poi_form.html:176 templates/pois/poi_form.html:177
-#: templates/pois/poi_list_archived_row.html:57
+#: templates/pois/poi_form.html:175 templates/pois/poi_form.html:176
+#: templates/pois/poi_list_archived_row.html:54
 msgid "Restore location"
 msgstr "Ort wiederherstellen"
 
-#: templates/pois/poi_form.html:182
+#: templates/pois/poi_form.html:181
 msgid "Restore this location"
 msgstr "Diesen Ort wiederherstellen"
 
-#: templates/pois/poi_form.html:185 templates/pois/poi_form.html:186
-#: templates/pois/poi_list_row.html:91
+#: templates/pois/poi_form.html:184 templates/pois/poi_form.html:185
+#: templates/pois/poi_list_row.html:88
 msgid "Archive location"
 msgstr "Ort archivieren"
 
-#: templates/pois/poi_form.html:191
+#: templates/pois/poi_form.html:190
 msgid "Archive this location"
 msgstr "Diesen Ort archivieren"
 
-#: templates/pois/poi_form.html:197 templates/pois/poi_form.html:198
-#: templates/pois/poi_list_archived_row.html:65
-#: templates/pois/poi_list_row.html:99
+#: templates/pois/poi_form.html:196 templates/pois/poi_form.html:197
+#: templates/pois/poi_list_archived_row.html:62
+#: templates/pois/poi_list_row.html:96
 msgid "Delete location"
 msgstr "Ort löschen"
 
-#: templates/pois/poi_form.html:203
+#: templates/pois/poi_form.html:202
 msgid "Delete this location"
 msgstr "Diesen Ort löschen"
 
@@ -3141,15 +3139,15 @@ msgstr "Diesen Ort löschen"
 msgid "Archived locations"
 msgstr "Archivierte Orte"
 
-#: templates/pois/poi_list.html:64 templates/pois/poi_list_archived.html:38
+#: templates/pois/poi_list.html:62 templates/pois/poi_list_archived.html:36
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
-#: templates/pois/poi_list.html:77
+#: templates/pois/poi_list.html:75
 msgid "No locations available yet."
 msgstr "Noch keine Orte vorhanden."
 
-#: templates/pois/poi_list_archived.html:51
+#: templates/pois/poi_list_archived.html:49
 msgid "No locations archived yet."
 msgstr "Noch keine Orte archiviert."
 

--- a/src/cms/models/chat/chat_message.py
+++ b/src/cms/models/chat/chat_message.py
@@ -54,15 +54,23 @@ class ChatMessage(models.Model):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <ChatMessage object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``ChatMessage object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation of the chat message with information about sender, sent_datetime and text
-                 (useful for debugging purposes)
+        :return: A readable string representation of the chat message
         :rtype: str
         """
-        return "{} ({}): {}".format(
-            self.sender, self.sent_datetime.strftime("%Y-%m-%d %H:%M"), self.text
-        )
+        return f"{self.sent_datetime.strftime('%Y-%m-%d %H:%M')} - {self.sender.profile.full_user_name}: {self.text}"
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<ChatMessage: ChatMessage object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the chat message
+        :rtype: str
+        """
+        return f"<ChatMessage (id: {self.id}, sender: {self.sender.username}, date: {self.sent_datetime.strftime('%Y-%m-%d %H:%M')})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/config/configuration.py
+++ b/src/cms/models/config/configuration.py
@@ -23,6 +23,26 @@ class Configuration(models.Model):
         verbose_name=_("modification date"),
     )
 
+    def __str__(self):
+        """
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``Configuration object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
+
+        :return: A readable string representation of the configuration
+        :rtype: str
+        """
+        return f"{self.key}: {self.value}"
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<Configuration: Configuration object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the configuration
+        :rtype: str
+        """
+        return f"<Configuration (id: {self.id}, key: {self.key}, value: {self.value})>"
+
     class Meta:
         #: The verbose name of the model
         verbose_name = _("configuration")

--- a/src/cms/models/events/event.py
+++ b/src/cms/models/events/event.py
@@ -194,18 +194,35 @@ class Event(models.Model):
     @property
     def backend_translation(self):
         """
-        This function tries to determine which translation to be used for showing an event in the backend.
-        The first priority is the current backend language.
-        If no translation is present in this language, the fallback is the region's default language.
+        This function returns the translation of this event in the current backend language.
+
+        :return: The backend translation of a event
+        :rtype: ~cms.models.events.event_translation.EventTranslation
+        """
+        return self.translations.filter(language__slug=get_language()).first()
+
+    @property
+    def default_translation(self):
+        """
+        This function returns the translation of this event in the region's default language.
+        Since an event can only be created by creating a translation in the default language, this is guaranteed to return
+        an event translation.
+
+        :return: The default translation of an event
+        :rtype: ~cms.models.events.event_translation.EventTranslation
+        """
+        return self.translations.filter(language=self.region.default_language).first()
+
+    @property
+    def best_translation(self):
+        """
+        This function returns the translation of this event in the current backend language and if it doesn't exist, it
+        provides a fallback to the translation in the region's default language.
 
         :return: The "best" translation of an event for displaying in the backend
         :rtype: ~cms.models.events.event_translation.EventTranslation
         """
-        event_translation = self.translations.filter(language__slug=get_language())
-        if not event_translation.exists():
-            alt_slug = self.region.default_language.slug
-            event_translation = self.translations.filter(language__slug=alt_slug)
-        return event_translation.first()
+        return self.backend_translation or self.default_translation
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/events/event.py
+++ b/src/cms/models/events/event.py
@@ -224,6 +224,26 @@ class Event(models.Model):
         """
         return self.backend_translation or self.default_translation
 
+    def __str__(self):
+        """
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``Event object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
+
+        :return: A readable string representation of the event
+        :rtype: str
+        """
+        return self.best_translation.title
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<Event: Event object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the event
+        :rtype: str
+        """
+        return f"<Event (id: {self.id}, region: {self.region.slug}, slug: {self.best_translation.slug})>"
+
     class Meta:
         #: The verbose name of the model
         verbose_name = _("event")

--- a/src/cms/models/events/event_translation.py
+++ b/src/cms/models/events/event_translation.py
@@ -291,12 +291,23 @@ class EventTranslation(models.Model):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <EventTranslation object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``EventTranslation object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation (in this case the title) of the event
+        :return: A readable string representation of the event translation
         :rtype: str
         """
         return self.title
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<EventTranslation: EventTranslation object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the event translation
+        :rtype: str
+        """
+        return f"<EventTranslation (id: {self.id}, event_id: {self.event.id}, language: {self.language.slug}, slug: {self.slug})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/events/recurrence_rule.py
+++ b/src/cms/models/events/recurrence_rule.py
@@ -1,6 +1,7 @@
 from django.contrib.postgres.fields import ArrayField
 from django.core.validators import MinValueValidator
 from django.db import models
+from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
 from ...constants import frequency, weekdays, weeks
@@ -62,6 +63,28 @@ class RecurrenceRule(models.Model):
             "If the recurrence is not for an indefinite period, this field contains the end date"
         ),
     )
+
+    def __str__(self):
+        """
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``RecurrenceRule object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
+
+        :return: A readable string representation of the recurrence rule
+        :rtype: str
+        """
+        return ugettext('Recurrence rule of "{}" ({})').format(
+            self.event.best_translation.title, self.get_frequency_display()
+        )
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<RecurrenceRule: RecurrenceRule object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the recurrence rule
+        :rtype: str
+        """
+        return f"<RecurrenceRule (id: {self.id}, event: {self.event.best_translation.slug})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/feedback/event_feedback.py
+++ b/src/cms/models/feedback/event_feedback.py
@@ -26,7 +26,7 @@ class EventFeedback(Feedback):
         :return: The name of the object this feedback refers to
         :rtype: str
         """
-        return self.event_translation.event.backend_translation.title
+        return self.event_translation.event.best_translation.title
 
     @property
     def object_url(self):
@@ -41,7 +41,7 @@ class EventFeedback(Feedback):
             kwargs={
                 "event_id": self.event_translation.event.id,
                 "region_slug": self.region.slug,
-                "language_slug": self.event_translation.event.backend_translation.language.slug,
+                "language_slug": self.event_translation.event.best_translation.language.slug,
             },
         )
 

--- a/src/cms/models/feedback/feedback.py
+++ b/src/cms/models/feedback/feedback.py
@@ -157,6 +157,31 @@ class Feedback(models.Model):
         """
         return bool(self.read_by)
 
+    def __str__(self):
+        """
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``Feedback object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
+
+        :return: A readable string representation of the feedback
+        :rtype: str
+        """
+        return self.comment
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<Feedback: Feedback object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the feedback
+        :rtype: str
+        """
+        # pylint: disable=unidiomatic-typecheck
+        if type(self) == Feedback:
+            class_name = type(self.submodel_instance).__name__
+        else:
+            class_name = type(self).__name__
+        return f"<{class_name} (id: {self.id})>"
+
     class Meta:
         #: The verbose name of the model
         verbose_name = _("feedback")

--- a/src/cms/models/feedback/imprint_page_feedback.py
+++ b/src/cms/models/feedback/imprint_page_feedback.py
@@ -19,7 +19,6 @@ class ImprintPageFeedback(Feedback):
         :rtype: str
         """
         try:
-            # pylint: disable=no-member
             return self.region.imprint.get_translation(self.language.slug).title
         except ImprintPage.DoesNotExist:
             return _("Imprint")

--- a/src/cms/models/feedback/page_feedback.py
+++ b/src/cms/models/feedback/page_feedback.py
@@ -26,7 +26,7 @@ class PageFeedback(Feedback):
         :return: The name of the object this feedback refers to
         :rtype: str
         """
-        return self.page_translation.page.backend_translation.title
+        return self.page_translation.page.best_translation.title
 
     @property
     def object_url(self):
@@ -41,7 +41,7 @@ class PageFeedback(Feedback):
             kwargs={
                 "page_id": self.page_translation.page.id,
                 "region_slug": self.region.slug,
-                "language_slug": self.page_translation.page.backend_translation.language.slug,
+                "language_slug": self.page_translation.page.best_translation.language.slug,
             },
         )
 

--- a/src/cms/models/feedback/poi_feedback.py
+++ b/src/cms/models/feedback/poi_feedback.py
@@ -26,7 +26,7 @@ class POIFeedback(Feedback):
         :return: The name of the object this feedback refers to
         :rtype: str
         """
-        return self.poi_translation.poi.backend_translation.title
+        return self.poi_translation.poi.best_translation.title
 
     @property
     def object_url(self):
@@ -41,7 +41,7 @@ class POIFeedback(Feedback):
             kwargs={
                 "poi_id": self.poi_translation.poi.id,
                 "region_slug": self.region.slug,
-                "language_slug": self.poi_translation.poi.backend_translation.language.slug,
+                "language_slug": self.poi_translation.poi.best_translation.language.slug,
             },
         )
 

--- a/src/cms/models/languages/language.py
+++ b/src/cms/models/languages/language.py
@@ -1,6 +1,7 @@
 from django.core.validators import MinLengthValidator
 from django.db import models
 from django.utils import timezone
+from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
 from ...constants import text_directions
@@ -76,16 +77,29 @@ class Language(models.Model):
         :return: The translated name of the language
         :rtype: str
         """
-        return _(self.english_name)
+        return ugettext(self.english_name)
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <Language object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``Language object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation (in this case the English name) of the language
+        :return: A readable string representation of the language
         :rtype: str
         """
-        return self.english_name
+        return self.translated_name
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<Language: Language object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the language
+        :rtype: str
+        """
+        return (
+            f"<Language (id: {self.id}, slug: {self.slug}, name: {self.english_name})>"
+        )
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/languages/language_tree_node.py
+++ b/src/cms/models/languages/language_tree_node.py
@@ -159,12 +159,23 @@ class LanguageTreeNode(MPTTModel):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <LanguageTreeNode object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``LanguageTreeNode object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation (in this case the English name) of the node's language
+        :return: A readable string representation of the language node
         :rtype: str
         """
-        return self.language.english_name
+        return self.translated_name
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<LanguageTreeNode: LanguageTreeNode object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the language node
+        :rtype: str
+        """
+        return f"<LanguageTreeNode (id: {self.id}, language: {self.language.slug}, region: {self.region})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/media/document.py
+++ b/src/cms/models/media/document.py
@@ -40,12 +40,23 @@ class Document(models.Model):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <Document object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``Document object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation (in this case the filename) of the document
+        :return: A readable string representation of the document
         :rtype: str
         """
         return self.document.name
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<Document: Document object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the document
+        :rtype: str
+        """
+        return f"<Document (id: {self.id}, name: {self.document.name})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/offers/offer.py
+++ b/src/cms/models/offers/offer.py
@@ -101,6 +101,26 @@ class Offer(models.Model):
             post_data.update({"search-plz": self.region.postal_code})
         return post_data
 
+    def __str__(self):
+        """
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``Offer object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
+
+        :return: A readable string representation of the offer
+        :rtype: str
+        """
+        return self.name
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<Offer: Offer object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the offer
+        :rtype: str
+        """
+        return f"<Offer (id: {self.id}, region: {self.region.slug}, slug: {self.slug})>"
+
     class Meta:
         #: The verbose name of the model
         verbose_name = _("offer")

--- a/src/cms/models/offers/offer_template.py
+++ b/src/cms/models/offers/offer_template.py
@@ -62,12 +62,23 @@ class OfferTemplate(models.Model):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <OfferTemplate object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``OfferTemplate object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation (in this case the name) of the offer template
+        :return: A readable string representation of the offer template
         :rtype: str
         """
         return self.name
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<OfferTemplate: OfferTemplate object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the offer template
+        :rtype: str
+        """
+        return f"<OfferTemplate (id: {self.id}, slug: {self.slug})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/pages/abstract_base_page.py
+++ b/src/cms/models/pages/abstract_base_page.py
@@ -121,18 +121,24 @@ class AbstractBasePage(models.Model):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <Page object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``AbstractBasePage object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation of the page with information about the most important fields (useful for
-                 debugging purposes)
+        :return: A readable string representation of the page
         :rtype: str
         """
-        if self.id:
-            first_translation = self.get_first_translation()
-            if first_translation:
-                return f"(id: {self.id}, slug: {first_translation.slug} ({first_translation.language.slug}))"
-            return f"(id: {self.id})"
-        return super().__str__()
+        return self.best_translation.title
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<AbstractBasePage: AbstractBasePage object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the page
+        :rtype: str
+        """
+        class_name = type(self).__name__
+        return f"<{class_name} (id: {self.id}, region: {self.region.slug}, slug: {self.best_translation.slug})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/pages/abstract_base_page_translation.py
+++ b/src/cms/models/pages/abstract_base_page_translation.py
@@ -54,6 +54,7 @@ class AbstractBasePageTranslation(models.Model):
     def page(self):
         """
         The page the translation belongs to
+
         To be implemented in the inheriting model
         """
         raise NotImplementedError
@@ -62,6 +63,7 @@ class AbstractBasePageTranslation(models.Model):
     def language(self):
         """
         The language of the page translation
+
         To be implemented in the inheriting model
         """
         raise NotImplementedError
@@ -70,6 +72,7 @@ class AbstractBasePageTranslation(models.Model):
     def creator(self):
         """
         The user who created the page translation
+
         To be implemented in the inheriting model
         """
         raise NotImplementedError
@@ -78,6 +81,7 @@ class AbstractBasePageTranslation(models.Model):
     def permalink(self):
         """
         This property calculates the permalink dynamically
+
         To be implemented in the inheriting model
         """
         raise NotImplementedError
@@ -86,6 +90,7 @@ class AbstractBasePageTranslation(models.Model):
     def short_url(self):
         """
         This property calculates the short url dynamically
+
         To be implemented in the inheriting model
         """
         raise NotImplementedError
@@ -298,6 +303,27 @@ class AbstractBasePageTranslation(models.Model):
         :rtype: bool
         """
         return not self.currently_in_translation and not self.is_outdated
+
+    def __str__(self):
+        """
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``AbstractBasePageTranslation object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
+
+        :return: A readable string representation of the page translation
+        :rtype: str
+        """
+        return self.title
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<AbstractBasePageTranslation: AbstractBasePageTranslation object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the page translation
+        :rtype: str
+        """
+        class_name = type(self).__name__
+        return f"<{class_name} (id: {self.id}, page_id: {self.page.id}, language: {self.language.slug}, slug: {self.slug})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/pages/imprint_page_translation.py
+++ b/src/cms/models/pages/imprint_page_translation.py
@@ -77,18 +77,6 @@ class ImprintPageTranslation(AbstractBasePageTranslation):
         """
         return settings.IMPRINT_SLUG
 
-    def __str__(self):
-        """
-        This overwrites the default Python __str__ method which would return <ImprintPageTranslation object at 0xDEADBEEF>
-
-        :return: The string representation of the imprint page translation with information about the most important
-                 fields (useful for debugging purposes)
-        :rtype: str
-        """
-        if self.id:
-            return f"(id: {self.id}, page_id: {self.page.id}, lang: {self.language.slug}, version: {self.version})"
-        return super().__str__()
-
     class Meta:
         #: The verbose name of the model
         verbose_name = _("imprint translation")

--- a/src/cms/models/pages/page_translation.py
+++ b/src/cms/models/pages/page_translation.py
@@ -61,7 +61,9 @@ class PageTranslation(AbstractBasePageTranslation):
         """
         return "/".join(
             [
-                ancestor.get_first_translation([self.language.slug]).slug
+                ancestor.get_translation(self.language.slug).slug
+                if ancestor.get_translation(self.language.slug)
+                else ancestor.default_translation.slug
                 for ancestor in self.page.get_ancestors()
             ]
         )

--- a/src/cms/models/pois/poi.py
+++ b/src/cms/models/pois/poi.py
@@ -84,18 +84,35 @@ class POI(models.Model):
     @property
     def backend_translation(self):
         """
-        This function tries to determine which translation to be used for showing a POI in the backend.
-        The first priority is the current backend language.
-        If no translation is present in this language, the fallback is the region's default language.
+        This function returns the translation of this POI in the current backend language.
+
+        :return: The backend translation of a POI
+        :rtype: ~cms.models.pois.poi_translation.POITranslation
+        """
+        return self.translations.filter(language__slug=get_language()).first()
+
+    @property
+    def default_translation(self):
+        """
+        This function returns the translation of this POI in the region's default language.
+        Since a POI can only be created by creating a translation in the default language, this is guaranteed to return
+        a POI translation.
+
+        :return: The default translation of a POI
+        :rtype: ~cms.models.pois.poi_translation.POITranslation
+        """
+        return self.translations.filter(language=self.region.default_language).first()
+
+    @property
+    def best_translation(self):
+        """
+        This function returns the translation of this POI in the current backend language and if it doesn't exist, it
+        provides a fallback to the translation in the region's default language.
 
         :return: The "best" translation of a POI for displaying in the backend
         :rtype: ~cms.models.pois.poi_translation.POITranslation
         """
-        poi_translation = self.translations.filter(language__slug=get_language())
-        if not poi_translation.exists():
-            alt_slug = self.region.default_language.slug
-            poi_translation = self.translations.filter(language__slug=alt_slug)
-        return poi_translation.first()
+        return self.backend_translation or self.default_translation
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/pois/poi.py
+++ b/src/cms/models/pois/poi.py
@@ -114,6 +114,26 @@ class POI(models.Model):
         """
         return self.backend_translation or self.default_translation
 
+    def __str__(self):
+        """
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``POI object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
+
+        :return: A readable string representation of the POI
+        :rtype: str
+        """
+        return self.best_translation.title
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<POI: POI object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the POI
+        :rtype: str
+        """
+        return f"<POI (id: {self.id}, region: {self.region.slug}, slug: {self.best_translation.slug})>"
+
     class Meta:
         #: The verbose name of the model
         verbose_name = _("location")

--- a/src/cms/models/pois/poi_translation.py
+++ b/src/cms/models/pois/poi_translation.py
@@ -290,6 +290,26 @@ class POITranslation(models.Model):
         """
         return not self.currently_in_translation and not self.is_outdated
 
+    def __str__(self):
+        """
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``POITranslation object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
+
+        :return: A readable string representation of the POI translation
+        :rtype: str
+        """
+        return self.title
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<POITranslation: POITranslation object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the POI translation
+        :rtype: str
+        """
+        return f"<POITranslation (id: {self.id}, poi_id: {self.poi.id}, language: {self.language.slug}, slug: {self.slug})>"
+
     class Meta:
         #: The verbose name of the model
         verbose_name = _("location translation")

--- a/src/cms/models/push_notifications/push_notification_channel.py
+++ b/src/cms/models/push_notifications/push_notification_channel.py
@@ -11,12 +11,23 @@ class PushNotificationChannel(models.Model):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method, returns the channel name
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``PushNotificationChannel object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: channel name
+        :return: A readable string representation of the push notification channel
         :rtype: str
         """
         return self.name
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<PushNotificationChannel: PushNotificationChannel object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the push notification channel
+        :rtype: str
+        """
+        return f"<PushNotificationChannel (id: {self.id}, name: {self.name})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/push_notifications/push_notification_translation.py
+++ b/src/cms/models/push_notifications/push_notification_translation.py
@@ -2,6 +2,9 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
+from ..languages.language import Language
+from .push_notification import PushNotification
+
 
 class PushNotificationTranslation(models.Model):
     """
@@ -19,13 +22,13 @@ class PushNotificationTranslation(models.Model):
         verbose_name=_("content"),
     )
     language = models.ForeignKey(
-        "Language",
+        Language,
         on_delete=models.CASCADE,
         related_name="push_notification_translations",
         verbose_name=_("language"),
     )
     push_notification = models.ForeignKey(
-        "PushNotification",
+        PushNotification,
         on_delete=models.CASCADE,
         related_name="translations",
         verbose_name=_("push notification"),
@@ -41,12 +44,23 @@ class PushNotificationTranslation(models.Model):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <PushNotificationTranslation object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``PushNotificationTranslation object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation (in this case the title) of the push notification translation
+        :return: A readable string representation of the event
         :rtype: str
         """
         return self.title
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<PushNotificationTranslation: PushNotificationTranslation object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the event
+        :rtype: str
+        """
+        return f"<PushNotificationTranslation (id: {self.id}, push_notification_id: {self.push_notification.id}, title: {self.title})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/regions/region.py
+++ b/src/cms/models/regions/region.py
@@ -1,7 +1,12 @@
+from html import escape
+
+
 from django.contrib.auth import get_user_model
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.utils import timezone
+from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import get_object_or_404
 
@@ -300,12 +305,31 @@ class Region(models.Model):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <Region object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``Region object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation (in this case the name) of the region
+        :return: A readable string representation of the region
         :rtype: str
         """
-        return self.name
+        label = escape(self.name)
+        if self.status == region_status.HIDDEN:
+            # Add warning if region is hidden
+            label += " (&#9888; " + ugettext("Hidden") + ")"
+        elif self.status == region_status.ARCHIVED:
+            # Add warning if region is archived
+            label += " (&#9888; " + ugettext("Archived") + ")"
+        # mark as safe so that the warning triangle is not escaped
+        return mark_safe(label)
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<Region: Region object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the region
+        :rtype: str
+        """
+        return f"<Region (id: {self.id}, slug: {self.slug})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/users/organization.py
+++ b/src/cms/models/users/organization.py
@@ -34,12 +34,23 @@ class Organization(models.Model):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <Organization object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``Organization object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation (in this case the title) of the organization
+        :return: A readable string representation of the organization
         :rtype: str
         """
         return self.name
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<Organization: Organization object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the organization
+        :rtype: str
+        """
+        return f"<Organization (id: {self.id}, slug: {self.slug})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/users/user_mfa.py
+++ b/src/cms/models/users/user_mfa.py
@@ -39,12 +39,25 @@ class UserMfa(models.Model):
 
     def __str__(self):
         """
-        This overwrites the default Python __str__ method which would return <UserMfa object at 0xDEADBEEF>
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``UserMfa object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: The string representation (in this case the title) of the multi-factor authentication key
+        :return: A readable string representation of the user MFA
         :rtype: str
         """
-        return self.user.username + str(self.key_id)
+        return f"{self.name} ({self.user.profile.full_user_name})"
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<UserMfa: UserMfa object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the user MFA
+        :rtype: str
+        """
+        return (
+            f"<UserMfa (id: {self.id}, name: {self.name}, user: {self.user.username})>"
+        )
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/models/users/user_profile.py
+++ b/src/cms/models/users/user_profile.py
@@ -94,19 +94,30 @@ class UserProfile(models.Model):
         logger.debug(
             "Field chat_last_visited of %r updated from %s to %s",
             self.user.profile,
-            previous_chat_last_visited.strftime("%Y-%m-%d %H:%M:%r"),
-            self.chat_last_visited.strftime("%Y-%m-%d %H:%M:%r"),
+            previous_chat_last_visited.strftime("%Y-%m-%d %H:%M:%S"),
+            self.chat_last_visited.strftime("%Y-%m-%d %H:%M:%S"),
         )
         return previous_chat_last_visited
 
     def __str__(self):
         """
-        The string representation of this user profile
+        This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``UserProfile object (id)``.
+        It is used in the Django admin backend and as label for ModelChoiceFields.
 
-        :return: THe username
+        :return: A readable string representation of the user profile
         :rtype: str
         """
-        return self.user.username
+        return self.full_user_name
+
+    def __repr__(self):
+        """
+        This overwrites the default Django ``__repr__()`` method which would return ``<UserProfile: UserProfile object (id)>``.
+        It is used for logging.
+
+        :return: The canonical string representation of the user profile
+        :rtype: str
+        """
+        return f"<UserProfile (id: {self.id}, username: {self.user.username})>"
 
     class Meta:
         #: The verbose name of the model

--- a/src/cms/templates/events/event_form.html
+++ b/src/cms/templates/events/event_form.html
@@ -21,9 +21,8 @@
                         {% blocktrans %}Edit event "{{ event_title }}"{% endblocktrans %}
                         {% endwith %}
                         {% if LANGUAGE_CODE != language.slug %}
-                            {% get_translation event_form.instance LANGUAGE_CODE as backend_translation %}
-                            {% if backend_translation %}
-                                ({% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}: "{{ backend_translation.title }}")
+                            {% if event_form.instance.backend_translation %}
+                                ({% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}: "{{ event_form.instance.backend_translation.title }}")
                             {% endif %}
                         {% endif %}
                     {% else %}

--- a/src/cms/templates/events/event_list.html
+++ b/src/cms/templates/events/event_list.html
@@ -50,11 +50,9 @@
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% if LANGUAGE_CODE != language.slug %}
-                    {% get_language LANGUAGE_CODE as backend_language %}
-                    {% if backend_language %}
-                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
-                    {% endif %}
+                {% get_language LANGUAGE_CODE as backend_language %}
+                {% if backend_language and backend_language != language %}
+                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2 no-sort" data-sort-method="none">
                     <div class="lang-grid flags">

--- a/src/cms/templates/events/event_list_archived.html
+++ b/src/cms/templates/events/event_list_archived.html
@@ -35,11 +35,9 @@
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% if LANGUAGE_CODE != language.slug %}
-                    {% get_language LANGUAGE_CODE as backend_language %}
-                    {% if backend_language %}
-                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
-                    {% endif %}
+                {% get_language LANGUAGE_CODE as backend_language %}
+                {% if backend_language and backend_language != language %}
+                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2 no-sort" data-sort-method="none">
                     <div class="lang-grid flags">

--- a/src/cms/templates/events/event_list_archived_row.html
+++ b/src/cms/templates/events/event_list_archived_row.html
@@ -27,20 +27,17 @@
         </a>
     </td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% if LANGUAGE_CODE != language.slug %}
-        {% get_language LANGUAGE_CODE as backend_language %}
-        {% if backend_language %}
-            {% get_translation event LANGUAGE_CODE as backend_translation %}
-            <td>
-                <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                    {% if backend_translation %}
-                        {{ backend_translation.title }}
-                    {% else %}
-                        <i>{% trans 'Translation not available' %}</i>
-                    {% endif %}
-                </a>
-            </td>
-        {% endif %}
+    {% get_language LANGUAGE_CODE as backend_language %}
+    {% if backend_language and backend_language != language %}
+        <td>
+            <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                {% if event.backend_translation %}
+                    {{ event.backend_translation.title }}
+                {% else %}
+                    <i>{% trans 'Translation not available' %}</i>
+                {% endif %}
+            </a>
+        </td>
     {% endif %}
     <td>
         <div class="block py-3 px-2 text-gray-800">

--- a/src/cms/templates/events/event_list_row.html
+++ b/src/cms/templates/events/event_list_row.html
@@ -19,20 +19,17 @@
         </a>
     </td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% if LANGUAGE_CODE != language.slug %}
-        {% get_language LANGUAGE_CODE as backend_language %}
-        {% if backend_language %}
-            {% get_translation event LANGUAGE_CODE as backend_translation %}
-            <td>
-                <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                    {% if backend_translation %}
-                        {{ backend_translation.title }}
-                    {% else %}
-                        <i>{% trans 'Translation not available' %}</i>
-                    {% endif %}
-                </a>
-            </td>
-        {% endif %}
+    {% get_language LANGUAGE_CODE as backend_language %}
+    {% if backend_language and backend_language != language %}
+        <td>
+            <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                {% if event.backend_translation %}
+                    {{ event.backend_translation.title }}
+                {% else %}
+                    <i>{% trans 'Translation not available' %}</i>
+                {% endif %}
+            </a>
+        </td>
     {% endif %}
     <td>
         <div class="block py-3 px-2 text-gray-800">

--- a/src/cms/templates/pages/_page_order_table.html
+++ b/src/cms/templates/pages/_page_order_table.html
@@ -18,7 +18,7 @@
                                 <i data-feather="move"></i>
                             </span>
                         </td>
-                        <td id="page_title" data-default-title="{{ node.backend_translation.title }}">{{ node.backend_translation.title }}</td>
+                        <td id="page_title" data-default-title="{{ node.best_translation.title }}">{{ node.best_translation.title }}</td>
                     </tr>
                 {% else %}
                     {% if page and node.get_previous_sibling == page %}
@@ -28,7 +28,7 @@
                     {% endif %}
                     <tr class="border border-gray-200 hover:bg-gray-100">
                         <td></td>
-                        <td>{{ node.backend_translation.title }}</td>
+                        <td>{{ node.best_translation.title }}</td>
                     </tr>
                     {% if not node.get_next_sibling %}
                         {% if not page in node.get_siblings %}
@@ -56,7 +56,7 @@
                                 <i data-feather="move"></i>
                             </span>
                         </td>
-                        <td id="page_title" data-default-title="{{ page.backend_translation.title }}">{{ page.backend_translation.title }}</td>
+                        <td id="page_title" data-default-title="{{ page.best_translation.title }}">{{ page.best_translation.title }}</td>
                     </tr>
                 {% endif %}
             {% endif %}

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -21,9 +21,8 @@
                             {% blocktrans %}Edit page "{{ page_title }}"{% endblocktrans %}
                         {% endwith %}
                         {% if LANGUAGE_CODE != language.slug %}
-                            {% get_translation page LANGUAGE_CODE as backend_translation %}
-                            {% if backend_translation %}
-                                ({% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}: "{{ backend_translation.title }}")
+                            {% if page.backend_translation %}
+                                ({% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}: "{{ page.backend_translation.title }}")
                             {% endif %}
                         {% endif %}
                     {% else %}
@@ -330,7 +329,7 @@
                                 </div>
                                 {% for ancestor in page.explicitly_archived_ancestors %}
                                     <a href="{% url 'edit_page' page_id=ancestor.id region_slug=region.slug language_slug=language.slug %}" class="block pt-2 hover:underline">
-                                        <i data-feather="edit" class="inline-block mr-2"></i> {{ ancestor.backend_translation.title }}
+                                        <i data-feather="edit" class="inline-block mr-2"></i> {{ ancestor.best_translation.title }}
                                     </a>
                                 {% endfor %}
                             {% else %}
@@ -361,7 +360,7 @@
                                     </div>
                                     {% for descendant in page.get_descendants %}
                                     <a href="{% url 'edit_page' page_id=descendant.id region_slug=region.slug language_slug=language.slug %}" class="block pt-2 hover:underline">
-                                        <i data-feather="edit" class="inline-block mr-2"></i> {{ descendant.backend_translation.title }}
+                                        <i data-feather="edit" class="inline-block mr-2"></i> {{ descendant.best_translation.title }}
                                     </a>
                                     {% endfor %}
                                 {% else %}

--- a/src/cms/templates/pages/page_tree.html
+++ b/src/cms/templates/pages/page_tree.html
@@ -67,11 +67,9 @@
                 <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% if LANGUAGE_CODE != language.slug %}
-                    {% get_language LANGUAGE_CODE as backend_language %}
-                    {% if backend_language %}
-                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
-                    {% endif %}
+                {% get_language LANGUAGE_CODE as backend_language %}
+                {% if backend_language and backend_language != language %}
+                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags whitespace-nowrap">

--- a/src/cms/templates/pages/page_tree_archived.html
+++ b/src/cms/templates/pages/page_tree_archived.html
@@ -26,11 +26,9 @@
                 <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% if LANGUAGE_CODE != language.slug %}
-                    {% get_language LANGUAGE_CODE as backend_language %}
-                    {% if backend_language %}
-                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
-                    {% endif %}
+                {% get_language LANGUAGE_CODE as backend_language %}
+                {% if backend_language and backend_language != language %}
+                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags whitespace-nowrap">

--- a/src/cms/templates/pages/page_tree_archived_node.html
+++ b/src/cms/templates/pages/page_tree_archived_node.html
@@ -28,20 +28,17 @@
         </a>
     </td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% if LANGUAGE_CODE != language.slug %}
-        {% get_language LANGUAGE_CODE as backend_language %}
-        {% if backend_language %}
-            {% get_translation page LANGUAGE_CODE as backend_translation %}
-            <td>
-                <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                    {% if backend_translation %}
-                        {{ backend_translation.title }}
-                    {% else %}
-                        <i>{% trans 'Translation not available' %}</i>
-                    {% endif %}
-                </a>
-            </td>
-        {% endif %}
+    {% get_language LANGUAGE_CODE as backend_language %}
+    {% if backend_language and backend_language != language %}
+        <td>
+            <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                {% if page.backend_translation %}
+                    {{ page.backend_translation.title }}
+                {% else %}
+                    <i>{% trans 'Translation not available' %}</i>
+                {% endif %}
+            </a>
+        </td>
     {% endif %}
     <td class="whitespace-nowrap">
         <div class="block py-3 px-2 text-gray-800">
@@ -83,7 +80,7 @@
             <button title="{% trans 'Restore page' %}" class="confirmation-button py-3 pl-2"
                     data-confirmation-title="{{ restore_dialog_title }}"
                     data-confirmation-text="{{ restore_dialog_text }}"
-                    data-confirmation-subject="{{ page.backend_translation.title }}"
+                    data-confirmation-subject="{{ page.best_translation.title }}"
                     data-action="{% url 'restore_page' page_id=page.id region_slug=region.slug language_slug=language.slug %}">
                 <i data-feather="refresh-ccw" class="inline-block text-gray-800"></i>
             </button>
@@ -101,7 +98,7 @@
                 <button title="{% trans 'Delete page' %}" class="confirmation-button py-3 pl-2"
                     data-confirmation-title="{{ delete_dialog_title }}"
                     data-confirmation-text="{{ delete_dialog_text }}"
-                    data-confirmation-subject="{{ page.backend_translation.title }}"
+                    data-confirmation-subject="{{ page.best_translation.title }}"
                     data-action="{% url 'delete_page' page_id=page.id region_slug=region.slug language_slug=language.slug %}">
                     <i data-feather="trash-2" class="inline-block text-gray-800"></i>
                 </button>

--- a/src/cms/templates/pages/page_tree_node.html
+++ b/src/cms/templates/pages/page_tree_node.html
@@ -43,29 +43,19 @@
         </a>
     </td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% if LANGUAGE_CODE != language.slug %}
-        {% get_language LANGUAGE_CODE as backend_language %}
-        {% if backend_language %}
-            {% get_translation page LANGUAGE_CODE as backend_translation %}
-            <td>
-                <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                    <div class="translation-title">
-                        {% if backend_translation %}
-                            {% if not backend_translation.currently_in_translation %}
-                                {{ backend_translation.title }}
-                            {% else %}
-                                <i>{% trans 'Currently in translation' %}</i>
-                            {% endif %}
-                        {% else %}
-                            <i>{% trans 'Translation not available' %}</i>
-                        {% endif %}
-                    </div>
-                    <div class="ajax-title hidden">
-                        <i>{% trans 'Currently in translation' %}</i>
-                    </div>
-                </a>
-            </td>
-        {% endif %}
+    {% get_language LANGUAGE_CODE as backend_language %}
+    {% if backend_language and backend_language != language %}
+        <td>
+            <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                <div class="translation-title">
+                    {% if page.backend_translation %}
+                        {{ page.backend_translation.title }}
+                    {% else %}
+                        <i>{% trans 'Translation not available' %}</i>
+                    {% endif %}
+                </div>
+            </a>
+        </td>
     {% endif %}
     <td class="whitespace-nowrap">
         <div class="block py-3 px-2 text-gray-800">
@@ -123,7 +113,7 @@
         <button title="{% trans 'Archive page' %}" class="confirmation-button py-3 px-2"
                 data-confirmation-title="{{ archive_dialog_title }}"
                 data-confirmation-text="{{ archive_dialog_text }}"
-                data-confirmation-subject="{{ page.backend_translation.title }}"
+                data-confirmation-subject="{{ page.best_translation.title }}"
                 data-action="{% url 'archive_page' page_id=page.id region_slug=region.slug language_slug=language.slug %}">
             <i data-feather="archive" class="inline-block text-gray-800"></i>
         </button>
@@ -136,7 +126,7 @@
                 <button title="{% trans 'Delete page' %}" class="confirmation-button py-3 px-2"
                         data-confirmation-title="{{ delete_dialog_title }}"
                         data-confirmation-text="{{ delete_dialog_text }}"
-                        data-confirmation-subject="{{ page.backend_translation.title }}"
+                        data-confirmation-subject="{{ page.best_translation.title }}"
                         data-action="{% url 'delete_page' page_id=page.id region_slug=region.slug language_slug=language.slug %}">
                     <i data-feather="trash-2" class="inline-block text-gray-800"></i>
                 </button>

--- a/src/cms/templates/pois/poi_form.html
+++ b/src/cms/templates/pois/poi_form.html
@@ -22,9 +22,8 @@
                         {% trans 'Create new translation of the location' %}
                     {% endif %}
                     {% get_current_language as LANGUAGE_CODE %}
-                    {% get_translation poi_form.instance LANGUAGE_CODE as backend_translation %}
-                    {% if backend_translation and LANGUAGE_CODE != language.slug %}
-                        ({% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}: "{{ backend_translation.title }}")
+                    {% if poi_form.instance.backend_translation and LANGUAGE_CODE != language.slug %}
+                        ({% trans 'Title in' %} {% translated_language_name LANGUAGE_CODE %}: "{{ poi_form.instance.backend_translation.title }}")
                     {% endif %}
                 {% else %}
                     {% trans 'Create new location' %}

--- a/src/cms/templates/pois/poi_list.html
+++ b/src/cms/templates/pois/poi_list.html
@@ -45,11 +45,9 @@
                 <th class="text-sm text-left uppercase py-3">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% if LANGUAGE_CODE != language.slug %}
-                    {% get_language LANGUAGE_CODE as backend_language %}
-                    {% if backend_language %}
-                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
-                    {% endif %}
+                {% get_language LANGUAGE_CODE as backend_language %}
+                {% if backend_language and backend_language != language %}
+                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags" style="white-space: nowrap;">

--- a/src/cms/templates/pois/poi_list_archived.html
+++ b/src/cms/templates/pois/poi_list_archived.html
@@ -28,11 +28,9 @@
                 <th class="text-sm text-left uppercase py-3">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
-                {% if LANGUAGE_CODE != language.slug %}
-                    {% get_language LANGUAGE_CODE as backend_language %}
-                    {% if backend_language %}
-                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
-                    {% endif %}
+                {% get_language LANGUAGE_CODE as backend_language %}
+                {% if backend_language and backend_language != language %}
+                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3">{% trans 'Street' %}</th>
                 <th class="text-sm text-left uppercase py-3">{% trans 'Postal Code' %}</th>

--- a/src/cms/templates/pois/poi_list_archived_row.html
+++ b/src/cms/templates/pois/poi_list_archived_row.html
@@ -26,20 +26,17 @@
 		</a>
 	</td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% if LANGUAGE_CODE != language.slug %}
-        {% get_language LANGUAGE_CODE as backend_language %}
-        {% if backend_language %}
-            {% get_translation poi LANGUAGE_CODE as backend_translation %}
-            <td>
-                <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                    {% if backend_translation %}
-                        {{ backend_translation.title }}
-                    {% else %}
-                        <i>{% trans 'Translation not available' %}</i>
-                    {% endif %}
-                </a>
-            </td>
-        {% endif %}
+    {% get_language LANGUAGE_CODE as backend_language %}
+    {% if backend_language and backend_language != language %}
+        <td>
+            <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                {% if poi.backend_translation %}
+                    {{ poi.backend_translation.title }}
+                {% else %}
+                    <i>{% trans 'Translation not available' %}</i>
+                {% endif %}
+            </a>
+        </td>
     {% endif %}
 	<td>
 		{{ poi.address }}

--- a/src/cms/templates/pois/poi_list_row.html
+++ b/src/cms/templates/pois/poi_list_row.html
@@ -26,20 +26,17 @@
 		</a>
 	</td>
     {% get_current_language as LANGUAGE_CODE %}
-    {% if LANGUAGE_CODE != language.slug %}
-        {% get_language LANGUAGE_CODE as backend_language %}
-        {% if backend_language %}
-            {% get_translation poi LANGUAGE_CODE as backend_translation %}
-            <td>
-                <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
-                    {% if backend_translation %}
-                        {{ backend_translation.title }}
-                    {% else %}
-                        <i>{% trans 'Translation not available' %}</i>
-                    {% endif %}
-                </a>
-            </td>
-        {% endif %}
+    {% get_language LANGUAGE_CODE as backend_language %}
+    {% if backend_language and backend_language != language %}
+        <td>
+            <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 text-gray-800">
+                {% if poi.backend_translation %}
+                    {{ poi.backend_translation.title }}
+                {% else %}
+                    <i>{% trans 'Translation not available' %}</i>
+                {% endif %}
+            </a>
+        </td>
     {% endif %}
 	<td>
 		<div class="block py-3 px-2 text-gray-800">

--- a/src/cms/templatetags/content_filters.py
+++ b/src/cms/templatetags/content_filters.py
@@ -68,13 +68,13 @@ def translated_language_name(language_slug):
 @register.simple_tag
 def get_language(language_slug):
     """
-    This tag returns the name of the requested language in the current backend language
+    This tag returns the requested language by slug
 
     :param language_slug: The slug of the requested language
     :type language_slug: str
 
-    :return: The translated name of the requested language
-    :rtype: str
+    :return: The requested language
+    :rtype: ~cms.models.languages.language.Language
     """
     return Language.objects.filter(slug=language_slug).first()
 

--- a/src/cms/views/pages/page_actions.py
+++ b/src/cms/views/pages/page_actions.py
@@ -514,7 +514,7 @@ def move_page(request, region_slug, language_slug, page_id, target_id, position)
         messages.success(
             request,
             _('The page "{page}" was successfully moved.').format(
-                page=page.get_first_translation([language_slug]).title
+                page=page.best_translation.title
             ),
         )
     except (ValueError, InvalidMove) as e:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I noticed that PR #738 (Improve logging) got a little bit out of control, so I will split it into separate PRs.
This one provides a few enhancements for the models.

### Proposed changes
<!-- Describe this PR in more detail. -->
-  Improve handling of backend translations
    - Distinguish between `backend_translation`, `default_translation` and `best_translation` in the content models:
        - `backend_translation`: The translation of the page in the current backend language (used in the content lists in the column "Title in [backend language]")
        - `default_translation`: The translation of the page in the region's default language
        - `best_translation`: If `backend_translation` exists, it is returned and `default_translation` as fallback (used anywhere else in the backend where `None` is no acceptable result)
    - Remove some complexity in the templates
-  Improve string representations of models
    - Make output of `__str__()` method consistent (used as readable name in model choice fields and in Django admin) - This makes all custom ModelChoiceFields obsolete because the `__str__()` method is used as default label for the model instances
    - Make output of `__repr__()` method consistent (designed for logging)
    - Register all models in Django admin

