### PR TITLE
Fix user creation

### DIFF
--- a/src/cms/forms/users/user_form.py
+++ b/src/cms/forms/users/user_form.py
@@ -92,7 +92,10 @@ class UserForm(CustomModelForm):
         # assign all selected roles which the user does not have already
         for role in set(self.cleaned_data["roles"]) - set(user.groups.all()):
             role.user_set.add(user)
-            logger.info("%r was assigned to %r", role, user.profile)
+            if hasattr(user, "profile"):
+                logger.info("%r was assigned to %r", role, user.profile)
+            else:
+                logger.info("%r was assigned to %r", role, user)
 
         # remove all unselected roles which the user had before
         for role in set(user.groups.all()) - set(self.cleaned_data["roles"]):


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
 Fix `RelatedObjectDoesNotExist` error in user form

### Proposed changes
<!-- Describe this PR in more detail. -->
- Only use `user.profile` in logging if user already has a profile

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #768
