### PR TITLE
Fix event handler of page order table

### DIFF
--- a/src/frontend/js/pages/page-order.ts
+++ b/src/frontend/js/pages/page-order.ts
@@ -2,7 +2,7 @@ import feather from "feather-icons";
 import { off, on } from "../utils/wrapped-events";
 
 let initialPageTitle: string;
-window.addEventListener("change", () => {
+window.addEventListener("load", () => {
   // Event handler for changing the parent page option
   const parentEl = document.getElementById("parent");
   if (parentEl) {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Initializes the event listener on window load, not on window change

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #775
