### PR TITLE
Fix page drag & drop

### DIFF
--- a/src/cms/templates/language_tree/language_tree.html
+++ b/src/cms/templates/language_tree/language_tree.html
@@ -22,7 +22,7 @@
 </div>
 
 <div class="table-listing">
-    <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
+    <table data-activate-tree-drag-drop class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
         <thead>
             <tr class="border-b border-solid border-gray-200">
                 <th class="text-sm text-left uppercase py-3 pl-4 pr-2"></th>

--- a/src/cms/templates/pages/_page_order_table.html
+++ b/src/cms/templates/pages/_page_order_table.html
@@ -3,7 +3,7 @@
 {% load content_filters %}
 {% load page_filters %}
 <div class="table-listing">
-    <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white table-auto">
+    <table data-activate-page-order class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white table-auto">
         <tbody>
             {% get_current_language as LANGUAGE_CODE %}
             {% recursetree siblings %}

--- a/src/cms/templates/pages/page_tree.html
+++ b/src/cms/templates/pages/page_tree.html
@@ -55,7 +55,7 @@
 
 <form method="POST" id="bulk-action-form" class="table-listing">
     {% csrf_token %}
-    <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white table-auto">
+    <table data-activate-tree-drag-drop class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white table-auto">
         <thead>
             <tr class="border-b border-solid border-gray-200">
                 <th class="text-sm text-left uppercase py-3 pl-4 pr-2 min"><input type="checkbox" id="bulk-select-all"></th>

--- a/src/frontend/js/pages/page-order.ts
+++ b/src/frontend/js/pages/page-order.ts
@@ -3,19 +3,19 @@ import { off, on } from "../utils/wrapped-events";
 
 let initialPageTitle: string;
 window.addEventListener("load", () => {
+
+  // Only activate event listeners if explicitly enabled
+  if (!document.querySelector("[data-activate-page-order]")) return;
+
   // Event handler for changing the parent page option
   const parentEl = document.getElementById("parent");
-  if (parentEl) {
-    parentEl.addEventListener("change", getPageOrderTable);
-  }
+  parentEl.addEventListener("change", getPageOrderTable);
 
   // Event handler for updating the page title
   const pageTitleEl = document.getElementById("id_title") as HTMLInputElement;
-  if (pageTitleEl) {
-    pageTitleEl.addEventListener("input", updatePageTitle);
-    // save initial page title
-    initialPageTitle = pageTitleEl.value;
-  }
+  pageTitleEl.addEventListener("input", updatePageTitle);
+  // save initial page title
+  initialPageTitle = pageTitleEl.value;
 
   // Register all handlers once initially
   registerEventHandlers();

--- a/src/frontend/js/tree-drag-and-drop.ts
+++ b/src/frontend/js/tree-drag-and-drop.ts
@@ -6,93 +6,24 @@
 import { off, on } from "./utils/wrapped-events";
 
 window.addEventListener("load", () => {
+
+  // Only activate event listeners if explicitly enabled
+  if (!document.querySelector("[data-activate-tree-drag-drop]")) return;
+
   // event handler for starting drag events
   document.querySelectorAll(".drag").forEach((node) => {
     (node as HTMLElement).addEventListener("dragstart", dragstart);
   });
-  function dragstart(event: DragEvent) {
-    const target = event.target as HTMLElement;
-    // prepare the dragged node id for data transfer
-    event.dataTransfer.setData("text", target.getAttribute("data-drag-id"));
-    window.setTimeout(() => changeDom(target));
-    // get descendants of dragged node
-    const descendants = JSON.parse(
-      target.getAttribute("data-node-descendants")
-    ) as number[];
-    // add event listeners for hovering over drop regions
-    document.querySelectorAll(".drop").forEach((node) => {
-      // get target node id of the hovered drop region
-      const drop_id = parseInt(node.getAttribute("data-drop-id"));
-      if (descendants.includes(drop_id)) {
-        // if the target node is a descendant of the dragged node, disallow dropping it
-        on(node, "dragover", dropDisallow);
-      } else {
-        // else, the move would be valid and dropping is allowed
-        on(node,
-          "dragover",
-          (e: Event) => {
-            e.preventDefault();
-            dropAllow(e);
-          }
-        );
-      }
-    });
-  }
-
-  /* manipulating the dom during dragstart event fires immediately a dragend event (chrome browser)
-so the changes to the dom must be delayed */
-  function changeDom(target: HTMLElement) {
-    // change appearance of dragged item
-    target.classList.remove("text-gray-800");
-    target.classList.add("text-blue-500");
-    // show dropping regions between table rows
-    document.querySelectorAll(".drop-between").forEach((node) => {
-      node.closest("tr").classList.remove("hidden");
-    });
-  }
-
-  // event handlers for dragover events
-  function dropAllow(event: Event) {
-    const target = event.target as HTMLElement;
-    target.parentElement.closest("tr").classList.add("drop-allow");
-  }
-  function dropDisallow(event: Event) {
-    const target = event.target as HTMLElement;
-    target.parentElement.closest("tr").classList.add("drop-disallow");
-  }
 
   // event handler for stopping drag events
   document.querySelectorAll(".drag").forEach(function (node) {
     on(node, "dragend", dragend);
   });
 
-  function dragend(event: Event) {
-    event.preventDefault();
-
-    const target = event.target as HTMLElement;
-    // hide the drop regions between table rows
-    document.querySelectorAll(".drop-between").forEach((node) => {
-      node.closest("tr").classList.add("hidden");
-    });
-    document.querySelectorAll('.drop').forEach((node) => {
-      off(node, 'dragover');
-  });
-
-    // change appearance of dragged item
-    target.classList.remove("text-blue-500");
-    target.classList.add("text-gray-800");
-  }
-
   // event handler for dragleave events
   document.querySelectorAll(".drop").forEach((node) => {
     node.addEventListener("dragleave", dragleave);
   });
-  function dragleave(event: Event) {
-    // remove hover effect on allowed or disallowed drop regions
-    const target = (event.target as HTMLElement).closest("tr");
-    target.classList.remove("drop-allow");
-    target.classList.remove("drop-disallow");
-  }
 
   // event handler for drop events
   document.querySelectorAll(".drop").forEach((node) => {
@@ -101,20 +32,105 @@ so the changes to the dom must be delayed */
       drop(e as DragEvent);
     });
   });
-  function drop(event: DragEvent) {
-    // prevent the table from collapsing again after successful drop
-    document.querySelectorAll(".drag").forEach((node) => {
-      off(node, "dragend");
-    });
-    // get dragged node id from data transfer
-    var node_id = event.dataTransfer.getData("text");
-    // get target node if from dropped region
-    const target = (event.target as HTMLElement).closest("tr");
-    const target_id = target.getAttribute("data-drop-id");
-    const position = target.getAttribute("data-drop-position");
-    // abuse confirmation dialog form to perform action
-    let form = document.getElementById("confirmation-dialog").querySelector("form");
-    form.action = window.location.href + node_id + "/move/" + target_id + "/" + position;
-    form.submit();
-  }
 });
+
+/*
+ * This function handles the start of a dragging event
+ *
+ * Manipulating the dom during dragstart event fires immediately a dragend event (chrome browser),
+ * so the changes to the dom must be delayed
+ */
+function dragstart(event: DragEvent) {
+  const target = event.target as HTMLElement;
+  // prepare the dragged node id for data transfer
+  event.dataTransfer.setData("text", target.getAttribute("data-drag-id"));
+  window.setTimeout(() => changeDom(target));
+  // get descendants of dragged node
+  const descendants = JSON.parse(
+      target.getAttribute("data-node-descendants")
+  ) as number[];
+  // add event listeners for hovering over drop regions
+  document.querySelectorAll(".drop").forEach((node) => {
+    // get target node id of the hovered drop region
+    const drop_id = parseInt(node.getAttribute("data-drop-id"));
+    if (descendants.includes(drop_id)) {
+      // if the target node is a descendant of the dragged node, disallow dropping it
+      on(node, "dragover", dropDisallow);
+    } else {
+      // else, the move would be valid and dropping is allowed
+      on(node,
+          "dragover",
+          (e: Event) => {
+            e.preventDefault();
+            dropAllow(e);
+          }
+      );
+    }
+  });
+}
+
+/* manipulating the dom during dragstart event fires immediately a dragend event (chrome browser)
+so the changes to the dom must be delayed */
+function changeDom(target: HTMLElement) {
+  // change appearance of dragged item
+  target.classList.remove("text-gray-800");
+  target.classList.add("text-blue-500");
+  // show dropping regions between table rows
+  document.querySelectorAll(".drop-between").forEach((node) => {
+    node.closest("tr").classList.remove("hidden");
+  });
+}
+
+// These functions add the hover effect when the dragged page is hovered over a valid/invalid drop region
+function dropAllow(event: Event) {
+  const target = event.target as HTMLElement;
+  target.parentElement.closest("tr").classList.add("drop-allow");
+}
+function dropDisallow(event: Event) {
+  const target = event.target as HTMLElement;
+  target.parentElement.closest("tr").classList.add("drop-disallow");
+}
+
+// This function handles the event that the drag stops, no matter if on a valid drop region or not
+function dragend(event: Event) {
+  event.preventDefault();
+
+  const target = event.target as HTMLElement;
+  // hide the drop regions between table rows
+  document.querySelectorAll(".drop-between").forEach((node) => {
+    node.closest("tr").classList.add("hidden");
+  });
+  document.querySelectorAll('.drop').forEach((node) => {
+    off(node, 'dragover');
+  });
+
+  // change appearance of dragged item
+  target.classList.remove("text-blue-500");
+  target.classList.add("text-gray-800");
+}
+
+// This function handles the event then the cursor leaves a drop region without actually dropping
+function dragleave(event: Event) {
+  // remove hover effect on allowed or disallowed drop regions
+  const target = (event.target as HTMLElement).closest("tr");
+  target.classList.remove("drop-allow");
+  target.classList.remove("drop-disallow");
+}
+
+// This function handles the event when the page is dropped onto the target div
+function drop(event: DragEvent) {
+  // prevent the table from collapsing again after successful drop
+  document.querySelectorAll(".drag").forEach((node) => {
+    off(node, "dragend");
+  });
+  // get dragged node id from data transfer
+  var node_id = event.dataTransfer.getData("text");
+  // get target node if from dropped region
+  const target = (event.target as HTMLElement).closest("tr");
+  const target_id = target.getAttribute("data-drop-id");
+  const position = target.getAttribute("data-drop-position");
+  // abuse confirmation dialog form to perform action
+  let form = document.getElementById("confirmation-dialog").querySelector("form");
+  form.action = window.location.href + node_id + "/move/" + target_id + "/" + position;
+  form.submit();
+}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Both drag & drop scripts were working concurrently, because both set event listeners to the same class names.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Only activate tree drag & drop on page & language tree
- Only activate page order drag & drop on page form
- For tree drag & drop: Move function definitions from inside the event listener to the global scope of the script

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #784
