### PR TITLE
Fixes the install script python3.7-dev check

### DIFF
--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -14,7 +14,7 @@ echo "Checking system requirements..." | print_info
 if [[ ! -x "$(command -v python3.7)" ]]; then  echo "Python3.7 is not installed. Please install it manually and run this script again."  | print_error
     exit 1
 fi
-if python3.7 -m platform | grep -qi Ubuntu && ! dpkg -l | grep -qi python3.7-dev; then
+if python3.7 -m platform | grep -qi Ubuntu && ! dpkg -l | grep -i python3.7-dev > /dev/null; then
     echo "You are on Ubuntu and python3.7-dev is not installed. Please install python3.7-dev manually and run this script again."  | print_error
     exit 1
 fi


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes the install script python3.7-dev checker

### Proposed changes
<!-- Describe this PR in more detail. -->

Referencing @timoludwig 
"`grep -q` exits immediately after it found the first match, but dpkg -l is not done writing its output, so it sends the error 141 SIGPIPE because it can no longer pipe its output to grep because the process is dead"

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #805 
