### PR TITLE
Enable colored logging

### DIFF
--- a/src/backend/logging_formatter.py
+++ b/src/backend/logging_formatter.py
@@ -1,0 +1,35 @@
+import logging
+
+
+class ColorFormatter(logging.Formatter):
+    """
+    Logging Formatter to add colors
+    """
+
+    #: The bash color codes for the different logging levels
+    COLORS = {
+        logging.DEBUG: 36,  # cyan
+        logging.INFO: 34,  # blue
+        logging.WARNING: 33,  # yellow
+        logging.ERROR: 31,  # red
+        logging.CRITICAL: 31,  # red
+    }
+
+    def format(self, record):
+        """
+        Format the specified record as colored text (see :meth:`python:logging.Formatter.format`).
+
+        :param record: The log record
+        :type record: ~logging.LogRecord
+
+        :return: The formatted logging message
+        :rtype: str
+        """
+        # Define color escape sequence
+        color = f"\x1b[0;{self.COLORS.get(record.levelno)}m"
+        # Make level name bold
+        fmt = self._fmt.replace("{levelname}", "\x1b[1m{levelname}" + color)
+        # Make entire line colored
+        # pylint: disable=protected-access
+        self._style._fmt = color + fmt + "\x1b[0m"
+        return super().format(record)

--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -34,6 +34,8 @@ For production use, the following settings can be set with environment variables
 import os
 import urllib
 
+from .logging_formatter import ColorFormatter
+
 
 ###################
 # CUSTOM SETTINGS #
@@ -331,7 +333,18 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "default": {
+        "console": {
+            "format": "{asctime} \x1b[1m{levelname}\x1b[0m {name} - {message}",
+            "datefmt": "%b %d %H:%M:%S",
+            "style": "{",
+        },
+        "console-colored": {
+            "()": ColorFormatter,
+            "format": "{asctime} {levelname} {name} - {message}",
+            "datefmt": "%b %d %H:%M:%S",
+            "style": "{",
+        },
+        "logfile": {
             "format": "{asctime} {levelname:7} {name} - {message}",
             "datefmt": "%b %d %H:%M:%S",
             "style": "{",
@@ -358,12 +371,17 @@ LOGGING = {
         "console": {
             "filters": ["require_debug_true"],
             "class": "logging.StreamHandler",
-            "formatter": "default",
+            "formatter": "console",
+        },
+        "console-colored": {
+            "filters": ["require_debug_true"],
+            "class": "logging.StreamHandler",
+            "formatter": "console-colored",
         },
         "logfile": {
             "class": "logging.FileHandler",
             "filename": LOGFILE,
-            "formatter": "default",
+            "formatter": "logfile",
         },
         "authlog": {
             "filters": ["require_debug_false"],
@@ -377,7 +395,6 @@ LOGGING = {
             "class": "logging.handlers.SysLogHandler",
             "address": "/dev/log",
             "facility": "syslog",
-            "formatter": "syslog",
         },
         "mail_admins": {
             "level": "ERROR",
@@ -389,23 +406,23 @@ LOGGING = {
     "loggers": {
         # Loggers of integreat-cms django apps
         "api": {
-            "handlers": ["console", "logfile", "mail_admins"],
+            "handlers": ["console-colored", "logfile", "mail_admins"],
             "level": LOG_LEVEL,
         },
         "backend": {
-            "handlers": ["console", "logfile", "mail_admins"],
+            "handlers": ["console-colored", "logfile", "mail_admins"],
             "level": LOG_LEVEL,
         },
         "cms": {
-            "handlers": ["console", "logfile", "mail_admins"],
+            "handlers": ["console-colored", "logfile", "mail_admins"],
             "level": LOG_LEVEL,
         },
         "gvz_api": {
-            "handlers": ["console", "logfile", "mail_admins"],
+            "handlers": ["console-colored", "logfile", "mail_admins"],
             "level": LOG_LEVEL,
         },
         "sitemap": {
-            "handlers": ["console", "logfile", "mail_admins"],
+            "handlers": ["console-colored", "logfile", "mail_admins"],
             "level": LOG_LEVEL,
         },
         # Syslog for authentication


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I have no idea why I missed this opportunity in #738 (Improve logging) - I mean who doesn't want colors, right? 

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add `ColorFormatter` which inherits from the default Python logging Formatter
- Colorize logging output based on logging level
- This only affects the console output which is used if `DEBUG` is `True`.

![logging](https://user-images.githubusercontent.com/16021269/111402196-0ed11a80-86cb-11eb-86ba-b1e80d9d1bfd.png)
### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes the problem that our console log looks boring

