### PR TITLE
Add functionality to the help button & Deactivate Django.Admin in production

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -76,6 +76,9 @@ BLOG_URLS = {
     "de": f"{WEBSITE_URL}/blog/",
 }
 
+#: URL to the Integreat wiki
+WIKI_URL = "https://wiki.integreat-app.de"
+
 #: RSS feed URLs to the Integreat blog
 RSS_FEED_URLS = {
     "en": f"{WEBSITE_URL}/en/feed/",

--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -143,7 +143,6 @@ else:
 INSTALLED_APPS = [
     "cms.apps.CmsConfig",
     "gvz_api.apps.GvzApiConfig",
-    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.messages",
@@ -157,6 +156,10 @@ INSTALLED_APPS = [
     "mptt",
     "rules.apps.AutodiscoverRulesConfig",
 ]
+
+#: The default Django Admin application will only be activated if the system is in debug mode.
+if DEBUG:
+    INSTALLED_APPS.append("django.contrib.admin")
 
 #: Activated middlewares (see :setting:`django:MIDDLEWARE`)
 MIDDLEWARE = [

--- a/src/backend/urls.py
+++ b/src/backend/urls.py
@@ -17,13 +17,21 @@ Additionally, the error handlers in :mod:`cms.views.error_handler` are reference
 For more information on this file, see :doc:`topics/http/urls`.
 """
 from django.conf.urls import include, url
+from django.conf import settings
 from django.contrib import admin
 
 
 urlpatterns = [
     url(r"^api/", include("api.urls")),
-    url(r"^admin/", admin.site.urls),
     url(r"^i18n/", include("django.conf.urls.i18n")),
+]
+
+# The admin/endpoint is only activated if the system is in debug mode.
+if settings.DEBUG:
+    urlpatterns.append(url(r"^admin/", admin.site.urls))
+
+# Unfortunatly we need to do this in such way, as the admin endpoint needs to be added before the endpoints of the other apps.
+urlpatterns += [
     url(r"^", include("sitemap.urls")),
     url(r"^", include("cms.urls")),
 ]

--- a/src/cms/admin.py
+++ b/src/cms/admin.py
@@ -2,8 +2,10 @@
 File routing to the admin region
 """
 from django.apps import apps
+from django.conf import settings
 from django.contrib import admin
 
 
-for model in apps.get_app_config("cms").get_models():
-    admin.site.register(model)
+if settings.DEBUG:
+    for model in apps.get_app_config("cms").get_models():
+        admin.site.register(model)

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-15 15:08+0000\n"
+"POT-Creation-Date: 2021-04-15 18:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -889,7 +889,7 @@ msgstr "Wenn das Feedback ungelesen ist, ist dieses Feld leer."
 msgid "feedback"
 msgstr "Feedback"
 
-#: models/feedback/imprint_page_feedback.py:24 templates/_base.html:211
+#: models/feedback/imprint_page_feedback.py:24 templates/_base.html:213
 msgid "Imprint"
 msgstr "Impressum"
 
@@ -898,7 +898,7 @@ msgstr "Impressum"
 msgid "imprint feedback"
 msgstr "Impressums-Feedback"
 
-#: models/feedback/map_feedback.py:20 templates/_base.html:148
+#: models/feedback/map_feedback.py:20 templates/_base.html:150
 #: templates/pois/poi_list.html:11
 msgid "Locations on map"
 msgstr "Orte auf Karte"
@@ -1588,160 +1588,160 @@ msgstr "Benutzerprofil"
 msgid "user profiles"
 msgstr "Benutzerprofile"
 
-#: templates/_base.html:11
+#: templates/_base.html:12
 msgid "Django Admin"
 msgstr "Django Admin"
 
-#: templates/_base.html:15
+#: templates/_base.html:17
 msgid "Help"
 msgstr "Hilfe"
 
-#: templates/_base.html:30 templates/_base.html:48
+#: templates/_base.html:32 templates/_base.html:50
 msgid "Network Management"
 msgstr "Netzwerkverwaltung"
 
-#: templates/_base.html:63
+#: templates/_base.html:65
 msgid "User Settings"
 msgstr "Benutzereinstellungen"
 
-#: templates/_base.html:67
+#: templates/_base.html:69
 msgid "Log out"
 msgstr "Abmelden"
 
-#: templates/_base.html:82 templates/dashboard/dashboard.html:9
+#: templates/_base.html:84 templates/dashboard/dashboard.html:9
 msgid "My Dashboard"
 msgstr "Mein Dashboard"
 
-#: templates/_base.html:86 templates/analytics/translation_coverage.html:12
+#: templates/_base.html:88 templates/analytics/translation_coverage.html:12
 msgid "Translation Report"
 msgstr "Übersetzungs-Bericht"
 
-#: templates/_base.html:91 templates/regions/region_form.html:140
+#: templates/_base.html:93 templates/regions/region_form.html:140
 #: templates/statistics/_statistics_widget.html:7
 #: templates/statistics/statistics_overview.html:10
 #: templates/statistics/statistics_overview.html:53
 msgid "Statistics"
 msgstr "Statistiken"
 
-#: templates/_base.html:97
+#: templates/_base.html:99
 msgid "Media Library"
 msgstr "Medienbibliothek"
 
-#: templates/_base.html:101
+#: templates/_base.html:103
 msgid "All media files"
 msgstr "Alle Mediendateien"
 
-#: templates/_base.html:104
+#: templates/_base.html:106
 msgid "Upload new media file"
 msgstr "Neue Mediendatei hochladen"
 
-#: templates/_base.html:112 templates/pages/page_tree.html:13
+#: templates/_base.html:114 templates/pages/page_tree.html:13
 msgid "Pages"
 msgstr "Seiten"
 
-#: templates/_base.html:116
+#: templates/_base.html:118
 msgid "All pages"
 msgstr "Alle Seiten"
 
-#: templates/_base.html:120 templates/pages/page_tree.html:45
+#: templates/_base.html:122 templates/pages/page_tree.html:45
 #: templates/pages/page_tree.html:49
 msgid "Create page"
 msgstr "Seite erstellen"
 
-#: templates/_base.html:130 templates/events/event_list.html:10
+#: templates/_base.html:132 templates/events/event_list.html:10
 #: templates/regions/region_form.html:112
 msgid "Events"
 msgstr "Veranstaltungen"
 
-#: templates/_base.html:134
+#: templates/_base.html:136
 msgid "All events"
 msgstr "Alle Veranstaltungen"
 
-#: templates/_base.html:138 templates/events/event_list.html:37
+#: templates/_base.html:140 templates/events/event_list.html:37
 msgid "Create event"
 msgstr "Veranstaltung erstellen"
 
-#: templates/_base.html:152
+#: templates/_base.html:154
 msgid "All locations"
 msgstr "Alle Orte"
 
-#: templates/_base.html:156 templates/pois/poi_list.html:32
+#: templates/_base.html:158 templates/pois/poi_list.html:32
 msgid "Create location"
 msgstr "Ort erstellen"
 
-#: templates/_base.html:166 templates/_base.html:254
+#: templates/_base.html:168 templates/_base.html:256
 msgid "Users"
 msgstr "Benutzer"
 
-#: templates/_base.html:170
+#: templates/_base.html:172
 msgid "All users"
 msgstr "Alle Benutzer"
 
-#: templates/_base.html:173 templates/users/admin/list.html:18
+#: templates/_base.html:175 templates/users/admin/list.html:18
 #: templates/users/region/list.html:13
 msgid "Create user"
 msgstr "Benutzer erstellen"
 
-#: templates/_base.html:181 templates/_base.html:278
+#: templates/_base.html:183 templates/_base.html:280
 #: templates/feedback/region_feedback_list.html:11
 msgid "Feedback"
 msgstr "Feedback"
 
-#: templates/_base.html:188
+#: templates/_base.html:190
 msgid "News"
 msgstr "Nachrichten"
 
-#: templates/_base.html:192
+#: templates/_base.html:194
 msgid "All push notifications"
 msgstr "Alle Push-Benachrichtigungen"
 
-#: templates/_base.html:196
+#: templates/_base.html:198
 #: templates/push_notifications/push_notification_list.html:13
 msgid "Create push notification"
 msgstr "Push-Benachrichtigung verfassen"
 
-#: templates/_base.html:205 templates/offers/offer_list.html:9
+#: templates/_base.html:207 templates/offers/offer_list.html:9
 msgid "Offers"
 msgstr "Angebote"
 
-#: templates/_base.html:218 templates/language_tree/language_tree.html:10
+#: templates/_base.html:220 templates/language_tree/language_tree.html:10
 msgid "Language tree"
 msgstr "Sprach-Baum"
 
-#: templates/_base.html:222
+#: templates/_base.html:224
 msgid "All language tree nodes"
 msgstr "Alle Sprach-Knoten"
 
-#: templates/_base.html:225 templates/language_tree/language_tree.html:20
+#: templates/_base.html:227 templates/language_tree/language_tree.html:20
 msgid "Create language tree node"
 msgstr "Sprach-Knoten hinzufügen"
 
-#: templates/_base.html:232 templates/_base.html:283
+#: templates/_base.html:234 templates/_base.html:285
 #: templates/push_notifications/push_notification_form.html:75
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: templates/_base.html:237 templates/dashboard/admin_dashboard.html:8
+#: templates/_base.html:239 templates/dashboard/admin_dashboard.html:8
 msgid "Admin Dashboard"
 msgstr "Admin Dashboard"
 
-#: templates/_base.html:242
+#: templates/_base.html:244
 msgid "Regions"
 msgstr "Regionen"
 
-#: templates/_base.html:248
+#: templates/_base.html:250
 msgid "Languages"
 msgstr "Sprachen"
 
-#: templates/_base.html:260
+#: templates/_base.html:262
 msgid "Roles"
 msgstr "Rollen"
 
-#: templates/_base.html:266
+#: templates/_base.html:268
 msgid "Organizations"
 msgstr "Organisationen"
 
-#: templates/_base.html:272
+#: templates/_base.html:274
 msgid "Offer templates"
 msgstr "Angebots-Vorlagen"
 

--- a/src/cms/templates/_base.html
+++ b/src/cms/templates/_base.html
@@ -6,10 +6,12 @@
 
 <header class="fixed h-14 pl-56 top-0 inset-x-0 flex flex-wrap z-10 bg-gray-300">
     <div class="flex-1 relative w-full"></div>
-	<a href="/admin" target="_blank" rel="noopener noreferrer" class="relative px-2 pt-4 text-gray-800 hover:bg-gray-200 border-r border-gray-400">
-		<i data-feather="sliders"></i>
-		{% trans 'Django Admin' %}
-	</a>
+	{% if debug %}
+		<a href="/admin" target="_blank" rel="noopener noreferrer" class="relative px-2 pt-4 text-gray-800 hover:bg-gray-200 border-r border-gray-400">
+			<i data-feather="sliders"></i>
+			{% trans 'Django Admin' %}
+		</a>
+	{% endif %}
 	<a href="{% url 'wiki_redirect' %}" target="_blank" rel="noopener noreferrer" class="relative px-2 pt-4 text-gray-800 hover:bg-gray-200 border-r border-gray-400">
 		<i data-feather="help-circle"></i>
 		{% trans 'Help' %}

--- a/src/cms/templates/_base.html
+++ b/src/cms/templates/_base.html
@@ -10,7 +10,7 @@
 		<i data-feather="sliders"></i>
 		{% trans 'Django Admin' %}
 	</a>
-	<a href="/" class="relative px-2 pt-4 text-gray-800 hover:bg-gray-200 border-r border-gray-400">
+	<a href="{% url 'wiki_redirect' %}" target="_blank" rel="noopener noreferrer" class="relative px-2 pt-4 text-gray-800 hover:bg-gray-200 border-r border-gray-400">
 		<i data-feather="help-circle"></i>
 		{% trans 'Help' %}
 	</a>

--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -56,6 +56,11 @@ urlpatterns = [
             ]
         ),
     ),
+    url(
+        r"^wiki",
+        RedirectView.as_view(url=django_settings.WIKI_URL),
+        name="wiki_redirect",
+    ),
     url(r"^$", dashboard.RedirectView.as_view(), name="redirect"),
     url(
         r"^admin_dashboard/$",


### PR DESCRIPTION
### Short description
This PR introduces a global setting for the wiki-URL and deactivates the django.contrib.admin app, if the system is run on production mode.


### Proposed changes
- Introduce WIKI_URL in settings.py
- Create a redirect to the Wiki
- Only add django.contrib.admin to INSTALLED_APPS, if `DEBUG=True`
- Only add `/admin` endpoint to `urls.py` if `DEBUG=True`
- Only show Django-Administration Link in base.html, if debug is true.

### Resolved issues

Fixes: #746
Fixes: #689 
