### PR TITLE
Fix broken poi field in event form

### DIFF
--- a/src/cms/views/events/event_actions.py
+++ b/src/cms/views/events/event_actions.py
@@ -215,7 +215,7 @@ def search_poi_ajax(request):
     # All latest revisions of a POI (one for each language)
     latest_public_poi_revisions = (
         POITranslation.objects.filter(poi=OuterRef("pk"), status=status.PUBLIC)
-        .order_by("language", "-version")
+        .order_by("language__pk", "-version")
         .distinct("language")
         .values("id")
     )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix broken poi field in event form

### Proposed changes
<!-- Describe this PR in more detail. -->

According to the docs:
```
Keep in mind that order_by() uses any default related model ordering that has been defined. 
You might have to explicitly order by the relation _id or referenced field to make sure 
the DISTINCT ON expressions match those at the beginning of the ORDER BY clause. 
``` 
Since the language model is ordered by bcp47_tag, docs suggest to explicitly order by the relations id. 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #861
