### PR TITLE
Rename query string for pagination in views

### DIFF
--- a/src/cms/views/events/event_list_view.py
+++ b/src/cms/views/events/event_list_view.py
@@ -167,7 +167,7 @@ class EventListView(
             poi = None
         # for consistent pagination querysets should be ordered
         paginator = Paginator(events.order_by("start_date", "start_time"), PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         event_chunk = paginator.get_page(chunk)
         context = self.get_context_data(**kwargs)
         return render(

--- a/src/cms/views/feedback/admin_feedback_list_view.py
+++ b/src/cms/views/feedback/admin_feedback_list_view.py
@@ -106,7 +106,7 @@ class AdminFeedbackListView(PermissionRequiredMixin, TemplateView):
             filter_form.changed_data.clear()
 
         paginator = Paginator(admin_feedback, PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         admin_feedback_chunk = paginator.get_page(chunk)
 
         return render(

--- a/src/cms/views/feedback/region_feedback_list_view.py
+++ b/src/cms/views/feedback/region_feedback_list_view.py
@@ -107,7 +107,7 @@ class RegionFeedbackListView(PermissionRequiredMixin, TemplateView):
             filter_form.changed_data.clear()
 
         paginator = Paginator(region_feedback, PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         region_feedback_chunk = paginator.get_page(chunk)
 
         return render(

--- a/src/cms/views/languages/language_list_view.py
+++ b/src/cms/views/languages/language_list_view.py
@@ -45,7 +45,7 @@ class LanguageListView(PermissionRequiredMixin, TemplateView):
         languages = Language.objects.all()
         # for consistent pagination querysets should be ordered
         paginator = Paginator(languages.order_by("slug"), PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         language_chunk = paginator.get_page(chunk)
         return render(
             request,

--- a/src/cms/views/offer_templates/offer_template_list_view.py
+++ b/src/cms/views/offer_templates/offer_template_list_view.py
@@ -45,7 +45,7 @@ class OfferTemplateListView(PermissionRequiredMixin, TemplateView):
         offer_templates = OfferTemplate.objects.all()
         # for consistent pagination querysets should be ordered
         paginator = Paginator(offer_templates.order_by("slug"), PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         offer_templates_chunk = paginator.get_page(chunk)
         return render(
             request,

--- a/src/cms/views/organizations/organization_list_view.py
+++ b/src/cms/views/organizations/organization_list_view.py
@@ -45,7 +45,7 @@ class OrganizationListView(PermissionRequiredMixin, TemplateView):
         organizations = Organization.objects.all()
         # for consistent pagination querysets should be ordered
         paginator = Paginator(organizations.order_by("slug"), PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         organization_chunk = paginator.get_page(chunk)
         return render(
             request,

--- a/src/cms/views/pois/poi_list_view.py
+++ b/src/cms/views/pois/poi_list_view.py
@@ -102,7 +102,7 @@ class POIListView(PermissionRequiredMixin, TemplateView, POIContextMixin):
         pois = region.pois.filter(archived=self.archived)
         # for consistent pagination querysets should be ordered
         paginator = Paginator(pois.order_by("region__slug"), PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         poi_chunk = paginator.get_page(chunk)
         context = self.get_context_data(**kwargs)
         return render(

--- a/src/cms/views/push_notifications/push_notification_list_view.py
+++ b/src/cms/views/push_notifications/push_notification_list_view.py
@@ -78,7 +78,7 @@ class PushNotificationListView(PermissionRequiredMixin, TemplateView):
         push_notifications = region.push_notifications.all()
         # for consistent pagination querysets should be ordered
         paginator = Paginator(push_notifications.order_by("created_date"), PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         push_notifications_chunk = paginator.get_page(chunk)
         return render(
             request,

--- a/src/cms/views/regions/region_list_view.py
+++ b/src/cms/views/regions/region_list_view.py
@@ -46,7 +46,7 @@ class RegionListView(PermissionRequiredMixin, TemplateView):
         regions = Region.objects.all()
         # for consistent pagination querysets should be ordered
         paginator = Paginator(regions.order_by("created_date"), PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         region_chunk = paginator.get_page(chunk)
         return render(
             request, self.template_name, {**self.base_context, "regions": region_chunk}

--- a/src/cms/views/roles/role_list_view.py
+++ b/src/cms/views/roles/role_list_view.py
@@ -46,7 +46,7 @@ class RoleListView(PermissionRequiredMixin, TemplateView):
         roles = Role.objects.all()
         # for consistent pagination querysets should be ordered
         paginator = Paginator(roles.order_by("name"), PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         role_chunk = paginator.get_page(chunk)
         return render(
             request, self.template_name, {**self.base_context, "roles": role_chunk}

--- a/src/cms/views/users/region_user_list_view.py
+++ b/src/cms/views/users/region_user_list_view.py
@@ -46,7 +46,7 @@ class RegionUserListView(PermissionRequiredMixin, TemplateView):
         region = Region.get_current_region(request)
         # for consistent pagination querysets should be ordered
         paginator = Paginator(region.users.order_by("username"), PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         user_chunk = paginator.get_page(chunk)
         return render(
             request, self.template_name, {**self.base_context, "users": user_chunk}

--- a/src/cms/views/users/user_list_view.py
+++ b/src/cms/views/users/user_list_view.py
@@ -46,7 +46,7 @@ class UserListView(PermissionRequiredMixin, TemplateView):
         users = get_user_model().objects.all()
         # for consistent pagination querysets should be ordered
         paginator = Paginator(users.order_by("username"), PER_PAGE)
-        chunk = request.GET.get("chunk")
+        chunk = request.GET.get("page")
         user_chunk = paginator.get_page(chunk)
         return render(
             request, self.template_name, {**self.base_context, "users": user_chunk}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes the links for all pagination links after the first page

### Proposed changes
<!-- Describe this PR in more detail. -->

Rename the paginators query string in the list views

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #833
