### PR TITLE
Remove unused created_date and last_updated fields

### DIFF
--- a/src/cms/fixtures/test_data.json
+++ b/src/cms/fixtures/test_data.json
@@ -279,7 +279,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T07:57:42.436Z",
       "last_updated": "2019-08-12T07:57:42.456Z"
     }
   },
@@ -297,7 +296,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T07:58:36.305Z",
       "last_updated": "2019-08-12T08:05:51.712Z"
     }
   },
@@ -315,7 +313,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T07:59:21.581Z",
       "last_updated": "2019-08-12T08:05:45.631Z"
     }
   },
@@ -333,7 +330,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T07:59:50.954Z",
       "last_updated": "2019-08-12T08:05:39.369Z"
     }
   },
@@ -351,7 +347,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:01:13.169Z",
       "last_updated": "2019-08-12T08:01:13.187Z"
     }
   },
@@ -369,7 +364,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:01:42.253Z",
       "last_updated": "2019-08-12T08:01:42.279Z"
     }
   },
@@ -387,7 +381,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:02:48.827Z",
       "last_updated": "2019-08-12T08:02:48.852Z"
     }
   },
@@ -405,7 +398,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:03:48.554Z",
       "last_updated": "2019-08-12T08:03:48.584Z"
     }
   },
@@ -423,7 +415,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:04:39.710Z",
       "last_updated": "2019-08-12T08:04:39.746Z"
     }
   },
@@ -441,7 +432,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:05:26.597Z",
       "last_updated": "2019-08-12T08:05:26.616Z"
     }
   },
@@ -459,7 +449,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:08:37.158Z",
       "last_updated": "2019-08-12T08:08:37.172Z"
     }
   },
@@ -477,7 +466,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:08:54.805Z",
       "last_updated": "2019-08-12T08:08:54.855Z"
     }
   },
@@ -495,7 +483,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:09:45.042Z",
       "last_updated": "2019-08-12T08:09:45.052Z"
     }
   },
@@ -513,7 +500,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:10:22.985Z",
       "last_updated": "2019-08-12T08:10:23.049Z"
     }
   },
@@ -531,7 +517,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:11:24.417Z",
       "last_updated": "2019-08-12T08:11:24.443Z"
     }
   },
@@ -549,7 +534,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:11:53.038Z",
       "last_updated": "2019-08-12T08:11:53.052Z"
     }
   },
@@ -567,7 +551,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:13:41.021Z",
       "last_updated": "2019-08-12T08:13:41.049Z"
     }
   },
@@ -585,7 +568,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:17:48.342Z",
       "last_updated": "2019-08-12T08:17:48.382Z"
     }
   },
@@ -603,7 +585,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:18:09.766Z",
       "last_updated": "2019-08-12T08:27:30.183Z"
     }
   },
@@ -621,7 +602,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:18:36.113Z",
       "last_updated": "2019-08-12T08:27:25.680Z"
     }
   },
@@ -639,7 +619,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:19:10.521Z",
       "last_updated": "2019-08-12T08:27:20.623Z"
     }
   },
@@ -657,7 +636,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:19:48.980Z",
       "last_updated": "2019-08-12T08:27:16.550Z"
     }
   },
@@ -675,7 +653,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:20:16.705Z",
       "last_updated": "2019-08-12T08:27:11.677Z"
     }
   },
@@ -693,7 +670,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:20:43.653Z",
       "last_updated": "2019-08-12T08:27:07.546Z"
     }
   },
@@ -711,7 +687,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:22:18.585Z",
       "last_updated": "2019-08-12T08:22:18.602Z"
     }
   },
@@ -729,7 +704,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:22:31.256Z",
       "last_updated": "2019-08-12T08:22:31.270Z"
     }
   },
@@ -747,7 +721,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:23:17.979Z",
       "last_updated": "2019-08-12T08:23:17.994Z"
     }
   },
@@ -765,7 +738,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:23:59.016Z",
       "last_updated": "2019-08-12T08:23:59.042Z"
     }
   },
@@ -783,7 +755,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:24:36.073Z",
       "last_updated": "2019-08-12T08:24:36.101Z"
     }
   },
@@ -801,7 +772,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:25:07.388Z",
       "last_updated": "2019-08-12T08:25:07.407Z"
     }
   },
@@ -819,7 +789,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:25:47.171Z",
       "last_updated": "2019-08-12T08:25:47.203Z"
     }
   },
@@ -837,7 +806,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:26:21.704Z",
       "last_updated": "2019-08-12T08:26:21.723Z"
     }
   },
@@ -855,7 +823,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2019-08-12T08:26:50.465Z",
       "last_updated": "2019-08-12T08:26:50.483Z"
     }
   },
@@ -869,7 +836,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T07:57:42.432Z",
-      "last_updated": "2019-08-12T08:09:45.047Z",
       "lft": 1,
       "rght": 12,
       "tree_id": 1,
@@ -888,7 +854,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T07:58:36.298Z",
-      "last_updated": "2019-08-12T08:10:23.031Z",
       "lft": 6,
       "rght": 7,
       "tree_id": 1,
@@ -907,7 +872,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T07:59:21.571Z",
-      "last_updated": "2019-08-12T08:11:53.048Z",
       "lft": 4,
       "rght": 5,
       "tree_id": 1,
@@ -926,7 +890,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T07:59:50.923Z",
-      "last_updated": "2019-08-12T08:13:41.042Z",
       "lft": 2,
       "rght": 3,
       "tree_id": 1,
@@ -945,7 +908,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T08:01:13.162Z",
-      "last_updated": "2019-08-12T08:08:54.846Z",
       "lft": 8,
       "rght": 9,
       "tree_id": 1,
@@ -964,7 +926,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T08:01:42.227Z",
-      "last_updated": "2019-08-12T08:01:42.271Z",
       "lft": 10,
       "rght": 11,
       "tree_id": 1,
@@ -983,7 +944,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T08:17:48.337Z",
-      "last_updated": "2019-08-12T08:26:21.713Z",
       "lft": 1,
       "rght": 14,
       "tree_id": 2,
@@ -1002,7 +962,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T08:18:09.754Z",
-      "last_updated": "2019-08-12T08:27:30.170Z",
       "lft": 2,
       "rght": 3,
       "tree_id": 2,
@@ -1021,7 +980,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T08:18:36.107Z",
-      "last_updated": "2019-08-12T08:27:25.672Z",
       "lft": 4,
       "rght": 5,
       "tree_id": 2,
@@ -1040,7 +998,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T08:19:10.505Z",
-      "last_updated": "2019-08-12T08:27:20.613Z",
       "lft": 6,
       "rght": 7,
       "tree_id": 2,
@@ -1059,7 +1016,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T08:19:48.948Z",
-      "last_updated": "2019-08-12T08:27:16.540Z",
       "lft": 8,
       "rght": 9,
       "tree_id": 2,
@@ -1078,7 +1034,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T08:20:16.690Z",
-      "last_updated": "2019-08-12T08:27:11.670Z",
       "lft": 10,
       "rght": 11,
       "tree_id": 2,
@@ -1097,7 +1052,6 @@
       "explicitly_archived": false,
       "mirrored_page": null,
       "created_date": "2019-08-12T08:20:43.643Z",
-      "last_updated": "2019-08-12T08:27:07.539Z",
       "lft": 12,
       "rght": 13,
       "tree_id": 2,
@@ -1207,7 +1161,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2020-01-22T12:45:51.950Z",
       "last_updated": "2020-01-22T12:46:33.967Z"
     }
   },
@@ -1225,7 +1178,6 @@
       "version": 1,
       "minor_edit": false,
       "creator": 1,
-      "created_date": "2020-01-22T12:46:16.739Z",
       "last_updated": "2020-01-22T12:46:16.746Z"
     }
   },
@@ -1256,7 +1208,6 @@
       "language": 1,
       "version": 1,
       "minor_edit": false,
-      "created_date": "2020-01-22T12:52:13.611Z",
       "last_updated": "2020-01-22T12:52:13.616Z",
       "creator": 1
     }
@@ -1274,7 +1225,6 @@
       "language": 2,
       "version": 1,
       "minor_edit": false,
-      "created_date": "2020-01-22T12:52:56.720Z",
       "last_updated": "2020-01-22T12:52:56.726Z",
       "creator": 1
     }

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-05-26 10:18+0000\n"
+"POT-Creation-Date: 2021-05-29 15:29+0000\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
 "Language: German\n"
@@ -1585,8 +1585,8 @@ msgstr ""
 msgid "sender"
 msgstr "Absender"
 
-#: models/chat/chat_message.py:44 models/pois/poi_translation.py:49
-#: models/push_notifications/push_notification_translation.py:22
+#: models/chat/chat_message.py:44 models/pois/poi_translation.py:48
+#: models/push_notifications/push_notification_translation.py:21
 msgid "content"
 msgstr "Inhalt"
 
@@ -1612,7 +1612,7 @@ msgid "region"
 msgstr "Region"
 
 #: models/events/event.py:32 models/pois/poi.py:144
-#: models/pois/poi_translation.py:37
+#: models/pois/poi_translation.py:36
 msgid "location"
 msgstr "Ort"
 
@@ -1648,7 +1648,7 @@ msgstr "archiviert"
 msgid "copy"
 msgstr "Kopie"
 
-#: models/events/event.py:304 models/events/event_translation.py:25
+#: models/events/event.py:304 models/events/event_translation.py:24
 msgid "event"
 msgstr "Veranstaltung"
 
@@ -1656,78 +1656,78 @@ msgstr "Veranstaltung"
 msgid "events"
 msgstr "Veranstaltungen"
 
-#: models/events/event_translation.py:31 models/pois/poi_translation.py:26
+#: models/events/event_translation.py:30 models/pois/poi_translation.py:25
 #: models/regions/region.py:42
 msgid "URL parameter"
 msgstr "URL-Parameter"
 
-#: models/events/event_translation.py:33 models/offers/offer_template.py:23
-#: models/pages/page_translation.py:35 models/pois/poi_translation.py:28
+#: models/events/event_translation.py:32 models/offers/offer_template.py:23
+#: models/pages/page_translation.py:35 models/pois/poi_translation.py:27
 msgid "String identifier without spaces and special characters."
 msgstr "Bezeichner ohne Leerzeichen und Sonderzeichen."
 
-#: models/events/event_translation.py:34 models/offers/offer_template.py:24
-#: models/pages/page_translation.py:36 models/pois/poi_translation.py:29
+#: models/events/event_translation.py:33 models/offers/offer_template.py:24
+#: models/pages/page_translation.py:36 models/pois/poi_translation.py:28
 msgid "Unique per region and language."
 msgstr "Eindeutig pro Region und Sprache."
 
-#: models/events/event_translation.py:35 models/pages/page_translation.py:37
-#: models/pois/poi_translation.py:30
+#: models/events/event_translation.py:34 models/pages/page_translation.py:37
+#: models/pois/poi_translation.py:29
 msgid "Leave blank to generate unique parameter from title."
 msgstr ""
 "Dieses Feld freilassen, um einen eindeutigen Alias aus dem Titel zu "
 "generieren."
 
-#: models/events/event_translation.py:43
-#: models/pages/abstract_base_page_translation.py:27
-#: models/pois/poi_translation.py:44 models/regions/region.py:53
+#: models/events/event_translation.py:42
+#: models/pages/abstract_base_page_translation.py:26
+#: models/pois/poi_translation.py:43 models/regions/region.py:53
 msgid "status"
 msgstr "Status"
 
-#: models/events/event_translation.py:45 models/pois/poi_translation.py:21
-#: models/push_notifications/push_notification_translation.py:17
+#: models/events/event_translation.py:44 models/pois/poi_translation.py:20
+#: models/push_notifications/push_notification_translation.py:16
 msgid "title"
 msgstr "Titel"
 
-#: models/events/event_translation.py:46 models/media/document.py:11
+#: models/events/event_translation.py:45 models/media/document.py:11
 msgid "description"
 msgstr "Beschreibung"
 
-#: models/events/event_translation.py:51 models/feedback/feedback.py:28
+#: models/events/event_translation.py:50 models/feedback/feedback.py:28
 #: models/languages/language.py:133 models/languages/language_tree_node.py:23
 #: models/pages/imprint_page_translation.py:32
-#: models/pages/page_translation.py:50 models/pois/poi_translation.py:54
-#: models/push_notifications/push_notification_translation.py:28
+#: models/pages/page_translation.py:50 models/pois/poi_translation.py:53
+#: models/push_notifications/push_notification_translation.py:27
 msgid "language"
 msgstr "Sprache"
 
-#: models/events/event_translation.py:55
-#: models/pages/abstract_base_page_translation.py:31
-#: models/pois/poi_translation.py:58
+#: models/events/event_translation.py:54
+#: models/pages/abstract_base_page_translation.py:30
+#: models/pois/poi_translation.py:57
 msgid "currently in translation"
 msgstr "wird derzeit übersetzt"
 
-#: models/events/event_translation.py:57
-#: models/pages/abstract_base_page_translation.py:33
-#: models/pois/poi_translation.py:60
+#: models/events/event_translation.py:56
+#: models/pages/abstract_base_page_translation.py:32
+#: models/pois/poi_translation.py:59
 msgid ""
 "Flag to indicate a translation is being updated by an external translator"
 msgstr ""
 "Feld, die anzeigt, dass eine Übersetzung von einem externen Übersetzer "
 "aktualisiert wird"
 
-#: models/events/event_translation.py:60 models/pois/poi_translation.py:63
+#: models/events/event_translation.py:59 models/pois/poi_translation.py:62
 msgid "revision"
 msgstr "Revision"
 
-#: models/events/event_translation.py:63
-#: models/pages/abstract_base_page_translation.py:39
-#: models/pois/poi_translation.py:66
+#: models/events/event_translation.py:62
+#: models/pages/abstract_base_page_translation.py:38
+#: models/pois/poi_translation.py:65
 msgid "minor edit"
 msgstr "geringfügige Änderung"
 
-#: models/events/event_translation.py:65
-#: models/pages/abstract_base_page_translation.py:41
+#: models/events/event_translation.py:64
+#: models/pages/abstract_base_page_translation.py:40
 msgid ""
 "Tick if this change does not require an update of translations in other "
 "languages"
@@ -1735,40 +1735,26 @@ msgstr ""
 "Kreuzen Sie an, wenn diese Änderung keine Aktualisierung der Übersetzungen "
 "in anderen Sprachen erfordert"
 
-#: models/events/event_translation.py:73
+#: models/events/event_translation.py:72
 #: models/pages/imprint_page_translation.py:39
-#: models/pages/page_translation.py:57 models/pois/poi_translation.py:84
+#: models/pages/page_translation.py:57 models/pois/poi_translation.py:79
 msgid "creator"
 msgstr "Ersteller"
 
-#: models/events/event_translation.py:77 models/feedback/feedback.py:58
-#: models/languages/language.py:83 models/languages/language_tree_node.py:51
-#: models/offers/offer_template.py:56 models/pages/abstract_base_page.py:19
-#: models/pages/abstract_base_page_translation.py:46
-#: models/pois/poi_translation.py:73
-#: models/push_notifications/push_notification.py:40
-#: models/push_notifications/push_notification_translation.py:38
-#: models/regions/region.py:103 models/users/organization.py:28
-#: models/users/user_mfa_key.py:37
-msgid "creation date"
-msgstr "Erstellungsdatum"
-
-#: models/events/event_translation.py:81 models/languages/language.py:87
+#: models/events/event_translation.py:76 models/languages/language.py:87
 #: models/languages/language_tree_node.py:55 models/offers/offer_template.py:60
-#: models/pages/abstract_base_page.py:22
-#: models/pages/abstract_base_page_translation.py:50
-#: models/pois/poi_translation.py:77
-#: models/push_notifications/push_notification.py:44
-#: models/push_notifications/push_notification_translation.py:42
+#: models/pages/abstract_base_page_translation.py:45
+#: models/pois/poi_translation.py:72
+#: models/push_notifications/push_notification_translation.py:37
 #: models/regions/region.py:107 models/users/organization.py:32
 msgid "modification date"
 msgstr "Änderungsdatum"
 
-#: models/events/event_translation.py:315 models/feedback/event_feedback.py:18
+#: models/events/event_translation.py:310 models/feedback/event_feedback.py:18
 msgid "event translation"
 msgstr "Veranstaltungs-Übersetzung"
 
-#: models/events/event_translation.py:317
+#: models/events/event_translation.py:312
 msgid "event translations"
 msgstr "Veranstaltungs-Übersetzungen"
 
@@ -1889,6 +1875,15 @@ msgstr "Der Benutzer, der dieses Feedback als gelesen markiert hat."
 msgid "If the feedback is unread, this field is empty."
 msgstr "Wenn das Feedback ungelesen ist, ist dieses Feld leer."
 
+#: models/feedback/feedback.py:58 models/languages/language.py:83
+#: models/languages/language_tree_node.py:51 models/offers/offer_template.py:56
+#: models/pages/abstract_base_page.py:19
+#: models/push_notifications/push_notification.py:40
+#: models/regions/region.py:103 models/users/organization.py:28
+#: models/users/user_mfa_key.py:37
+msgid "creation date"
+msgstr "Erstellungsdatum"
+
 #: models/feedback/feedback.py:187 models/feedback/feedback.py:189
 msgid "feedback"
 msgstr "Feedback"
@@ -1928,7 +1923,7 @@ msgid "offer list feedback"
 msgstr "Angebotslisten-Feedback"
 
 #: models/feedback/page_feedback.py:18
-#: models/pages/abstract_base_page_translation.py:328
+#: models/pages/abstract_base_page_translation.py:323
 #: models/pages/page_translation.py:287
 msgid "page translation"
 msgstr "Seiten-Übersetzung"
@@ -1937,7 +1932,7 @@ msgstr "Seiten-Übersetzung"
 msgid "page feedback"
 msgstr "Seiten-Feedback"
 
-#: models/feedback/poi_feedback.py:18 models/pois/poi_translation.py:316
+#: models/feedback/poi_feedback.py:18 models/pois/poi_translation.py:311
 msgid "location translation"
 msgstr "Orts-Übersetzung"
 
@@ -2166,28 +2161,28 @@ msgstr "explizit archiviert"
 msgid "Whether or not the page is explicitly archived"
 msgstr "Ob die Seite explizit archiviert ist oder nicht"
 
-#: models/pages/abstract_base_page.py:142 models/pages/page.py:208
+#: models/pages/abstract_base_page.py:139 models/pages/page.py:208
 #: models/pages/page_translation.py:44
 msgid "page"
 msgstr "Seite"
 
-#: models/pages/abstract_base_page.py:144 models/pages/page.py:210
+#: models/pages/abstract_base_page.py:141 models/pages/page.py:210
 msgid "pages"
 msgstr "Seiten"
 
-#: models/pages/abstract_base_page_translation.py:16
+#: models/pages/abstract_base_page_translation.py:15
 msgid "title of the page"
 msgstr "Titel der Seite"
 
-#: models/pages/abstract_base_page_translation.py:20
+#: models/pages/abstract_base_page_translation.py:19
 msgid "content of the page"
 msgstr "Inhalt der Seite"
 
-#: models/pages/abstract_base_page_translation.py:36
+#: models/pages/abstract_base_page_translation.py:35
 msgid "version"
 msgstr "Version"
 
-#: models/pages/abstract_base_page_translation.py:330
+#: models/pages/abstract_base_page_translation.py:325
 #: models/pages/page_translation.py:289
 msgid "page translations"
 msgstr "Seiten-Übersetzungen"
@@ -2343,11 +2338,11 @@ msgstr "Ob der Ort schreibgeschützt und in der API verborgen ist oder nicht."
 msgid "locations"
 msgstr "Orte"
 
-#: models/pois/poi_translation.py:47
+#: models/pois/poi_translation.py:46
 msgid "short description"
 msgstr "Kurzbeschreibung"
 
-#: models/pois/poi_translation.py:68
+#: models/pois/poi_translation.py:67
 msgid ""
 "Tick if this change does not require an update of translations in other "
 "languages."
@@ -2355,7 +2350,7 @@ msgstr ""
 "Kreuzen Sie an, wenn diese Änderung keine Aktualisierung der Übersetzungen "
 "in anderen Sprachen erfordert."
 
-#: models/pois/poi_translation.py:318
+#: models/pois/poi_translation.py:313
 msgid "location translations"
 msgstr "Orts-Übersetzungen"
 
@@ -2377,31 +2372,31 @@ msgstr ""
 msgid "The date and time when the push notification was sent."
 msgstr "Datum und Uhrzeit, als die Push-Benachrichtigung gesendet wurde"
 
-#: models/push_notifications/push_notification.py:50
+#: models/push_notifications/push_notification.py:46
 msgid "mode"
 msgstr "Modus"
 
-#: models/push_notifications/push_notification.py:52
+#: models/push_notifications/push_notification.py:48
 msgid ""
 "Sets behavior for dealing with not existing push notification translations"
 msgstr ""
 "Legt das Verhalten für den Umgang mit nicht vorhandenen Übersetzungen von "
 "Push-Benachrichtigungen fest"
 
-#: models/push_notifications/push_notification.py:83
-#: models/push_notifications/push_notification_translation.py:34
+#: models/push_notifications/push_notification.py:79
+#: models/push_notifications/push_notification_translation.py:33
 msgid "push notification"
 msgstr "Push-Benachrichtigung"
 
-#: models/push_notifications/push_notification.py:85
+#: models/push_notifications/push_notification.py:81
 msgid "push notifications"
 msgstr "Push-Benachrichtigungen"
 
-#: models/push_notifications/push_notification_translation.py:67
+#: models/push_notifications/push_notification_translation.py:62
 msgid "push notification translation"
 msgstr "Push-Benachrichtigungs-Übersetzung"
 
-#: models/push_notifications/push_notification_translation.py:69
+#: models/push_notifications/push_notification_translation.py:64
 msgid "push notification translations"
 msgstr "Push-Benachrichtigungs-Übersetzungen"
 

--- a/src/cms/models/events/event_translation.py
+++ b/src/cms/models/events/event_translation.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
-from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from linkcheck.models import Link
@@ -71,10 +70,6 @@ class EventTranslation(models.Model):
         on_delete=models.SET_NULL,
         related_name="event_translations",
         verbose_name=_("creator"),
-    )
-    created_date = models.DateTimeField(
-        default=timezone.now,
-        verbose_name=_("creation date"),
     )
     last_updated = models.DateTimeField(
         auto_now=True,

--- a/src/cms/models/pages/abstract_base_page.py
+++ b/src/cms/models/pages/abstract_base_page.py
@@ -18,9 +18,6 @@ class AbstractBasePage(models.Model):
     created_date = models.DateTimeField(
         default=timezone.now, verbose_name=_("creation date")
     )
-    last_updated = models.DateTimeField(
-        auto_now=True, verbose_name=_("modification date")
-    )
 
     @property
     def archived(self):

--- a/src/cms/models/pages/abstract_base_page_translation.py
+++ b/src/cms/models/pages/abstract_base_page_translation.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from backend.settings import WEBAPP_URL
@@ -40,10 +39,6 @@ class AbstractBasePageTranslation(models.Model):
         help_text=_(
             "Tick if this change does not require an update of translations in other languages"
         ),
-    )
-    created_date = models.DateTimeField(
-        default=timezone.now,
-        verbose_name=_("creation date"),
     )
     last_updated = models.DateTimeField(
         auto_now=True,

--- a/src/cms/models/pois/poi_translation.py
+++ b/src/cms/models/pois/poi_translation.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
-from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from linkcheck.models import Link
@@ -67,10 +66,6 @@ class POITranslation(models.Model):
         help_text=_(
             "Tick if this change does not require an update of translations in other languages."
         ),
-    )
-    created_date = models.DateTimeField(
-        default=timezone.now,
-        verbose_name=_("creation date"),
     )
     last_updated = models.DateTimeField(
         auto_now=True,

--- a/src/cms/models/push_notifications/push_notification.py
+++ b/src/cms/models/push_notifications/push_notification.py
@@ -39,10 +39,6 @@ class PushNotification(models.Model):
         auto_now_add=True,
         verbose_name=_("creation date"),
     )
-    last_updated = models.DateTimeField(
-        auto_now=True,
-        verbose_name=_("modification date"),
-    )
     #: Manage choices in :mod:`cms.constants.push_notifications`
     mode = models.CharField(
         max_length=128,

--- a/src/cms/models/push_notifications/push_notification_translation.py
+++ b/src/cms/models/push_notifications/push_notification_translation.py
@@ -1,5 +1,4 @@
 from django.db import models
-from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from ..languages.language import Language
@@ -32,10 +31,6 @@ class PushNotificationTranslation(models.Model):
         on_delete=models.CASCADE,
         related_name="translations",
         verbose_name=_("push notification"),
-    )
-    created_date = models.DateTimeField(
-        default=timezone.now,
-        verbose_name=_("creation date"),
     )
     last_updated = models.DateTimeField(
         auto_now=True,


### PR DESCRIPTION
### Short description
This pr removes the `created_date` and `last_updated` fields from some models as specified in #846.
Additionally, this pr removes the `created_date` field from `ImprintPageTranslation` and the `last_updated` field from `ImprintPage`.

### Resolved issues
Fixes: #846
