### PR TITLE
Add node-js requirements to install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This content management system helps local integration experts to provide multil
 
 Following packages are required before installing the project (install them with your package manager):
 
-* npm
+* npm version 7 or higher
+* nodejs version 12 or version 14 or higher
 * python3.7 (Debian-based distributions) / python37 (Arch-based distributions)
 * python3.7-dev (only on Ubuntu)
 * python3-pip (Debian-based distributions) / python-pip (Arch-based distributions)

--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -36,6 +36,22 @@ if [ "${npm_version%%.*}" -lt 7 ]; then
     echo "npm version 7 or higher is required, but version $npm_version is installed. Please install a recent version manually (e.g. with 'npm install -g npm') and run this script again." >&2
     exit 1
 fi
+# Check if nodejs is installed
+if [ ! -x "$(command -v node)" ]; then
+    echo "The package nodejs is not installed. Please install nodejs version 12 or version 14 or higher manually and run this script again." >&2
+    exit 1
+fi
+# Get the node version (the format is vXX.YY.ZZ)
+node_version=$(node -v)
+# Strip leading "v" of the version
+node_numeric_version="${node_version:1}"
+# Strip trailing minor and patch version
+node_major_version="${node_numeric_version%%.*}"
+# Check node version requirements (12 or higher but not 13)
+if [ "${node_major_version}" -lt 12 ] || [ "${node_major_version}" -eq 13 ]; then
+    echo "nodejs version 12 or version 14 or higher is required, but version $node_version is installed. Please install a recent version manually and run this script again." >&2
+    exit 1
+fi
 
 # Check if script is running as root
 if [ $(id -u) = 0 ]; then

--- a/sphinx/installation.rst
+++ b/sphinx/installation.rst
@@ -13,7 +13,8 @@ Prerequisites
 Following packages are required before installing the project (install them with your package manager):
 
 * `git <https://git-scm.com/>`_
-* `npm <https://www.npmjs.com/>`_
+* `npm <https://www.npmjs.com/>`_ version 7 or higher
+* `nodejs <https://nodejs.org/>`_ version 12 or version 14 or higher
 * `python3.7 <https://packages.ubuntu.com/search?keywords=python3.7>`_ (`Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__ [#ppa]_) / `python37 <https://aur.archlinux.org/packages/python37/>`_ (`Arch-based distributions <https://wiki.archlinux.org/index.php/Arch-based_distributions>`_)
 * `python3.7-dev <https://packages.ubuntu.com/search?keywords=python3.7-dev>`_ (only required on `Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__)
 * `python3-pip <https://packages.ubuntu.com/search?keywords=python3-pip>`_ (`Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__) / `python-pip <https://www.archlinux.de/packages/extra/x86_64/python-pip>`_ (`Arch-based distributions <https://wiki.archlinux.org/index.php/Arch-based_distributions>`_)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Since our new webpack bundling process has new constraints to our node-js version, I added the requirements check to the install.sh script.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check if nodejs version 12 or version 14 or higher is installed

