### PR TITLE
Add possibility to refresh last_updated date

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-29 15:29+0000\n"
+"POT-Creation-Date: 2021-05-31 17:37+0000\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
 "Language: German\n"
@@ -5019,8 +5019,7 @@ msgstr ""
 #: views/events/event_view.py:197 views/imprint/imprint_sbs_view.py:197
 #: views/imprint/imprint_view.py:208
 #: views/organizations/organization_view.py:82 views/pages/page_sbs_view.py:193
-#: views/pages/page_view.py:252 views/regions/region_view.py:85
-#: views/settings/user_settings_view.py:89
+#: views/regions/region_view.py:85 views/settings/user_settings_view.py:89
 #: views/settings/user_settings_view.py:106 views/users/region_user_view.py:130
 #: views/users/user_view.py:132
 msgid "No changes detected."
@@ -5130,22 +5129,22 @@ msgid "Errors have occurred."
 msgstr "Es sind Fehler aufgetreten."
 
 #: views/imprint/imprint_sbs_view.py:207 views/imprint/imprint_view.py:241
-#: views/pages/page_sbs_view.py:201 views/pages/page_view.py:288
+#: views/pages/page_sbs_view.py:201 views/pages/page_view.py:271
 msgid "Translation was successfully created and published"
 msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht"
 
 #: views/imprint/imprint_sbs_view.py:210 views/imprint/imprint_view.py:244
-#: views/pages/page_sbs_view.py:204 views/pages/page_view.py:291
+#: views/pages/page_sbs_view.py:204 views/pages/page_view.py:274
 msgid "Translation was successfully created"
 msgstr "Übersetzung wurde erfolgreich erstellt"
 
 #: views/imprint/imprint_sbs_view.py:214 views/imprint/imprint_view.py:247
-#: views/pages/page_sbs_view.py:208 views/pages/page_view.py:294
+#: views/pages/page_sbs_view.py:208 views/pages/page_view.py:278
 msgid "Translation was successfully published"
 msgstr "Übersetzung wurde erfolgreich veröffentlicht"
 
 #: views/imprint/imprint_sbs_view.py:217 views/imprint/imprint_view.py:249
-#: views/pages/page_sbs_view.py:211 views/pages/page_view.py:296
+#: views/pages/page_sbs_view.py:211 views/pages/page_view.py:281
 msgid "Translation was successfully saved"
 msgstr "Übersetzung wurde erfolgreich gespeichert"
 
@@ -5178,7 +5177,7 @@ msgstr "Impressum wurde erfolgreich erstellt und veröffentlicht"
 msgid "imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
-#: views/imprint/imprint_view.py:286 views/pages/page_view.py:335
+#: views/imprint/imprint_view.py:286 views/pages/page_view.py:320
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -5419,11 +5418,15 @@ msgstr ""
 "Version <a href='%(revision_url)s' class='underline hover:no-"
 "underline'>Version %(revision)s</a> dieser Seite in der App angezeigt."
 
-#: views/pages/page_view.py:281
+#: views/pages/page_view.py:259
+msgid "No changes detected, but date refreshed"
+msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
+
+#: views/pages/page_view.py:264
 msgid "Page was successfully created and published"
 msgstr "Seite wurde erfolgreich erstellt und veröffentlicht"
 
-#: views/pages/page_view.py:284
+#: views/pages/page_view.py:267
 msgid "Page was successfully created"
 msgstr "Seite wurde erfolgreich erstellt"
 

--- a/src/cms/views/pages/page_view.py
+++ b/src/cms/views/pages/page_view.py
@@ -248,26 +248,6 @@ class PageView(PermissionRequiredMixin, TemplateView, PageContextMixin):
                 },
             )
 
-        if not page_form.has_changed() and not page_translation_form.has_changed():
-            messages.info(request, _("No changes detected."))
-            return render(
-                request,
-                self.template_name,
-                {
-                    **self.base_context,
-                    "page_form": page_form,
-                    "page_translation_form": page_translation_form,
-                    "page": page_instance,
-                    "siblings": siblings,
-                    "language": language,
-                    # Languages for tab view
-                    "languages": region.languages if page_instance else [language],
-                    "side_by_side_language_options": side_by_side_language_options,
-                    "right_to_left": language.text_direction
-                    == text_directions.RIGHT_TO_LEFT,
-                },
-            )
-
         page = page_form.save()
         page_translation = page_translation_form.save(
             page=page,
@@ -275,25 +255,30 @@ class PageView(PermissionRequiredMixin, TemplateView, PageContextMixin):
         )
 
         published = page_translation.status == status.PUBLIC
-        if not page_instance:
-            if published:
-                messages.success(
-                    request, _("Page was successfully created and published")
-                )
-            else:
-                messages.success(request, _("Page was successfully created"))
-        elif not page_translation_instance:
-            if published:
-                messages.success(
-                    request, _("Translation was successfully created and published")
-                )
-            else:
-                messages.success(request, _("Translation was successfully created"))
+        if not page_form.has_changed() and not page_translation_form.has_changed():
+            messages.info(request, _("No changes detected, but date refreshed"))
         else:
-            if published:
-                messages.success(request, _("Translation was successfully published"))
+            if not page_instance:
+                if published:
+                    messages.success(
+                        request, _("Page was successfully created and published")
+                    )
+                else:
+                    messages.success(request, _("Page was successfully created"))
+            elif not page_translation_instance:
+                if published:
+                    messages.success(
+                        request, _("Translation was successfully created and published")
+                    )
+                else:
+                    messages.success(request, _("Translation was successfully created"))
             else:
-                messages.success(request, _("Translation was successfully saved"))
+                if published:
+                    messages.success(
+                        request, _("Translation was successfully published")
+                    )
+                else:
+                    messages.success(request, _("Translation was successfully saved"))
 
         return redirect(
             "edit_page",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
It is now possible to update a page without any change to refresh the last update date.

### Proposed changes
<!-- Describe this PR in more detail. -->
- By clicking the update/aktualisieren button the last update date of the page will be refreshed to the current time, even if there is no change made in the page contents.
- After refreshing a message is shown ("no changes detected but date refreshed") .

- The button name does not change (stays always "Update/Aktualisieren") in the current commit, because I think changing the button name is probably confusing (Please see the conversation on the issue page). If the changing name is even though wished, I will add it.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #629
