### PR TITLE
Admin menu visible in user settings #786

### DIFF
--- a/src/cms/templates/_base.html
+++ b/src/cms/templates/_base.html
@@ -61,13 +61,13 @@
         </div>
     </div>
     <div id="user-info" class="relative px-2 text-gray-800 flex flex-col justify-center cursor-pointer hover:bg-gray-200">
-        <a href="{% url 'user_settings' %}" class="relative block whitespace-nowrap">
+        <a href="{% if region %}{% url 'user_settings' region_slug=region.slug %}{% else %}{% url 'user_settings' %}{% endif %}" class="relative block whitespace-nowrap">
             <i data-feather="user"></i>
             {{ request.user.profile.full_user_name }}
             <i data-feather="chevron-down"></i>
         </a>
         <div id="user-menu" class="absolute hidden shadow rounded-b top-full right-0 bg-gray-200">
-            <a href="{% url 'user_settings' %}" class="relative block whitespace-nowrap px-4 py-3 text-gray-800 hover:bg-gray-400">
+            <a href="{% if region %}{% url 'user_settings' region_slug=region.slug %}{% else %}{% url 'user_settings' %}{% endif %}" class="relative block whitespace-nowrap px-4 py-3 text-gray-800 hover:bg-gray-400">
                 <i data-feather="settings"></i>
                 {% trans 'User Settings' %}
             </a>

--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -938,6 +938,11 @@ urlpatterns = [
                         ]
                     ),
                 ),
+                url(
+                    r"^user_settings/$",
+                    settings.UserSettingsView.as_view(),
+                    name="user_settings",
+                ),
             ]
         ),
     ),

--- a/src/cms/views/settings/mfa/register_user_mfa_key_view.py
+++ b/src/cms/views/settings/mfa/register_user_mfa_key_view.py
@@ -87,4 +87,14 @@ class RegisterUserMfaKeyView(CreateView):
                 'The 2-factor authentication key "{}" was successfully registered.'
             ).format(new_key.name),
         )
-        return JsonResponse({"success": True, "successUrl": reverse("user_settings")})
+        # Determine success url
+        if request.user.is_superuser or request.user.is_staff:
+            # If user is superuser, return to user settings in network area
+            success_url = reverse("user_settings")
+        else:
+            # If user is region-user, return to user settings in first region
+            success_url = reverse(
+                "user_settings",
+                kwargs={"region_slug": request.user.profile.regions.first().slug},
+            )
+        return JsonResponse({"success": True, "successUrl": success_url})


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR modifies the link of the user setting so that the network setting/admin dashboard is not visible to the non-staff users. 

### Proposed changes
<!-- Describe this PR in more detail. -->

- added region slug in the link to the user settings.
-
-

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #786
