### PR TITLE
Change GVZ API wrapper

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -98,7 +98,7 @@ GVZ_API_ENABLED = True
 
 #: The URL to our GVZ (Gemeindeverzeichnis) API. This is used to automatically import coordinates and region aliases
 #: (see :mod:`gvz_api` for more information).
-GVZ_API_URL = "https://gvz.integreat-app.de/api"
+GVZ_API_URL = "https://gvz.integreat-app.de"
 
 
 ############

--- a/src/cms/forms/regions/region_form.py
+++ b/src/cms/forms/regions/region_form.py
@@ -132,10 +132,10 @@ class RegionForm(CustomModelForm):
         if apps.get_app_config("gvz_api").api_available:
             gvz_region = GvzRegion(
                 region_name=cleaned_data["name"],
-                region_key=cleaned_data["common_id"],
+                region_ags=cleaned_data["common_id"],
                 region_type=cleaned_data["administrative_division"],
             )
-            if gvz_region.aliases and cleaned_data["aliases"] == "":
+            if gvz_region.aliases and cleaned_data["aliases"] in [{}, ""]:
                 cleaned_data["aliases"] = gvz_region.aliases
             if gvz_region.longitude and cleaned_data["longitude"] == 0.0:
                 cleaned_data["longitude"] = gvz_region.longitude

--- a/src/gvz_api/apps.py
+++ b/src/gvz_api/apps.py
@@ -28,11 +28,9 @@ class GvzApiConfig(AppConfig):
         if "runserver" in sys.argv or "APACHE_PID_FILE" in os.environ:
             if settings.GVZ_API_ENABLED:
                 try:
-                    response = requests.get(
-                        f"{settings.GVZ_API_URL}/search/expect_empty_json", timeout=3
-                    )
-                    # Require the response to be empty, otherwise it's probably an error
-                    assert not json.loads(response.text)
+                    response = requests.get(f"{settings.GVZ_API_URL}/api/", timeout=3)
+                    # Require the response to return a valid JSON, otherwise it's probably an error
+                    assert json.loads(response.text)
                 except (
                     json.decoder.JSONDecodeError,
                     requests.exceptions.RequestException,


### PR DESCRIPTION
This PR adopts the GVZ API v2.

To accommodate the API changes, the handling of requests is also changed. First, the children need to be searched recursively. Second, all details are directly provided in the answers. Therefore the coordinates dictionary for children can directly be created.

Fixes #796