### PR TITLE
Dev Tools: use python3.7

### DIFF
--- a/dev-tools/black.sh
+++ b/dev-tools/black.sh
@@ -10,7 +10,7 @@ fi
 cd $(dirname "$BASH_SOURCE")/..
 
 # Run black
-pipenv run black .
+pipenv --python 3.7 run black .
 
 # Update translations (because changed formatting affects line numbers)
 ./translate.sh

--- a/dev-tools/check_translations.sh
+++ b/dev-tools/check_translations.sh
@@ -58,7 +58,7 @@ cd $(dirname "$BASH_SOURCE")/../src/cms || exit 1
 TRANSLATION_FILE="locale/de/LC_MESSAGES/django.po"
 
 # Re-generating translation file
-pipenv run integreat-cms-cli makemessages -l de > /dev/null || exit 1
+pipenv --python 3.7 run integreat-cms-cli makemessages -l de > /dev/null || exit 1
 
 # Check if translation file is up to date
 TRANSLATION_DIFF=$(git diff --shortstat $TRANSLATION_FILE)

--- a/dev-tools/code_style.sh
+++ b/dev-tools/code_style.sh
@@ -10,7 +10,7 @@ fi
 cd $(dirname "$BASH_SOURCE")/..
 
 # Run black
-pipenv run black .
+pipenv --python 3.7 run black .
 
 # Run pylint
-pipenv run pylint_runner
+pipenv --python 3.7 run pylint_runner

--- a/dev-tools/create_superuser.sh
+++ b/dev-tools/create_superuser.sh
@@ -26,7 +26,7 @@ if nc -w1 localhost 5432; then
 
     cd $(dirname "$BASH_SOURCE")/..
 
-    pipenv run integreat-cms-cli createsuperuser
+    pipenv --python 3.7 run integreat-cms-cli createsuperuser
 
 else
 
@@ -57,7 +57,7 @@ else
 
     # Check if postgres database container is already running
     if [ "$(docker ps -q -f name=integreat_django_postgres)" ]; then
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli createsuperuser --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli createsuperuser --settings=backend.docker_settings
     else
         # Check if stopped container is available
         if [ "$(docker ps -aq -f status=exited -f name=integreat_django_postgres)" ]; then
@@ -76,7 +76,7 @@ else
             done
             echo ""
         fi
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli createsuperuser --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli createsuperuser --settings=backend.docker_settings
         # Stop the postgres database docker container
         docker stop integreat_django_postgres > /dev/null
     fi

--- a/dev-tools/generate_documentation.sh
+++ b/dev-tools/generate_documentation.sh
@@ -38,7 +38,7 @@ if [ "$1" == "--clean" ]; then
 fi
 
 # Copy original footer file
-cp $(pipenv --venv)/lib/python3.7/site-packages/sphinx_rtd_theme/footer.html ${SPHINX_DIR}/templates
+cp $(pipenv --python 3.7 --venv)/lib/python3.7/site-packages/sphinx_rtd_theme/footer.html ${SPHINX_DIR}/templates
 # Patch footer to add hyperlinks to copyright information
 if ! patch ${SPHINX_DIR}/templates/footer.html ${SPHINX_DIR}/patches/footer.diff; then
     echo -e "\nThe patch for the footer template could not be applied correctly." >&2
@@ -48,7 +48,7 @@ if ! patch ${SPHINX_DIR}/templates/footer.html ${SPHINX_DIR}/patches/footer.diff
 fi
 
 # Copy original breadcrumbs file
-cp $(pipenv --venv)/lib/python3.7/site-packages/sphinx_rtd_theme/breadcrumbs.html ${SPHINX_DIR}/templates
+cp $(pipenv --python 3.7 --venv)/lib/python3.7/site-packages/sphinx_rtd_theme/breadcrumbs.html ${SPHINX_DIR}/templates
 # Patch footer to add hyperlinks to copyright information
 if ! patch ${SPHINX_DIR}/templates/breadcrumbs.html ${SPHINX_DIR}/patches/breadcrumbs.diff; then
     echo -e "\nThe patch for the breadcrumbs template could not be applied correctly." >&2
@@ -59,7 +59,7 @@ fi
 
 # Generate new .rst files from source code for maximum verbosity
 export SPHINX_APIDOC_OPTIONS="members,undoc-members,inherited-members,show-inheritance"
-pipenv run sphinx-apidoc --no-toc --module-first -o ${SPHINX_DIR}/${SPHINX_APIDOC_EXT_DIR} ${SRC_DIR} ${SRC_DIR}/cms/migrations ${SRC_DIR}/gvz_api/migrations
+pipenv --python 3.7 run sphinx-apidoc --no-toc --module-first -o ${SPHINX_DIR}/${SPHINX_APIDOC_EXT_DIR} ${SRC_DIR} ${SRC_DIR}/cms/migrations ${SRC_DIR}/gvz_api/migrations
 
 # Modify .rst files to remove unnecessary submodule- & subpackage-titles
 # Example: "cms.models.push_notifications.push_notification_translation module" becomes "Push Notification Translation"
@@ -106,10 +106,10 @@ grep -rL ":orphan:" ${SPHINX_DIR}/${SPHINX_APIDOC_EXT_DIR}/*.rst | xargs -r sed 
 # Check if script is running in CircleCI context
 if [[ -n "$CIRCLECI" ]]; then
     # Compile .rst files to html documentation (deactivate parallel build due to EOFError - see https://github.com/sphinx-doc/sphinx/issues/8973)
-    pipenv run sphinx-build -W --keep-going ${SPHINX_DIR} ${DOC_DIR}
+    pipenv --python 3.7 run sphinx-build -W --keep-going ${SPHINX_DIR} ${DOC_DIR}
 else
     # Compile .rst files to html documentation
-    pipenv run sphinx-build -j auto -W --keep-going ${SPHINX_DIR} ${DOC_DIR}
+    pipenv --python 3.7 run sphinx-build -j auto -W --keep-going ${SPHINX_DIR} ${DOC_DIR}
 fi
 
 # Get exit status of sphinx-build

--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -48,8 +48,8 @@ node_numeric_version="${node_version:1}"
 # Strip trailing minor and patch version
 node_major_version="${node_numeric_version%%.*}"
 # Check node version requirements (12 or higher but not 13)
-if [ "${node_major_version}" -lt 12 ] || [ "${node_major_version}" -eq 13 ]; then
-    echo "nodejs version 12 or version 14 or higher is required, but version $node_version is installed. Please install a recent version manually and run this script again." >&2
+if ! [[ "${node_major_version}" =~ ^(12|14|15)$ ]] ; then
+    echo "nodejs version 12 or version 14 or 15 is required, but version $node_version is installed. Please install a supported version manually and run this script again." >&2
     exit 1
 fi
 

--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -85,7 +85,7 @@ else
 fi
 
 # Install pip dependencies
-pipenv install --dev
+pipenv --python 3.7 install --dev
 
 # Install pre-commit hook for black code style
-pipenv run pre-commit install
+pipenv --python 3.7 run pre-commit install

--- a/dev-tools/loadtestdata.sh
+++ b/dev-tools/loadtestdata.sh
@@ -25,7 +25,7 @@ if nc -w1 localhost 5432; then
 
     cd $(dirname "$BASH_SOURCE")/..
 
-    pipenv run integreat-cms-cli loaddata src/cms/fixtures/test_data.json
+    pipenv --python 3.7 run integreat-cms-cli loaddata src/cms/fixtures/test_data.json
 
 else
 
@@ -56,7 +56,7 @@ else
 
     # Check if postgres database container is already running
     if [ "$(docker ps -q -f name=integreat_django_postgres)" ]; then
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli loaddata src/cms/fixtures/test_data.json --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli loaddata src/cms/fixtures/test_data.json --settings=backend.docker_settings
     else
         # Check if stopped container is available
         if [ "$(docker ps -aq -f status=exited -f name=integreat_django_postgres)" ]; then
@@ -75,7 +75,7 @@ else
             done
             echo ""
         fi
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli loaddata src/cms/fixtures/test_data.json --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli loaddata src/cms/fixtures/test_data.json --settings=backend.docker_settings
         # Stop the postgres database docker container
         docker stop integreat_django_postgres > /dev/null
     fi

--- a/dev-tools/migrate.sh
+++ b/dev-tools/migrate.sh
@@ -26,9 +26,9 @@ if nc -w1 localhost 5432; then
 
     cd $(dirname "$BASH_SOURCE")/..
 
-    pipenv run integreat-cms-cli makemigrations cms
-    pipenv run integreat-cms-cli migrate
-    pipenv run integreat-cms-cli loaddata src/cms/fixtures/roles.json
+    pipenv --python 3.7 run integreat-cms-cli makemigrations cms
+    pipenv --python 3.7 run integreat-cms-cli migrate
+    pipenv --python 3.7 run integreat-cms-cli loaddata src/cms/fixtures/roles.json
 
 else
 
@@ -60,9 +60,9 @@ else
     # Check if postgres database container is already running
     if [ "$(docker ps -q -f name=integreat_django_postgres)" ]; then
         # Migrate database
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli makemigrations cms --settings=backend.docker_settings
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli migrate --settings=backend.docker_settings
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli loaddata src/cms/fixtures/roles.json --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli makemigrations cms --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli migrate --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli loaddata src/cms/fixtures/roles.json --settings=backend.docker_settings
     else
         # Check if stopped container is available
         if [ "$(docker ps -aq -f status=exited -f name=integreat_django_postgres)" ]; then
@@ -82,9 +82,9 @@ else
             echo ""
         fi
         # Migrate database
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli makemigrations cms --settings=backend.docker_settings
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli migrate --settings=backend.docker_settings
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli loaddata src/cms/fixtures/roles.json --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli makemigrations cms --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli migrate --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli loaddata src/cms/fixtures/roles.json --settings=backend.docker_settings
         # Stop the postgres database docker container
         docker stop integreat_django_postgres > /dev/null
     fi

--- a/dev-tools/package.sh
+++ b/dev-tools/package.sh
@@ -25,10 +25,10 @@ fi
 cd $(dirname "$BASH_SOURCE")/..
 
 # Compile CSS file
-pipenv run npm run prod
+pipenv --python 3.7 run npm run prod
 
 # Compile translation file
-pipenv run integreat-cms-cli compilemessages
+pipenv --python 3.7 run integreat-cms-cli compilemessages
 
 # Create debian package
 python3 setup.py --command-packages=stdeb.command bdist_deb

--- a/dev-tools/pylint.sh
+++ b/dev-tools/pylint.sh
@@ -10,4 +10,4 @@ fi
 cd $(dirname "$BASH_SOURCE")/..
 
 # Run pylint
-pipenv run pylint_runner
+pipenv --python 3.7 run pylint_runner

--- a/dev-tools/run.sh
+++ b/dev-tools/run.sh
@@ -43,7 +43,7 @@ if nc -w1 localhost 5432; then
     ./dev-tools/migrate.sh
 
     # Start Integreat CMS
-    pipenv run integreat-cms-cli runserver localhost:8000
+    pipenv --python 3.7 run integreat-cms-cli runserver localhost:8000
 
 else
 
@@ -109,7 +109,7 @@ else
     fi
 
     # Start Integreat CMS
-    sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli runserver localhost:8000 --settings=backend.docker_settings
+    sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli runserver localhost:8000 --settings=backend.docker_settings
 
     # Stop the postgres database docker container
     docker stop integreat_django_postgres > /dev/null

--- a/dev-tools/test.sh
+++ b/dev-tools/test.sh
@@ -13,7 +13,7 @@ if nc -w1 localhost 5432; then
     cd $(dirname "$BASH_SOURCE")/..
 
     # Execute tests
-    pipenv run integreat-cms-cli test cms
+    pipenv --python 3.7 run integreat-cms-cli test cms
 
 else
 
@@ -45,7 +45,7 @@ else
     # Check if postgres database container is already running
     if [ "$(docker ps -q -f name=integreat_django_postgres)" ]; then
         # Execute tests
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli test cms --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli test cms --settings=backend.docker_settings
     else
         # Check if stopped container is available
         if [ "$(docker ps -aq -f status=exited -f name=integreat_django_postgres)" ]; then
@@ -65,7 +65,7 @@ else
             echo ""
         fi
         # Execute tests
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli test cms --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli test cms --settings=backend.docker_settings
         # Stop the postgres database docker container
         docker stop integreat_django_postgres > /dev/null
     fi

--- a/dev-tools/test_cov.sh
+++ b/dev-tools/test_cov.sh
@@ -15,7 +15,7 @@ if nc -w1 localhost 5432; then
     # prepare code coverage
     rm -rf ./htmlcov/
     # Execute tests
-    pipenv run integreat-cms-cli test cms --set=COVERAGE
+    pipenv --python 3.7 run integreat-cms-cli test cms --set=COVERAGE
 
 else
 
@@ -47,7 +47,7 @@ else
     # Check if postgres database container is already running
     if [ "$(docker ps -q -f name=integreat_django_postgres)" ]; then
         # Execute tests
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli test cms --settings=backend.docker_settings
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli test cms --settings=backend.docker_settings
     else
         # Check if stopped container is available
         if [ "$(docker ps -aq -f status=exited -f name=integreat_django_postgres)" ]; then
@@ -70,7 +70,7 @@ else
         rm -rf ./htmlcov/ 
         # Execute tests
 
-        sudo -u $SUDO_USER env PATH="$PATH" pipenv run integreat-cms-cli test cms --settings=backend.docker_settings --set=COVERAGE
+        sudo -u $SUDO_USER env PATH="$PATH" pipenv --python 3.7 run integreat-cms-cli test cms --settings=backend.docker_settings --set=COVERAGE
 
         # Stop the postgres database docker container
         docker stop integreat_django_postgres > /dev/null

--- a/dev-tools/translate.sh
+++ b/dev-tools/translate.sh
@@ -31,7 +31,7 @@ fi
 cd $(dirname "$BASH_SOURCE")/../src/cms
 
 # Re-generating translation file
-pipenv run integreat-cms-cli makemessages -l de
+pipenv --python 3.7 run integreat-cms-cli makemessages -l de
 
 # Ignore POT-Creation-Date of otherwise unchanged translation file
 if git diff --shortstat locale/de/LC_MESSAGES/django.po | grep -q "1 file changed, 1 insertion(+), 1 deletion(-)"; then
@@ -39,4 +39,4 @@ if git diff --shortstat locale/de/LC_MESSAGES/django.po | grep -q "1 file change
 fi
 
 # Compile translation file
-pipenv run integreat-cms-cli compilemessages
+pipenv --python 3.7 run integreat-cms-cli compilemessages

--- a/dev-tools/update_dependencies.sh
+++ b/dev-tools/update_dependencies.sh
@@ -30,4 +30,4 @@ npx npm-check --update-all --skip-unused
 npm audit fix
 
 # Check if pip dependencies are up to date
-pipenv update --dev
+pipenv --python 3.7 update --dev


### PR DESCRIPTION
### Short description
Fix python3 version to 3.7 in dev-tools scripts.

### Resolved issues
Fixes not working dev-tools scripts on machines where the default python3 version is not 3.7.