### PR TITLE
Remove `node_modules` from static files

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -612,12 +612,6 @@ else:
 #: (see :setting:`django:STATIC_URL` and :doc:`Managing static files <django:howto/static-files/index>`)
 STATIC_URL = "/static/"
 
-#: This setting defines the additional locations the staticfiles app will traverse
-#: (see :setting:`django:STATICFILES_DIRS` and :doc:`Managing static files <django:howto/static-files/index>`)
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "../node_modules"),
-]
-
 #: The list of finder backends that know how to find static files in various locations
 #: (see :setting:`django:STATICFILES_FINDERS`)
 STATICFILES_FINDERS = (


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Since our change to WebPack, we luckily don't need to serve the `node_modules` under the `static` path anymore.
Interestingly, we had an issue for this (#484 "Do not serve `node_modules` under `/static`"), but closed it even though the `node_modules` were still served.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Remove `node_modules` from static files

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes #484