### PR TITLE
Improve page link field

### DIFF
--- a/src/cms/forms/pages/page_translation_form.py
+++ b/src/cms/forms/pages/page_translation_form.py
@@ -1,7 +1,6 @@
 import logging
 
 from django.core.exceptions import ValidationError
-from django.forms import TextInput
 from django.utils.translation import ugettext_lazy as _
 
 from ..custom_model_form import CustomModelForm
@@ -28,9 +27,6 @@ class PageTranslationForm(CustomModelForm):
         model = PageTranslation
         #: The fields of the model which should be handled by this form
         fields = ["title", "slug", "status", "text", "minor_edit"]
-        widgets = {
-            "slug": TextInput(attrs={"readonly": "readonly"}),
-        }
 
     def __init__(self, *args, **kwargs):
         """

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-18 00:30+0000\n"
+"POT-Creation-Date: 2021-03-18 13:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -379,7 +379,7 @@ msgstr "Das Ende der Veranstaltung kann nicht vor seinem Beginn sein"
 
 #: forms/events/event_translation_form.py:124
 #: forms/imprint/imprint_translation_form.py:111
-#: forms/pages/page_translation_form.py:134
+#: forms/pages/page_translation_form.py:130
 #: forms/pois/poi_translation_form.py:137
 msgid "Use of Heading 1 style not allowed."
 msgstr "Bitte benutzen Sie keine Überschrift 1 in diesem Feld."
@@ -1939,7 +1939,7 @@ msgstr "Nicht nach"
 
 #: templates/events/_event_filter_form.html:34
 #: templates/events/event_form.html:316 templates/imprint/imprint_form.html:222
-#: templates/imprint/imprint_sbs.html:163 templates/pages/page_form.html:421
+#: templates/imprint/imprint_sbs.html:163 templates/pages/page_form.html:424
 #: templates/pages/page_sbs.html:173 templates/pois/poi_form.html:218
 msgid "Location"
 msgstr "Ort"
@@ -2050,7 +2050,7 @@ msgid "Version"
 msgstr "Version"
 
 #: templates/events/event_form.html:140 templates/imprint/imprint_form.html:122
-#: templates/imprint/imprint_sbs.html:147 templates/pages/page_form.html:223
+#: templates/imprint/imprint_sbs.html:147 templates/pages/page_form.html:226
 #: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:128
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
@@ -2125,37 +2125,37 @@ msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
 #: templates/events/event_form.html:315 templates/imprint/imprint_form.html:221
-#: templates/imprint/imprint_sbs.html:162 templates/pages/page_form.html:420
+#: templates/imprint/imprint_sbs.html:162 templates/pages/page_form.html:423
 #: templates/pages/page_sbs.html:172 templates/pois/poi_form.html:217
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
 #: templates/events/event_form.html:318 templates/imprint/imprint_form.html:224
-#: templates/imprint/imprint_sbs.html:165 templates/pages/page_form.html:423
+#: templates/imprint/imprint_sbs.html:165 templates/pages/page_form.html:426
 #: templates/pages/page_sbs.html:175 templates/pois/poi_form.html:220
 msgid "Link"
 msgstr "Link"
 
 #: templates/events/event_form.html:320 templates/imprint/imprint_form.html:226
-#: templates/imprint/imprint_sbs.html:167 templates/pages/page_form.html:425
+#: templates/imprint/imprint_sbs.html:167 templates/pages/page_form.html:428
 #: templates/pages/page_sbs.html:177 templates/pois/poi_form.html:222
 msgid "Phone"
 msgstr "Telefon"
 
 #: templates/events/event_form.html:322 templates/imprint/imprint_form.html:228
-#: templates/imprint/imprint_sbs.html:169 templates/pages/page_form.html:427
+#: templates/imprint/imprint_sbs.html:169 templates/pages/page_form.html:430
 #: templates/pages/page_sbs.html:179 templates/pois/poi_form.html:224
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
 #: templates/events/event_form.html:324 templates/imprint/imprint_form.html:230
-#: templates/imprint/imprint_sbs.html:171 templates/pages/page_form.html:429
+#: templates/imprint/imprint_sbs.html:171 templates/pages/page_form.html:432
 #: templates/pages/page_sbs.html:181 templates/pois/poi_form.html:226
 msgid "Email"
 msgstr "Email"
 
 #: templates/events/event_form.html:326 templates/imprint/imprint_form.html:232
-#: templates/imprint/imprint_sbs.html:173 templates/pages/page_form.html:431
+#: templates/imprint/imprint_sbs.html:173 templates/pages/page_form.html:434
 #: templates/pages/page_sbs.html:183 templates/pois/poi_form.html:228
 msgid "Hint"
 msgstr "Tipp"
@@ -2395,7 +2395,7 @@ msgstr "Kurz-URL"
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: templates/imprint/imprint_form.html:143 templates/pages/page_form.html:393
+#: templates/imprint/imprint_form.html:143 templates/pages/page_form.html:396
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
@@ -2693,7 +2693,7 @@ msgstr "Angebots-Vorlagen verwalten"
 msgid "Active since"
 msgstr "Aktiv seit"
 
-#: templates/offers/offer_list.html:33 templates/pages/page_form.html:303
+#: templates/offers/offer_list.html:33 templates/pages/page_form.html:306
 #: templates/regions/region_list.html:33 templates/settings/user.html:59
 msgid "Actions"
 msgstr "Aktionen"
@@ -2808,31 +2808,31 @@ msgstr "Übersetzung wird durchgeführt"
 msgid "Abort translation process"
 msgstr "Übersetzungsprozess abbrechen"
 
-#: templates/pages/page_form.html:217
+#: templates/pages/page_form.html:220
 msgid "Minor edit"
 msgstr "Geringfügige Änderung"
 
-#: templates/pages/page_form.html:233
+#: templates/pages/page_form.html:236
 msgid "Settings of the page"
 msgstr "Einstellungen der Seite"
 
-#: templates/pages/page_form.html:240
+#: templates/pages/page_form.html:243
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page_form.html:250
+#: templates/pages/page_form.html:253
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: templates/pages/page_form.html:255
+#: templates/pages/page_form.html:258
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:274
+#: templates/pages/page_form.html:277
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:275
+#: templates/pages/page_form.html:278
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -2840,17 +2840,17 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:311 templates/pages/page_form.html:312
-#: templates/pages/page_form.html:320
+#: templates/pages/page_form.html:314 templates/pages/page_form.html:315
+#: templates/pages/page_form.html:323
 #: templates/pages/page_tree_archived_node.html:80
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:317
+#: templates/pages/page_form.html:320
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:323
+#: templates/pages/page_form.html:326
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -2861,28 +2861,28 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
-#: templates/pages/page_form.html:336 templates/pages/page_form.html:337
+#: templates/pages/page_form.html:339 templates/pages/page_form.html:340
 #: templates/pages/page_tree_node.html:113
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:343
+#: templates/pages/page_form.html:346
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:349 templates/pages/page_form.html:367
+#: templates/pages/page_form.html:352 templates/pages/page_form.html:370
 #: templates/pages/page_tree_archived_node.html:98
 #: templates/pages/page_tree_node.html:126
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:353
+#: templates/pages/page_form.html:356
 #: templates/pages/page_tree_archived_node.html:94
 #: templates/pages/page_tree_node.html:122 views/pages/page_actions.py:216
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:354
+#: templates/pages/page_form.html:357
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -2893,15 +2893,15 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: templates/pages/page_form.html:373
+#: templates/pages/page_form.html:376
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: templates/pages/page_form.html:386
+#: templates/pages/page_form.html:389
 msgid "Translator view"
 msgstr "Übersetzeransicht"
 
-#: templates/pages/page_form.html:407
+#: templates/pages/page_form.html:410
 msgid "Show translator view"
 msgstr "Übersetzeransicht anzeigen"
 
@@ -3694,7 +3694,7 @@ msgstr ""
 #: views/events/event_view.py:197 views/imprint/imprint_sbs_view.py:197
 #: views/imprint/imprint_view.py:208
 #: views/organizations/organization_view.py:82 views/pages/page_sbs_view.py:193
-#: views/pages/page_view.py:241 views/regions/region_view.py:85
+#: views/pages/page_view.py:248 views/regions/region_view.py:85
 #: views/settings/user_settings_view.py:89
 #: views/settings/user_settings_view.py:106 views/users/region_user_view.py:116
 #: views/users/user_view.py:119
@@ -3799,28 +3799,28 @@ msgstr ""
 #: views/imprint/imprint_sbs_view.py:195 views/imprint/imprint_view.py:192
 #: views/offer_templates/offer_template_view.py:84
 #: views/organizations/organization_view.py:76 views/pages/page_sbs_view.py:191
-#: views/pages/page_view.py:223 views/regions/region_view.py:79
+#: views/pages/page_view.py:230 views/regions/region_view.py:79
 #: views/users/region_user_view.py:119 views/users/user_view.py:129
 msgid "Errors have occurred."
 msgstr "Es sind Fehler aufgetreten."
 
 #: views/imprint/imprint_sbs_view.py:207 views/imprint/imprint_view.py:241
-#: views/pages/page_sbs_view.py:201 views/pages/page_view.py:275
+#: views/pages/page_sbs_view.py:201 views/pages/page_view.py:282
 msgid "Translation was successfully created and published"
 msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht"
 
 #: views/imprint/imprint_sbs_view.py:210 views/imprint/imprint_view.py:244
-#: views/pages/page_sbs_view.py:204 views/pages/page_view.py:278
+#: views/pages/page_sbs_view.py:204 views/pages/page_view.py:285
 msgid "Translation was successfully created"
 msgstr "Übersetzung wurde erfolgreich erstellt"
 
 #: views/imprint/imprint_sbs_view.py:214 views/imprint/imprint_view.py:247
-#: views/pages/page_sbs_view.py:208 views/pages/page_view.py:281
+#: views/pages/page_sbs_view.py:208 views/pages/page_view.py:288
 msgid "Translation was successfully published"
 msgstr "Übersetzung wurde erfolgreich veröffentlicht"
 
 #: views/imprint/imprint_sbs_view.py:217 views/imprint/imprint_view.py:249
-#: views/pages/page_sbs_view.py:211 views/pages/page_view.py:283
+#: views/pages/page_sbs_view.py:211 views/pages/page_view.py:290
 msgid "Translation was successfully saved"
 msgstr "Übersetzung wurde erfolgreich gespeichert"
 
@@ -3853,7 +3853,7 @@ msgstr "Impressum wurde erfolgreich erstellt und veröffentlicht"
 msgid "imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
-#: views/imprint/imprint_view.py:286 views/pages/page_view.py:322
+#: views/imprint/imprint_view.py:286 views/pages/page_view.py:329
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -4067,11 +4067,11 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Seiten zu bearbeiten oder zu "
 "erstellen."
 
-#: views/pages/page_view.py:77
+#: views/pages/page_view.py:80
 msgid "You cannot edit this page because it is archived."
 msgstr "Sie können diese Seite nicht bearbeiten, weil sie archiviert ist."
 
-#: views/pages/page_view.py:84
+#: views/pages/page_view.py:87
 msgid ""
 "You cannot edit this page, because one of its parent pages is archived and "
 "therefore, this page is archived as well."
@@ -4079,7 +4079,7 @@ msgstr ""
 "Sie können diese Seite nicht bearbeiten, weil eine ihrer übergeordneten "
 "Seiten archiviert ist, und sie dadurch ebenfalls archiviert ist."
 
-#: views/pages/page_view.py:92
+#: views/pages/page_view.py:95
 msgid ""
 "You don't have the permission to edit this page, but you can propose changes "
 "and submit them for review instead."
@@ -4087,7 +4087,7 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu bearbeiten, aber "
 "Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: views/pages/page_view.py:100
+#: views/pages/page_view.py:103
 #, python-format
 msgid ""
 "The latest changes have only been saved as a draft. Currently, <a "
@@ -4098,11 +4098,11 @@ msgstr ""
 "Version <a href='%(revision_url)s' class='underline hover:no-"
 "underline'>Version %(revision)s</a> dieser Seite in der App angezeigt."
 
-#: views/pages/page_view.py:268
+#: views/pages/page_view.py:275
 msgid "Page was successfully created and published"
 msgstr "Seite wurde erfolgreich erstellt und veröffentlicht"
 
-#: views/pages/page_view.py:271
+#: views/pages/page_view.py:278
 msgid "Page was successfully created"
 msgstr "Seite wurde erfolgreich erstellt"
 

--- a/src/cms/templates/_base.html
+++ b/src/cms/templates/_base.html
@@ -282,7 +282,6 @@
         {% endif %}
     </div>
 </nav>
-<input type="text" class="hidden" id="copy_to_clipboard">
 <main class="relative">
     <div class="p-6">
         {% include "messages.html" %}   

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -182,26 +182,29 @@
                             </div>
                         {% endif %}
                     {% endif %}
-                    <label for="{{ page_translation_form.slug.id_for_label }}" class="block mb-2 font-bold">
-                        {{ page_translation_form.slug.label }}
-                        <button type="button" class="p-1 bg-gray-200 rounded ml-2"
-                            onclick='document.getElementById("id_slug").readOnly = false;'>
-                            <i data-feather="edit-2" class="inline-block"></i>
+                    <div id="link-container" class="flex items-center">
+                        <label for="{{ page_translation_form.slug.id_for_label }}" class="mr-2 font-bold">
+                            {{ page_translation_form.slug.label }}:
+                        </label>
+                        <a href="{{ page_link }}{{ page_translation_form.instance.slug }}" class="mr-2 text-blue-500 hover:underline">{{ page_link }}{{ page_translation_form.instance.slug }}</a>
+                        <div class="flex mr-2 hidden flex-grow">
+                            {% spaceless %}
+                            <span>{{ page_link }}</span>
+                            {% render_field page_translation_form.slug|add_error_class:"slug-error" class="flex-grow appearance-none rounded bg-gray-200" %}
+                            {% endspaceless %}
+                        </div>
+                        <button id="edit-slug-btn" type="button" class="mr-2 text-gray-800 hover:text-blue-500">
+                            <i data-feather="edit-3"></i>
                         </button>
-                    </label>
-                    <div class="my-2 text-s text-gray-600">{{ page_translation_form.slug.help_text }}</div>
-                    <div id="slug-div" class="appearance-none w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400">
-                        {% spaceless %}
-                            <div style="display: table; white-space: nowrap;">
-                                <span style="display: table-cell;">https://integreat.app/{{ region.slug }}/{{ language.slug }}/</span>
-                                {% if page_translation_form.instance.ancestor_path %}
-                                    <span style="display: table-cell;">{{ page_translation_form.instance.ancestor_path }}/</span>
-                                {% endif %}
-                                <span class="w-full table-cell">
-                                    {% render_field page_translation_form.slug|add_error_class:"slug-error" class="appearance-none w-full rounded" %}
-                                </span>
-                            </div>
-                        {% endspaceless %}
+                        <button id="copy-slug-btn" type="button" class="text-gray-800 hover:text-blue-500">
+                            <i data-feather="copy"></i>
+                        </button>
+                        <button id="save-slug-btn" type="button" class="mr-2 text-gray-800 hover:text-blue-500 hidden">
+                            <i data-feather="save"></i>
+                        </button>
+                        <button id="restore-slug-btn" type="button" class="text-gray-800 hover:text-blue-500 hidden">
+                            <i data-feather="x-circle"></i>
+                        </button>
                     </div>
                     <label for="{{ page_translation_form.text.id_for_label }}" class="block mb-2 mt-4 font-bold">{{ page_translation_form.text.label }}</label>
                     {% render_field page_translation_form.text class="bg-gray-200 w-full p-2 border border-gray-200 focus:outline-none focus:bg-white focus:border-gray-400 rounded tinymce_textarea" %}

--- a/src/cms/views/pages/page_view.py
+++ b/src/cms/views/pages/page_view.py
@@ -10,6 +10,8 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
 
+from backend.settings import WEBAPP_URL
+
 from ...constants import status
 from ...decorators import region_permission_required
 from ...forms import PageForm, PageTranslationForm
@@ -39,6 +41,7 @@ class PageView(PermissionRequiredMixin, TemplateView, PageContextMixin):
         "PUBLIC": status.PUBLIC,
     }
 
+    # pylint: disable=too-many-locals
     def get(self, request, *args, **kwargs):
         """
         Render :class:`~cms.forms.pages.page_form.PageForm` and :class:`~cms.forms.pages.page_translation_form.PageTranslationForm`
@@ -134,6 +137,9 @@ class PageView(PermissionRequiredMixin, TemplateView, PageContextMixin):
         else:
             siblings = page.parent.children.all()
         context = self.get_context_data(**kwargs)
+        page_link = f"{WEBAPP_URL}/{region.slug}/{language.slug}/"
+        if page and page_translation.ancestor_path:
+            page_link += f"{page_translation.ancestor_path}/"
         return render(
             request,
             self.template_name,
@@ -148,6 +154,7 @@ class PageView(PermissionRequiredMixin, TemplateView, PageContextMixin):
                 # Languages for tab view
                 "languages": region.languages if page else [language],
                 "side_by_side_language_options": side_by_side_language_options,
+                "page_link": page_link,
             },
         )
 

--- a/src/frontend/css/style.scss
+++ b/src/frontend/css/style.scss
@@ -540,11 +540,3 @@ to add animation */
     }
   }
 }
-
-/* page form styling */
-#slug-div {
-  input:read-only {
-      --tw-bg-opacity: 1;
-      background-color: rgba(229, 231, 235, var(--tw-bg-opacity));
-  }
-}

--- a/src/frontend/js/copy-clipboard.ts
+++ b/src/frontend/js/copy-clipboard.ts
@@ -4,15 +4,20 @@ window.addEventListener("load", () => {
       const value = (currentTarget as HTMLElement).getAttribute(
         "data-copy-to-clipboard"
       );
-      const tmpInput = document.createElement("input");
-      tmpInput.type = "text";
-      document.body.appendChild(tmpInput);
-      tmpInput.value = value;
-      tmpInput.select();
-      tmpInput.setSelectionRange(0, 99999);
-
-      document.execCommand("copy");
-      document.body.removeChild(tmpInput);
+      copyToClipboard(value);
     });
   });
 });
+
+
+export function copyToClipboard(value: string){
+  const tmpInput = document.createElement("input");
+  tmpInput.type = "text";
+  document.body.appendChild(tmpInput);
+  tmpInput.value = value;
+  tmpInput.select();
+  tmpInput.setSelectionRange(0, 99999);
+
+  document.execCommand("copy");
+  document.body.removeChild(tmpInput);
+}

--- a/src/frontend/js/forms/update-permalink.ts
+++ b/src/frontend/js/forms/update-permalink.ts
@@ -1,9 +1,17 @@
 /* this file updates the permalink of the current page form
-when the user edited the page translations title */
+when the user edited the page translations title 
+or when the user clicks the permalinks edit button */
 
 import { getCsrfToken } from "../utils/csrf-token";
+import { copyToClipboard } from "../copy-clipboard";
 
 window.addEventListener("load", () => {
+  /* slug field buffer for restoring input value */
+  var currentSlug: string;
+  /* slug field to be updated */
+  var slugField = <HTMLInputElement>document.getElementById("id_slug");
+  var linkContainer = document.getElementById("link-container");
+
   if (
     document.getElementById("id_title") &&
     (document.querySelector('[for="id_title"]') as HTMLElement)?.dataset
@@ -16,12 +24,59 @@ window.addEventListener("load", () => {
         const url = (document.querySelector('[for="id_title"]') as HTMLElement)
           .dataset.slugifyUrl;
         slugify(url, { title: currentTitle }).then((response) => {
-          document
-            .getElementById("id_slug")
-            .setAttribute("value", response["unique_slug"]);
+          /* on success write response to both slug field and permalink */
+          slugField.value = response["unique_slug"];
+          updatePermalink(response["unique_slug"]);
         });
       });
   }
+
+
+  function toggleSlugMode(){
+    // toggle all permalink buttons
+    let buttonList = document.getElementById("link-container").querySelectorAll("button");
+    for (let button of buttonList) {
+      button.classList.toggle("hidden");
+    }
+    // switch between link and slug field
+    linkContainer.querySelector("a").classList.toggle("hidden");
+    linkContainer.querySelector("div").classList.toggle("hidden");
+  }
+
+
+  function updatePermalink(currentSlug: string){
+    // get complete permalink string
+    let currentLink = linkContainer.querySelector("a").innerHTML;
+    // remove trailing slug from link
+    let updatedLink = currentLink.substr(0, currentLink.lastIndexOf("/")+1);
+    // update only inner html and keep href until form submission
+    linkContainer.querySelector("a").innerHTML = updatedLink.concat(currentSlug);
+  }
+
+  document.getElementById("edit-slug-btn").addEventListener("click", function(e){
+    // buffer the current slug field and toggle to editable
+    currentSlug = slugField.value;
+    toggleSlugMode();
+  });
+
+
+  document.getElementById("save-slug-btn").addEventListener("click", function(e){
+    updatePermalink(slugField.value);
+    toggleSlugMode();
+  });
+
+
+  document.getElementById("copy-slug-btn").addEventListener("click", function(e){
+    // copy whole permalink to clipboard
+    copyToClipboard(linkContainer.querySelector("a").innerHTML);
+  });
+
+
+  document.getElementById("restore-slug-btn").addEventListener("click", function(e){
+    // hide slug field and restore slug value
+    slugField.value = currentSlug;
+    toggleSlugMode();
+  });
 });
 
 async function slugify(url: string, data: any) {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Improve page link field 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Per default page link field is read-only.
- Deactivating read-only displays a form field, where user can edit manually.
- After editing user can click the save button to confirm the changes (saves to the input field, changes only get persistent on form       submission)
- When clicking the abort button, the previous slug value is restored

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #735

### Screenshots

![Screenshot from 2021-03-17 11-24-41](https://user-images.githubusercontent.com/47010475/111453388-d1dd4600-8713-11eb-83e8-2a410ed4e859.png)

![Screenshot from 2021-03-17 12-58-30](https://user-images.githubusercontent.com/47010475/111464003-867d6480-8720-11eb-8465-c30a1ff63911.png)



