### PR TITLE
Improve handling of administrative division

### DIFF
--- a/src/api/v3/regions.py
+++ b/src/api/v3/regions.py
@@ -22,10 +22,10 @@ def transform_region(region):
     """
     return {
         "id": region.id,
-        "name": region.get_administrative_division_display() + " " + region.name,
+        "name": region.full_name,
         "path": region.slug,
         "live": region.status == region_status.ACTIVE,
-        "prefix": region.get_administrative_division_display(),
+        "prefix": region.prefix,
         "name_without_prefix": region.name,
         "plz": region.postal_code,
         "extras": region.offers_enabled,
@@ -47,20 +47,10 @@ def transform_region_by_status(region):
     :return: return data necessary for API
     :rtype: dict
     """
-    return {
-        "id": region.id,
-        "name": region.get_administrative_division_display() + " " + region.name,
-        "path": region.slug,
-        "prefix": region.get_administrative_division_display(),
-        "name_without_prefix": region.name,
-        "plz": region.postal_code,
-        "offers": region.offers_enabled,
-        "events": region.events_enabled,
-        "push-notifications": region.push_notifications_enabled,
-        "longitude": region.longitude,
-        "latitude": region.latitude,
-        "aliases": region.aliases,
-    }
+    result = transform_region(region)
+    # Remove status
+    del result["live"]
+    return result
 
 
 @json_response

--- a/src/cms/fixtures/test_data.json
+++ b/src/cms/fixtures/test_data.json
@@ -35,6 +35,7 @@
       "slug": "augsburg",
       "status": "ACTIVE",
       "administrative_division": "CITY",
+      "administrative_division_included": true,
       "aliases": "[\"Haunstetten\",\"Friedberg\"]",
       "events_enabled": true,
       "chat_enabled": true,

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-23 16:16+0000\n"
+"POT-Creation-Date: 2021-03-24 01:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -227,12 +227,12 @@ msgstr "Einmalig stattfindende Veranstaltungen"
 msgid "Active"
 msgstr "Aktiv"
 
-#: constants/region_status.py:17 models/regions/region.py:330
+#: constants/region_status.py:17 models/regions/region.py:359
 msgid "Hidden"
 msgstr "Versteckt"
 
 #: constants/region_status.py:18 models/pages/page.py:190
-#: models/pages/page_translation.py:256 models/regions/region.py:333
+#: models/pages/page_translation.py:256 models/regions/region.py:362
 #: templates/pages/page_form.html:152
 #: templates/pages/page_tree_archived_node.html:13
 msgid "Archived"
@@ -452,7 +452,7 @@ msgstr "Kategorie"
 #: templates/pages/page_tree.html:67 templates/pages/page_tree_archived.html:26
 #: templates/pois/poi_form.html:109 templates/pois/poi_list.html:45
 #: templates/pois/poi_list_archived.html:28
-#: templates/regions/region_list.html:32
+#: templates/regions/region_list.html:31
 msgid "Status"
 msgstr "Status"
 
@@ -555,7 +555,7 @@ msgstr "Wert"
 #: models/pois/poi_translation.py:71
 #: models/push_notifications/push_notification.py:42
 #: models/push_notifications/push_notification_translation.py:38
-#: models/regions/region.py:106 models/users/organization.py:28
+#: models/regions/region.py:108 models/users/organization.py:28
 #: models/users/user_mfa.py:37
 msgid "creation date"
 msgstr "Erstellungsdatum"
@@ -568,7 +568,7 @@ msgstr "Erstellungsdatum"
 #: models/pois/poi_translation.py:75
 #: models/push_notifications/push_notification.py:46
 #: models/push_notifications/push_notification_translation.py:42
-#: models/regions/region.py:110 models/users/organization.py:32
+#: models/regions/region.py:112 models/users/organization.py:32
 msgid "modification date"
 msgstr "Änderungsdatum"
 
@@ -584,7 +584,7 @@ msgstr "Einstellungen"
 #: models/languages/language_tree_node.py:37 models/offers/offer.py:24
 #: models/pages/imprint_page.py:21 models/pages/page.py:43
 #: models/pois/poi.py:18 models/push_notifications/push_notification.py:18
-#: models/regions/region.py:349
+#: models/regions/region.py:378
 msgid "region"
 msgstr "Region"
 
@@ -630,7 +630,7 @@ msgid "events"
 msgstr "Veranstaltungen"
 
 #: models/events/event_translation.py:29 models/pois/poi_translation.py:24
-#: models/regions/region.py:39
+#: models/regions/region.py:41
 msgid "URL parameter"
 msgstr "URL-Parameter"
 
@@ -653,7 +653,7 @@ msgstr ""
 
 #: models/events/event_translation.py:41
 #: models/pages/abstract_base_page_translation.py:27
-#: models/pois/poi_translation.py:42 models/regions/region.py:50
+#: models/pois/poi_translation.py:42 models/regions/region.py:52
 msgid "status"
 msgstr "Status"
 
@@ -1025,7 +1025,7 @@ msgstr "Angebote"
 
 #: models/offers/offer_template.py:16
 #: models/push_notifications/push_notification_channel.py:10
-#: models/regions/region.py:23 models/users/organization.py:11
+#: models/regions/region.py:25 models/users/organization.py:11
 #: models/users/user_mfa.py:17
 msgid "name"
 msgstr "Name"
@@ -1034,7 +1034,7 @@ msgstr "Name"
 msgid "slug"
 msgstr "URL-Parameter"
 
-#: models/offers/offer_template.py:25 models/regions/region.py:42
+#: models/offers/offer_template.py:25 models/regions/region.py:44
 msgid "Leave blank to generate unique parameter from name"
 msgstr ""
 "Dieses Feld freilassen, um einen eindeutigen Alias aus dem Namen zu "
@@ -1061,7 +1061,7 @@ msgstr "POST-Parameter"
 msgid "Additional POST data for retrieving the URL."
 msgstr "Zusätzliche POST-Daten zum Abrufen der URL."
 
-#: models/offers/offer_template.py:40 models/regions/region.py:67
+#: models/offers/offer_template.py:40 models/regions/region.py:69
 msgid "Specify as JSON."
 msgstr "Als JSON angeben."
 
@@ -1217,7 +1217,7 @@ msgstr "Seitenlink"
 msgid "street and house number"
 msgstr "Straße und Hausnummer"
 
-#: models/pois/poi.py:23 models/regions/region.py:98
+#: models/pois/poi.py:23 models/regions/region.py:100
 msgid "postal code"
 msgstr "Postleitzahl"
 
@@ -1229,7 +1229,7 @@ msgstr "Stadt"
 msgid "country"
 msgstr "Land"
 
-#: models/pois/poi.py:27 models/regions/region.py:90
+#: models/pois/poi.py:27 models/regions/region.py:92
 msgid "latitude"
 msgstr "Geographische Breite"
 
@@ -1237,7 +1237,7 @@ msgstr "Geographische Breite"
 msgid "The latitude coordinate"
 msgstr "Die Breitengrad-Koordinate"
 
-#: models/pois/poi.py:30 models/regions/region.py:95
+#: models/pois/poi.py:30 models/regions/region.py:97
 msgid "longitude"
 msgstr "Geographische Länge"
 
@@ -1312,7 +1312,7 @@ msgid "push notification channel"
 msgstr "Push-Benachrichtigungskanal"
 
 #: models/push_notifications/push_notification_channel.py:36
-#: models/regions/region.py:84
+#: models/regions/region.py:86
 msgid "push notification channels"
 msgstr "Push-Benachrichtigungskanäle"
 
@@ -1324,85 +1324,85 @@ msgstr "Push-Benachrichtigungs-Übersetzung"
 msgid "push notification translations"
 msgstr "Push-Benachrichtigungs-Übersetzungen"
 
-#: models/regions/region.py:29
+#: models/regions/region.py:31
 msgid "community identification number"
 msgstr "Amtlicher Gemeindeschlüssel"
 
-#: models/regions/region.py:31
+#: models/regions/region.py:33
 msgid ""
 "Number sequence for identifying politically independent administrative units"
 msgstr ""
 "Ziffernfolge zur Identifizierung politisch selbständiger Verwaltungseinheiten"
 
-#: models/regions/region.py:41 models/users/organization.py:17
+#: models/regions/region.py:43 models/users/organization.py:17
 msgid "Unique string identifier without spaces and special characters."
 msgstr "Eindeutiger Bezeichner ohne Leerzeichen und Sonderzeichen."
 
-#: models/regions/region.py:59
+#: models/regions/region.py:61
 msgid "administrative division"
 msgstr "Verwaltungseinheit"
 
-#: models/regions/region.py:63
+#: models/regions/region.py:65
 msgid "aliases"
 msgstr "Aliasnamen"
 
-#: models/regions/region.py:65
+#: models/regions/region.py:67
 msgid "E.g. smaller municipalities in that area."
 msgstr "Z.B. kleinere Gemeinden in der Region."
 
-#: models/regions/region.py:66
+#: models/regions/region.py:68
 msgid "If empty, the CMS will try to fill this automatically."
 msgstr "Wird, wenn leer, automatisch vom CMS befüllt."
 
-#: models/regions/region.py:73
+#: models/regions/region.py:75
 msgid "activate events"
 msgstr "Veranstaltungen aktivieren"
 
-#: models/regions/region.py:74
+#: models/regions/region.py:76
 msgid "Whether or not events are enabled in the region"
 msgstr "Ob Ereignisse in der Region aktiviert sind oder nicht"
 
-#: models/regions/region.py:78
+#: models/regions/region.py:80
 msgid "activate push notifications"
 msgstr "Push-Benachrichtigungen aktivieren"
 
-#: models/regions/region.py:79
+#: models/regions/region.py:81
 msgid "Whether or not push notifications are enabled in the region"
 msgstr "Ob Push-Benachrichtigungen in der Region aktiviert sind oder nicht"
 
-#: models/regions/region.py:85
+#: models/regions/region.py:87
 msgid "Enter multiple channels separated by commas."
 msgstr "Mehrere Kanäle mit Kommata getrennt eingeben."
 
-#: models/regions/region.py:91
+#: models/regions/region.py:93
 msgid "The latitude coordinate of an approximate center of the region"
 msgstr "Die Breitengrad-Koordinate eines ungefähren Mittelpunkts der Region"
 
-#: models/regions/region.py:96
+#: models/regions/region.py:98
 msgid "The longitude coordinate of an approximate center of the region"
 msgstr "Die Längengrad-Koordinate eines ungefähren Mittelpunkts der Region"
 
-#: models/regions/region.py:101
+#: models/regions/region.py:103
 msgid "email address of the administrator"
 msgstr "E-Mail-Adresse des Administrators"
 
-#: models/regions/region.py:115
+#: models/regions/region.py:117
 msgid "activate statistics"
 msgstr "Statistiken aktivieren"
 
-#: models/regions/region.py:116
+#: models/regions/region.py:118
 msgid "Whether or not statistics are enabled for the region"
 msgstr "Ob Statistiken für die Region aktiviert sind oder nicht"
 
-#: models/regions/region.py:119
+#: models/regions/region.py:121
 msgid "Matomo URL"
 msgstr "Matomo-URL"
 
-#: models/regions/region.py:125
+#: models/regions/region.py:127
 msgid "Matomo authentication token"
 msgstr "Matomo Authentifizierungs-Token"
 
-#: models/regions/region.py:127
+#: models/regions/region.py:129
 msgid ""
 "The secret Matomo access token of the region is used to authenticate in API "
 "requests"
@@ -1410,21 +1410,21 @@ msgstr ""
 "Das geheime Matomo-Zugangs-Token der Region wird zur Authentifizierung bei "
 "API-Anfragen verwendet"
 
-#: models/regions/region.py:132
+#: models/regions/region.py:134
 msgid "activate SSL verification for Matomo"
 msgstr "SSL-Verifikation für Matomo aktivieren"
 
-#: models/regions/region.py:134
+#: models/regions/region.py:136
 msgid "Don't allow invalid SSL-certificates when interacting with Matomo API"
 msgstr ""
 "Erlaube keine ungültigen SSL-Zertifikate bei der Interaktion mit der Matomo "
 "API"
 
-#: models/regions/region.py:140
+#: models/regions/region.py:142
 msgid "activate page-specific permissions"
 msgstr "Seiten-spezifische-Berechtigungen aktivieren"
 
-#: models/regions/region.py:142
+#: models/regions/region.py:144
 msgid ""
 "This allows individual users to be granted the right to edit or publish a "
 "specific page."
@@ -1432,26 +1432,26 @@ msgstr ""
 "Damit kann einzelnen Benutzern das Recht zum Bearbeiten oder Veröffentlichen "
 "einer bestimmten Seite eingeräumt werden."
 
-#: models/regions/region.py:150 models/users/organization.py:23
+#: models/regions/region.py:152 models/users/organization.py:23
 msgid "logo"
 msgstr "Logo"
 
-#: models/regions/region.py:155
+#: models/regions/region.py:157
 msgid "activate author chat"
 msgstr "Autoren-Chat aktivieren"
 
-#: models/regions/region.py:157
+#: models/regions/region.py:159
 msgid ""
 "This gives all users of this region access to the cross-regional author chat."
 msgstr ""
 "Dies gewährt allen Benutzern dieser Region Zugang zum überregionalen Autoren-"
 "Chat."
 
-#: models/regions/region.py:163
+#: models/regions/region.py:165
 msgid "include administrative division into name"
 msgstr "Verwaltungseinheit dem Namen hinzufügen"
 
-#: models/regions/region.py:166
+#: models/regions/region.py:168
 msgid ""
 "Determines whether the administrative division is displayed next to the "
 "region name."
@@ -1459,7 +1459,7 @@ msgstr ""
 "Legt fest, ob die Verwaltungseinheit neben dem Namen der Region angezeigt "
 "wird."
 
-#: models/regions/region.py:169
+#: models/regions/region.py:171
 msgid ""
 "Sorting is always based on the name, independently from the administrative "
 "division."
@@ -1467,7 +1467,7 @@ msgstr ""
 "Sortierungen werden immer auf Grundlage der Namen vorgenommen, unabhängig "
 "von der Verwaltungseinheit."
 
-#: models/regions/region.py:351 models/users/user_profile.py:30
+#: models/regions/region.py:380 models/users/user_profile.py:30
 msgid "regions"
 msgstr "Regionen"
 
@@ -2628,13 +2628,13 @@ msgstr "Schreibrichtung"
 
 #: templates/languages/language_list.html:30
 #: templates/offer_templates/offer_template_list.html:28
-#: templates/regions/region_list.html:30
+#: templates/regions/region_list.html:29
 msgid "Created"
 msgstr "Erstellt"
 
 #: templates/languages/language_list.html:31
 #: templates/offer_templates/offer_template_list.html:27
-#: templates/pages/page_tree.html:83 templates/regions/region_list.html:31
+#: templates/pages/page_tree.html:83 templates/regions/region_list.html:30
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
 
@@ -2658,7 +2658,7 @@ msgstr "Datei hochladen"
 #: templates/offer_templates/offer_template_list.html:24
 #: templates/offers/offer_list.html:31
 #: templates/organizations/organization_list.html:24
-#: templates/regions/region_list.html:29 templates/roles/list.html:24
+#: templates/regions/region_list.html:28 templates/roles/list.html:24
 msgid "Name"
 msgstr "Name"
 
@@ -2714,7 +2714,7 @@ msgid "Active since"
 msgstr "Aktiv seit"
 
 #: templates/offers/offer_list.html:33 templates/pages/page_form.html:306
-#: templates/regions/region_list.html:33 templates/settings/user.html:59
+#: templates/regions/region_list.html:32 templates/settings/user.html:59
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -3260,15 +3260,11 @@ msgstr "Regionen"
 msgid "Create region"
 msgstr "Region erstellen"
 
-#: templates/regions/region_list.html:28
-msgid "Administrative division"
-msgstr "Verwaltungseinheit"
-
-#: templates/regions/region_list.html:42
+#: templates/regions/region_list.html:41
 msgid "No regions available yet."
 msgstr "Noch keine Regionen vorhanden."
 
-#: templates/regions/region_list_row.html:31
+#: templates/regions/region_list_row.html:26
 msgid "Open Dashboard"
 msgstr "Dashboard öffnen"
 
@@ -4313,6 +4309,9 @@ msgid ""
 msgstr ""
 "Ein Benutzer muss entweder Mitarbeiter/Super-Administrator sein, oder "
 "mindestens einer Region zugewiesen sein."
+
+#~ msgid "Administrative division"
+#~ msgstr "Verwaltungseinheit"
 
 #~ msgid "Region name option"
 #~ msgstr "Option zum Namen der Region"

--- a/src/cms/models/regions/region.py
+++ b/src/cms/models/regions/region.py
@@ -6,6 +6,8 @@ from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.utils import timezone
 from django.utils.safestring import mark_safe
+from django.utils.translation import activate
+from django.utils.translation import get_language
 from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 from django.shortcuts import get_object_or_404
@@ -193,6 +195,33 @@ class Region(models.Model):
         """
         tree_root = self.language_tree_nodes.filter(level=0).first()
         return tree_root.language if tree_root else None
+
+    @property
+    def prefix(self):
+        """
+        This property returns the administrative division of a region if it's included in the name
+
+        :return: The prefix of the region
+        :rtype: str
+        """
+        if self.administrative_division_included:
+            # Get administrative division in region's default language
+            current_language = get_language()
+            activate(self.default_language.slug)
+            prefix = self.get_administrative_division_display()
+            activate(current_language)
+            return prefix
+        return ""
+
+    @property
+    def full_name(self):
+        """
+        This property returns the full name of a region including its administrative division
+
+        :return: The full name of the region
+        :rtype: str
+        """
+        return f"{self.prefix} {self.name}".strip()
 
     @property
     def users(self):

--- a/src/cms/templates/pages/page_pdf.html
+++ b/src/cms/templates/pages/page_pdf.html
@@ -43,10 +43,7 @@
                         <pdf:pagenumber>
                     </td>
                     <td id="second-footer">
-                        {% if region.administrative_division_included %}
-                            {% language 'de' %}{{ region.get_administrative_division_display }} {% endlanguage %}
-                        {% endif %}
-                        {{ region.name }}
+                        {{ region.full_name }}
                     </td>
                     <td id="third-footer">
                         <img src="{% static 'images/integreat-logo.jpg' %}" height="40">

--- a/src/cms/templates/regions/region_list.html
+++ b/src/cms/templates/regions/region_list.html
@@ -25,7 +25,6 @@
     <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
         <thead>
             <tr class="border-b border-solid border-gray-200">
-                <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Administrative division' %}</th>
                 <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Name' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Created' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Last updated' %}</th>

--- a/src/cms/templates/regions/region_list_row.html
+++ b/src/cms/templates/regions/region_list_row.html
@@ -3,12 +3,7 @@
 <tr class="border-t border-solid border-gray-200 hover:bg-gray-100">
     <td class="pl-2">
         <a href="{% url 'edit_region' region_slug=region.slug %}" class="block py-3 px-2 text-gray-800">
-        	{{ region.get_administrative_division_display }}
-        </a>
-    </td>
-    <td>
-        <a href="{% url 'edit_region' region_slug=region.slug %}" class="block py-3 px-2 text-gray-800">
-            {{ region.name }}
+            {{ region.full_name }}
         </a>
     </td>
 	<td>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
In issue #703, I forgot to mention that the new field `administrative_division_included` should also determine the name of the regions in API responses. This PR now fixes this addendum.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Show administrative division in API only when included in the name
- Add `prefix` and `full_name` properties to `Region` model
- Return translation of administrative division always in the region's default language

