### PR TITLE
Fix PDF font style bug

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-18 13:42+0000\n"
+"POT-Creation-Date: 2021-03-20 14:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3553,7 +3553,7 @@ msgid "No valid pages selected for PDF generation."
 msgstr ""
 "Es wurden keine gültigen Seiten zur Erzeugung der PDF-Datei ausgewählt."
 
-#: utils/pdf_utils.py:105
+#: utils/pdf_utils.py:106
 msgid "The PDF could not be successfully generated."
 msgstr "PDF-Datei konnte nicht erfolgreich erzeugt werden."
 

--- a/src/cms/templates/pages/page_pdf.html
+++ b/src/cms/templates/pages/page_pdf.html
@@ -16,6 +16,16 @@
         for detailed information about the applied library concepts see
         the documentation of xhtml2pdf -->
         <link href="{% static 'pdf.css' %}" rel="stylesheet" type="text/css">
+        {% if language.slug not in prevent_italics %}
+            <!-- TODO In the moment the only font-family we could find that supports:
+            xhtml2pdf, arabic letters and italic style is DejaVu
+            but DejaVu has the drawback that it does not support for:
+            arabic and italic at the same time, so italic is not available for arabic -->
+            <style type="text/css">
+                em {font-family: DejaVu-Oblique;}
+                pdftoc.pdftoclevel2 {font-family: DejaVu-Oblique;}
+            </style>
+        {% endif %}
     </head>
     <body>
         <div id="header">
@@ -58,7 +68,11 @@
         {% recursetree pages %}
             <li>
                 {% get_public_translation node language.slug as page_translation %}
-                <h1 class="{% if node.level == 0 %}root_title{% endif %}">{{ page_translation.title }}</h1>
+                {% if node.level < 2 %}
+                    <h1 class="{% if node.level == 0 %}root_title{% endif %}">{{ page_translation.title }}</h1>
+                {% else %}
+                    <h2>{{ page_translation.title }}</h2>
+                {% endif %}
                 <div class="content" style="padding-bottom: 30px;">
                     {{ page_translation.text|safe }}
                 </div>
@@ -72,6 +86,5 @@
         {% if right_to_left %}
             </div>
         {% endif %}
-
     </body>
 </html>

--- a/src/cms/utils/pdf_utils.py
+++ b/src/cms/utils/pdf_utils.py
@@ -87,6 +87,7 @@ def generate_pdf(region, language_slug, pages):
         "pages": pages,
         "language": language,
         "amount_pages": amount_pages,
+        "prevent_italics": ["ar", "fa"],
     }
     response = HttpResponse(content_type="application/pdf")
     response["Content-Disposition"] = f'filename="{filename}"'

--- a/src/frontend/css/pdf_page_export.css
+++ b/src/frontend/css/pdf_page_export.css
@@ -1,3 +1,15 @@
+@font-face {
+    font-family: DejaVu;
+    src: url('../fonts/dejavu_sans/DejaVuSans.ttf') format('truetype');
+}
+@font-face {
+    font-family: DejaVu-Bold;
+    src: url('../fonts/dejavu_sans/DejaVuSans-Bold.ttf') format('truetype');
+}
+@font-face {
+    font-family: DejaVu-Oblique;
+    src: url('../fonts/dejavu_sans/DejaVuSans-Oblique.ttf') format('truetype');
+}
 @page {
     size: a4;
     margin: 2cm;
@@ -46,10 +58,6 @@
         border-top-width: 1px;
     }
 }
-@font-face {
-    font-family: DejaVu;
-    src: url('../fonts/dejavu_sans/DejaVuSans.ttf') format('truetype');
-}
 html, body {
     font-family: DejaVu;
 }
@@ -64,27 +72,27 @@ pdftoc {
 } 
 pdftoc.pdftoclevel0 {
     /* applied only to the root of the page tree */
-    font-weight: bold;
+    font-family: DejaVu-Bold;
 }
 pdftoc.pdftoclevel1 {
     /* applied for all children of the root page */
-    font-weight: bold;
+    font-family: DejaVu-Bold;
     margin-left: 2em;
 }
 pdftoc.pdftoclevel2 {
     /* applied to all sub headers of the pages */
-    font-weight: normal;
     margin-left: 4em;
-    font-style: italic;
 }
 h1 {
     font-size: xx-large;
+    font-family: DejaVu-Bold;
     margin: 0.67em 0;
     /* set the level on which the tag is mapped to toc */
     -pdf-outline-level: 1;
 }
 h2,h3,h4,h5,h6 {
     font-size: x-large;
+    font-family: DejaVu-Bold;
     margin: 0.83em 0;
     padding: 3px 0px;
     -pdf-outline-level: 2;
@@ -121,4 +129,8 @@ li {
     text-align: right;
     background-color: white;
 }
+strong {
+    font-family: DejaVu-Bold;
+}
+
 


### PR DESCRIPTION

### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes bold/italic font styles in PDF export

### Proposed changes
<!-- Describe this PR in more detail. -->

- The current font for PDF generation is DejaVu, which is a static
  font-family. That means different font wheights and styles are shiped
  in different files (see folder `cms.frontend.fonts.dejavu-sans`).
- xhtml2pdf + DejaVu accept arabic letters, but not in combination with
  italic style, so italic styles are excluded from arabic documents.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #751
