### PR TITLE
Add clean parameter to install.sh 

### DIFF
--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -53,6 +53,11 @@ fi
 
 cd $(dirname "$BASH_SOURCE")/..
 
+if [ "$1" == "--clean" ]; then
+  echo "Removing installed dependencies and compiled static files."
+  rm -rf .venv node_modules src/cms/static
+fi
+
 # Install npm dependencies
 npm install
 

--- a/sphinx/dev-tools.rst
+++ b/sphinx/dev-tools.rst
@@ -11,7 +11,12 @@ Installation
 
 Install all project dependencies and the local python package with :github-source:`dev-tools/install.sh`::
 
-    ./dev-tools/install.sh
+    ./dev-tools/install.sh [--clean]
+
+If the ``--clean`` parameter is provided, the script will clean all installed dependencies in the ``.venv/`` and
+``node_modules/`` directories as well as compiled static files in ``src/cms/static/``. Existing outdated JavaScript
+files in these directories can cause compilation failures for the :doc:`frontend-bundling`.
+
 
 Update all project dependencies and fix security issues with :github-source:`dev-tools/update_dependencies.sh`::
 

--- a/sphinx/troubleshooting.rst
+++ b/sphinx/troubleshooting.rst
@@ -4,6 +4,14 @@ Troubleshooting
 
 .. highlight:: bash
 
+.. admonition:: General Advice
+
+    If you are experiencing problems of any kind, make sure you have a clean working environment by executing::
+
+        ./dev-tools/install.sh --clean
+        ./dev-tools/prune_database.sh
+
+    before trying anything else.
 
 Pipenv not found
 ================
@@ -127,3 +135,20 @@ MacOS on M1
 
         pipenv run pip uninstall psycopg2-binary
         pipenv run pip install psycopg2-binary --no-cache-dir
+
+
+Webpack Compilation Errors
+==========================
+.. Error::
+
+    .. code-block:: text
+
+        ERROR in /path/to/integreat-cms/src/cms/static/@nodelib/...
+        ...
+        [tsl] ERROR in ...
+        TSXXXX: ...
+
+.. admonition:: Solution
+    :class: hint
+
+    There may be remnants of old JavaScript libraries in your installation. Run ``./dev-tools/install --clean`` to remove ``node_modules/`` and ``src/cms/static/`` or clean these directories manually.


### PR DESCRIPTION
### Short description
If `./node_modules` or `./src/cms/static/*` contain legacy JS files, this may result in Webpack compilation errors.

### Proposed changes
The `install.sh` removes the `./node_modules` and `./src/cms/static/*` directories.