### PR TITLE
Fixes non-existing translation PDF export

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-20 14:14+0000\n"
+"POT-Creation-Date: 2021-03-23 15:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -2300,7 +2300,7 @@ msgstr "Löschen"
 
 #: templates/feedback/admin_feedback_list.html:139
 #: templates/feedback/region_feedback_list.html:133
-#: templates/pages/page_tree.html:129
+#: templates/pages/page_tree.html:130
 msgid "Execute"
 msgstr "Ausführen"
 
@@ -2953,19 +2953,19 @@ msgstr "Noch keine Seiten vorhanden."
 msgid "Archive pages"
 msgstr "Seiten archivieren"
 
-#: templates/pages/page_tree.html:116
+#: templates/pages/page_tree.html:117
 msgid "Export as PDF"
 msgstr "Als PDF Exportieren"
 
-#: templates/pages/page_tree.html:120
+#: templates/pages/page_tree.html:121
 msgid "Export XLIFF for translation to"
 msgstr "Exportiere XLIFF für Übersetzung nach"
 
-#: templates/pages/page_tree.html:135
+#: templates/pages/page_tree.html:136
 msgid "Upload XLIFF File"
 msgstr "XLIFF-Datei hochladen"
 
-#: templates/pages/page_tree.html:145
+#: templates/pages/page_tree.html:146
 msgid "Upload"
 msgstr "Hochladen"
 
@@ -3954,32 +3954,32 @@ msgstr ""
 msgid "Page was successfully deleted"
 msgstr "Seite wurde erfolgreich gelöscht"
 
-#: views/pages/page_actions.py:520
+#: views/pages/page_actions.py:523
 #, python-brace-format
 msgid "The page \"{page}\" was successfully moved."
 msgstr "Die Seite \"{page}\" wurde erfolgreich verschoben."
 
-#: views/pages/page_actions.py:608 views/pages/page_actions.py:623
+#: views/pages/page_actions.py:611 views/pages/page_actions.py:626
 #, python-brace-format
 msgid "Information: The user {user} has this permission already."
 msgstr "Information: Der Nutzer {user} hat diese Berechtigung bereits"
 
-#: views/pages/page_actions.py:615
+#: views/pages/page_actions.py:618
 #, python-brace-format
 msgid "Success: The user {user} can now edit this page."
 msgstr "Erfolg: Der Nutzer {user} kann nun diese Seite bearbeiten"
 
-#: views/pages/page_actions.py:631
+#: views/pages/page_actions.py:634
 #, python-brace-format
 msgid "Success: The user {user} can now publish this page."
 msgstr "Erfolg: Der Nutzer {user} kann dieses Seite nun veröffentlichen"
 
-#: views/pages/page_actions.py:640 views/pages/page_actions.py:755
+#: views/pages/page_actions.py:643 views/pages/page_actions.py:758
 msgid "An error has occurred. Please contact an administrator."
 msgstr ""
 "Ein Fehler ist aufgetreten. Bitte kontaktieren Sie einen Administrator."
 
-#: views/pages/page_actions.py:723
+#: views/pages/page_actions.py:726
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the editors of this page, "
@@ -3989,12 +3989,12 @@ msgstr ""
 "bearbeiten wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin bearbeiten."
 
-#: views/pages/page_actions.py:729
+#: views/pages/page_actions.py:732
 #, python-brace-format
 msgid "Success: The user {user} cannot edit this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr bearbeiten"
 
-#: views/pages/page_actions.py:740
+#: views/pages/page_actions.py:743
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the publishers of this "
@@ -4004,7 +4004,7 @@ msgstr ""
 "veröffentlichen wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen."
 
-#: views/pages/page_actions.py:746
+#: views/pages/page_actions.py:749
 #, python-brace-format
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"

--- a/src/cms/templates/pages/page_tree.html
+++ b/src/cms/templates/pages/page_tree.html
@@ -113,7 +113,8 @@
                 <select id="bulk-action" class="block appearance-none bg-gray-200 border border-gray-200 text-gray-800 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-400">
                     <option>{% trans 'Select bulk action' %}</option>
                     <!-- TODO: <option data-bulk-action="">{% trans 'Archive pages' %}</option> -->
-                    <option data-bulk-action="{% url 'export_pdf' region_slug=region.slug language_slug=language.slug %}" data-target="_blank">{% trans 'Export as PDF' %}</option>
+                    <option id="pdf-export-option" data-bulk-action="{% url 'export_pdf' region_slug=region.slug language_slug=language.slug %}"
+                        data-target="_blank" data-language-slug="{{ language.slug }}">{% trans 'Export as PDF' %}</option>
                     {% if request.user.profile.expert_mode %}
                         {% for target_language in languages %}
                             {% if target_language != region.default_language %}

--- a/src/cms/views/pages/page_actions.py
+++ b/src/cms/views/pages/page_actions.py
@@ -257,8 +257,11 @@ def export_pdf(request, region_slug, language_slug):
     pages = region.pages.filter(explicitly_archived=False, id__in=page_ids)
     # generate PDF document wrapped in a HtmlResponse object
     response = generate_pdf(region, language_slug, pages)
-    # offer PDF document for download
-    response["Content-Disposition"] = response["Content-Disposition"] + "; attachment"
+    if response.status_code == 200:
+        # offer PDF document for download
+        response["Content-Disposition"] = (
+            response["Content-Disposition"] + "; attachment"
+        )
     return response
 
 

--- a/src/frontend/js/bulk-actions.ts
+++ b/src/frontend/js/bulk-actions.ts
@@ -65,11 +65,14 @@ window.addEventListener("load", () => {
 
   function toggleBulkActionButton() {
     // Only activate button if at least one item and the action is selected
+    // also check if at least one page translation exists for PDF export before activation
+    let selectedAction = bulkAction.options[bulkAction.selectedIndex];
     if (
       !selectItems
         .filter(isInputElement)
         .some((el) => el.checked) ||
-      bulkAction.selectedIndex === 0
+      bulkAction.selectedIndex === 0 ||
+      (selectedAction.id === "pdf-export-option" && !hasTranslation())
     ) {
       bulkActionButton.classList.remove(
         "bg-blue-500",
@@ -102,5 +105,18 @@ window.addEventListener("load", () => {
     }
     // Submit form and execute bulk action
     form.submit();
+  }
+
+  function hasTranslation(): boolean {
+    // checks if at least one of the selected pages has a translation for the current language
+    let languageSlug = document.getElementById("pdf-export-option").dataset.languageSlug;
+    return selectItems
+      .filter(isInputElement)
+      .filter(inputElement => inputElement.checked)
+      .some(inputElement => {
+        return inputElement
+          .closest("tr")
+          .querySelector(`.lang-grid .${languageSlug} .no-trans`) === null;
+      });
   }
 });


### PR DESCRIPTION

### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes KeyError exception when only non-existing page translations are selected for PDF export

### Proposed changes
<!-- Describe this PR in more detail. -->

- Adds a function to check, whether at least one translation exists for
  the selected pages.
- If this is the case, PDF export for the selection is allowed else
  denied.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #753

### Additional context

This new function should enable both proposed approaches: User dialog or disabled bulk-action-button.
