### PR TITLE
Return recurrent events in the events api

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -90,6 +90,9 @@ RSS_FEED_URLS = {
 #: How many days of chat history should be shown
 AUTHOR_CHAT_HISTORY_DAYS = 30
 
+#: The time span up to which recurrent events should be returned by the api
+API_EVENTS_MAX_TIME_SPAN_DAYS = 31
+
 ###############################
 # Firebase Push Notifications #
 ###############################

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -1632,7 +1632,7 @@ msgstr "End-Uhrzeit"
 msgid "end time"
 msgstr "End-Datum"
 
-#: models/events/event.py:44 models/events/recurrence_rule.py:91
+#: models/events/event.py:44 models/events/recurrence_rule.py:170
 msgid "recurrence rule"
 msgstr "Wiederholungs-Regel"
 
@@ -1758,27 +1758,27 @@ msgstr "Veranstaltungs-Übersetzung"
 msgid "event translations"
 msgstr "Veranstaltungs-Übersetzungen"
 
-#: models/events/recurrence_rule.py:20
+#: models/events/recurrence_rule.py:21
 msgid "frequency"
 msgstr "Häufigkeit"
 
-#: models/events/recurrence_rule.py:21
+#: models/events/recurrence_rule.py:22
 msgid "How often the event recurs"
 msgstr "Wie oft sich die Veranstaltung wiederholt"
 
-#: models/events/recurrence_rule.py:26
+#: models/events/recurrence_rule.py:27
 msgid "Repeat every ... time(s)"
 msgstr "Jedes ...-te Mal wiederholen"
 
-#: models/events/recurrence_rule.py:27
+#: models/events/recurrence_rule.py:28
 msgid "The interval in which the event recurs."
 msgstr "Das Intervall, in dem sich das Ereignis wiederholt."
 
-#: models/events/recurrence_rule.py:33
+#: models/events/recurrence_rule.py:34
 msgid "weekdays"
 msgstr "Wochentage"
 
-#: models/events/recurrence_rule.py:35
+#: models/events/recurrence_rule.py:36
 msgid ""
 "If the frequency is weekly, this field determines on which days the event "
 "takes place"
@@ -1786,11 +1786,11 @@ msgstr ""
 "Wenn die Häufigkeit wöchentlich ist, bestimmt dieses Feld, an welchen Tagen "
 "die Veranstaltung stattfindet"
 
-#: models/events/recurrence_rule.py:43
+#: models/events/recurrence_rule.py:44
 msgid "weekday"
 msgstr "Wochentag"
 
-#: models/events/recurrence_rule.py:45
+#: models/events/recurrence_rule.py:46
 msgid ""
 "If the frequency is monthly, this field determines on which days the event "
 "takes place"
@@ -1798,11 +1798,11 @@ msgstr ""
 "Wenn die Häufigkeit monatlich ist, bestimmt dieses Feld, an welchen Tagen "
 "die Veranstaltung stattfindet"
 
-#: models/events/recurrence_rule.py:53
+#: models/events/recurrence_rule.py:54
 msgid "week"
 msgstr "Woche"
 
-#: models/events/recurrence_rule.py:55
+#: models/events/recurrence_rule.py:56
 msgid ""
 "If the frequency is monthly, this field determines on which week of the "
 "month the event takes place"
@@ -1810,11 +1810,11 @@ msgstr ""
 "Wenn die Häufigkeit monatlich ist, bestimmt dieses Feld, in welcher Woche "
 "des Monats das Ereignis stattfindet"
 
-#: models/events/recurrence_rule.py:61
+#: models/events/recurrence_rule.py:62
 msgid "recurrence end date"
 msgstr "Enddatum der Wiederholung"
 
-#: models/events/recurrence_rule.py:63
+#: models/events/recurrence_rule.py:64
 msgid ""
 "If the recurrence is not for an indefinite period, this field contains the "
 "end date"
@@ -1822,11 +1822,11 @@ msgstr ""
 "Wenn die Wiederholung nicht auf unbestimmte Zeit erfolgt, enthält dieses "
 "Feld das Enddatum"
 
-#: models/events/recurrence_rule.py:75
+#: models/events/recurrence_rule.py:154
 msgid "Recurrence rule of \"{}\" ({})"
 msgstr "Wiederholungs-Regel von \"{}\" ({})"
 
-#: models/events/recurrence_rule.py:93
+#: models/events/recurrence_rule.py:172
 msgid "recurrence rules"
 msgstr "Wiederholungs-Regeln"
 


### PR DESCRIPTION
### Short description
This pr allows recurrent events to be returned by the events api.


### Proposed changes
Add a method `iter_after` to  the`RecurrenceRule` model to generate all valid dates covered by this rule after a start date.
Use this method in the events api endpoint to additionally return these events, up to a maximum time span.
These events and their translations will have an id of `null`. Additionally, a unique path will be created for each event translation.

### Resolved issues
Fixes: #842 
