### PR TITLE
Apache2: Add app online ping rule

### DIFF
--- a/example-configs/apache2-integreat-vhost.conf
+++ b/example-configs/apache2-integreat-vhost.conf
@@ -37,4 +37,8 @@ WSGIPythonHome /opt/integreat-cms/.venv/
         SetEnv DJANGO_DB_PASSWORD SECRET
         SetEnv DJANGO_STATIC_ROOT /var/www/cms/static
         SetEnv DJANGO_MEDIA_ROOT /var/www/cms/media
+
+        RewriteEngine On
+        # Ping response for app online check
+        RewriteRule "^ping$" - [R=204]
 </VirtualHost>


### PR DESCRIPTION
Add Apache2 config entry to return a 204 for the `/ping` URL. This enables the app to check its online status.