### PR TITLE
generalize slugify_ajax

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: constants/administrative_division.py:38 templates/events/event_form.html:252
+#: constants/administrative_division.py:38 templates/events/event_form.html:265
 #: templates/pois/poi_list.html:62 templates/pois/poi_list_archived.html:38
 msgid "City"
 msgstr "Stadt"
@@ -3267,78 +3267,78 @@ msgstr "Übersetzung erstellen"
 msgid "Version"
 msgstr "Version"
 
-#: templates/events/event_form.html:140 templates/imprint/imprint_form.html:122
+#: templates/events/event_form.html:153 templates/imprint/imprint_form.html:122
 #: templates/imprint/imprint_sbs.html:147 templates/pages/page_form.html:226
-#: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:148
+#: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:147
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
-#: templates/events/event_form.html:153 templates/imprint/imprint_form.html:167
-#: templates/pois/poi_form.html:161
+#: templates/events/event_form.html:166 templates/imprint/imprint_form.html:167
+#: templates/pois/poi_form.html:160
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
 
-#: templates/events/event_form.html:185
+#: templates/events/event_form.html:198
 msgid "Recurrence"
 msgstr "Wiederholung"
 
-#: templates/events/event_form.html:231
+#: templates/events/event_form.html:244
 msgid "Where"
 msgstr "Wo"
 
-#: templates/events/event_form.html:234
+#: templates/events/event_form.html:247
 msgid "Name of event location"
 msgstr "Name des Veranstaltungsortes"
 
-#: templates/events/event_form.html:238
+#: templates/events/event_form.html:251
 msgid "Remove location from event"
 msgstr "Veranstaltungsort von Veranstaltung entfernen"
 
-#: templates/events/event_form.html:247
+#: templates/events/event_form.html:260
 msgid ""
 "Create an event location or start typing the name of an existing location"
 msgstr ""
 "Erstelle einen Veranstaltungsort oder beginne den Namen eines bestehenden "
 "Veranstaltungsortes einzutippen"
 
-#: templates/events/event_form.html:250 templates/pois/poi_list.html:60
+#: templates/events/event_form.html:263 templates/pois/poi_list.html:60
 #: templates/pois/poi_list_archived.html:36
 msgid "Street"
 msgstr "Straße"
 
-#: templates/events/event_form.html:254 templates/pois/poi_list.html:63
+#: templates/events/event_form.html:267 templates/pois/poi_list.html:63
 #: templates/pois/poi_list_archived.html:39
 msgid "Country"
 msgstr "Land"
 
-#: templates/events/event_form.html:257
+#: templates/events/event_form.html:270
 msgid "Map"
 msgstr "Karte"
 
-#: templates/events/event_form.html:266
+#: templates/events/event_form.html:279
 #: templates/events/event_list_archived_row.html:93
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:273
+#: templates/events/event_form.html:286
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: templates/events/event_form.html:276 templates/events/event_list_row.html:94
+#: templates/events/event_form.html:289 templates/events/event_list_row.html:94
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
-#: templates/events/event_form.html:283
+#: templates/events/event_form.html:296
 msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
-#: templates/events/event_form.html:289
+#: templates/events/event_form.html:302
 #: templates/events/event_list_archived_row.html:102
 #: templates/events/event_list_row.html:103
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
-#: templates/events/event_form.html:296
+#: templates/events/event_form.html:309
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 
@@ -4127,7 +4127,7 @@ msgstr "Seite löschen"
 
 #: templates/pages/page_form.html:356
 #: templates/pages/page_tree_archived_node.html:94
-#: templates/pages/page_tree_node.html:129 views/pages/page_actions.py:219
+#: templates/pages/page_tree_node.html:129 views/pages/page_actions.py:217
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
@@ -4348,43 +4348,43 @@ msgstr "Neue Übersetzung des Ortes erstellen"
 msgid "Create new location"
 msgstr "Neuen Ort erstellen"
 
-#: templates/pois/poi_form.html:169
+#: templates/pois/poi_form.html:168
 msgid "Address"
 msgstr "Adresse"
 
-#: templates/pois/poi_form.html:178
+#: templates/pois/poi_form.html:177
 msgid "Location on map"
 msgstr "Ort auf Karte"
 
-#: templates/pois/poi_form.html:184
+#: templates/pois/poi_form.html:183
 msgid "Position"
 msgstr "Position"
 
-#: templates/pois/poi_form.html:199 templates/pois/poi_form.html:200
+#: templates/pois/poi_form.html:198 templates/pois/poi_form.html:199
 #: templates/pois/poi_list_archived_row.html:54
 msgid "Restore location"
 msgstr "Ort wiederherstellen"
 
-#: templates/pois/poi_form.html:205
+#: templates/pois/poi_form.html:204
 msgid "Restore this location"
 msgstr "Diesen Ort wiederherstellen"
 
-#: templates/pois/poi_form.html:208 templates/pois/poi_form.html:209
+#: templates/pois/poi_form.html:207 templates/pois/poi_form.html:208
 #: templates/pois/poi_list_row.html:84
 msgid "Archive location"
 msgstr "Ort archivieren"
 
-#: templates/pois/poi_form.html:214
+#: templates/pois/poi_form.html:213
 msgid "Archive this location"
 msgstr "Diesen Ort archivieren"
 
-#: templates/pois/poi_form.html:220 templates/pois/poi_form.html:221
+#: templates/pois/poi_form.html:219 templates/pois/poi_form.html:220
 #: templates/pois/poi_list_archived_row.html:62
 #: templates/pois/poi_list_row.html:92
 msgid "Delete location"
 msgstr "Ort löschen"
 
-#: templates/pois/poi_form.html:226
+#: templates/pois/poi_form.html:225
 msgid "Delete this location"
 msgstr "Diesen Ort löschen"
 
@@ -5019,18 +5019,18 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Veranstaltungen zu bearbeiten "
 "oder zu erstellen."
 
-#: views/events/event_view.py:70
+#: views/events/event_view.py:72
 msgid "You don't have the permission to edit this event."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Veranstaltung zu "
 "bearbeiten."
 
-#: views/events/event_view.py:75
+#: views/events/event_view.py:77
 msgid "You cannot edit this event because it is archived."
 msgstr ""
 "Sie können diese Veranstaltung nicht bearbeiten, weil sie archiviert ist."
 
-#: views/events/event_view.py:197 views/imprint/imprint_sbs_view.py:197
+#: views/events/event_view.py:201 views/imprint/imprint_sbs_view.py:197
 #: views/imprint/imprint_view.py:208
 #: views/organizations/organization_view.py:82 views/pages/page_sbs_view.py:193
 #: views/regions/region_view.py:85 views/settings/user_settings_view.py:89
@@ -5039,28 +5039,28 @@ msgstr ""
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
-#: views/events/event_view.py:232
+#: views/events/event_view.py:236
 msgid "Event was successfully created and published"
 msgstr "Veranstaltung wurde erfolgreich erstellt und veröffentlicht"
 
-#: views/events/event_view.py:235
+#: views/events/event_view.py:239
 msgid "Event was successfully created"
 msgstr "Veranstaltung wurde erfolgreich erstellt"
 
-#: views/events/event_view.py:241
+#: views/events/event_view.py:245
 msgid "Event translation was successfully created and published"
 msgstr ""
 "Veranstaltungsübersetzung wurde erfolgreich erstellt und veröffentlicht"
 
-#: views/events/event_view.py:245
+#: views/events/event_view.py:249
 msgid "Event translation was successfully created"
 msgstr "Veranstaltungsübersetzung wurde erfolgreich erstellt"
 
-#: views/events/event_view.py:249
+#: views/events/event_view.py:253
 msgid "Event was successfully published"
 msgstr "Veranstaltung wurde erfolgreich veröffentlicht"
 
-#: views/events/event_view.py:251
+#: views/events/event_view.py:255
 msgid "Event was successfully saved"
 msgstr "Veranstaltung wurde erfolgreich gespeichert"
 
@@ -5281,51 +5281,51 @@ msgstr "Organisation wurde erfolgreich erstellt"
 msgid "Organization was successfully saved"
 msgstr "Organisation wurde erfolgreich gespeichert"
 
-#: views/pages/page_actions.py:69
+#: views/pages/page_actions.py:67
 msgid "Page was successfully archived"
 msgstr "Seite wurde erfolgreich archiviert"
 
-#: views/pages/page_actions.py:122 views/pages/page_actions.py:136
+#: views/pages/page_actions.py:120 views/pages/page_actions.py:134
 msgid "Page was successfully restored."
 msgstr "Seite wurde erfolgreich wiederhergestellt."
 
-#: views/pages/page_actions.py:125
+#: views/pages/page_actions.py:123
 msgid ""
 "However, it is still archived because one of its parent pages is archived."
 msgstr ""
 "Sie ist jedoch immer noch archiviert, weil eine ihrer übergeordneten Seiten "
 "archiviert ist."
 
-#: views/pages/page_actions.py:223
+#: views/pages/page_actions.py:221
 msgid "Page was successfully deleted"
 msgstr "Seite wurde erfolgreich gelöscht"
 
-#: views/pages/page_actions.py:526
+#: views/pages/page_actions.py:524
 #, python-brace-format
 msgid "The page \"{page}\" was successfully moved."
 msgstr "Die Seite \"{page}\" wurde erfolgreich verschoben."
 
-#: views/pages/page_actions.py:614 views/pages/page_actions.py:629
+#: views/pages/page_actions.py:612 views/pages/page_actions.py:627
 #, python-brace-format
 msgid "Information: The user {user} has this permission already."
 msgstr "Information: Der Nutzer {user} hat diese Berechtigung bereits"
 
-#: views/pages/page_actions.py:621
+#: views/pages/page_actions.py:619
 #, python-brace-format
 msgid "Success: The user {user} can now edit this page."
 msgstr "Erfolg: Der Nutzer {user} kann nun diese Seite bearbeiten"
 
-#: views/pages/page_actions.py:637
+#: views/pages/page_actions.py:635
 #, python-brace-format
 msgid "Success: The user {user} can now publish this page."
 msgstr "Erfolg: Der Nutzer {user} kann dieses Seite nun veröffentlichen"
 
-#: views/pages/page_actions.py:646 views/pages/page_actions.py:761
+#: views/pages/page_actions.py:644 views/pages/page_actions.py:759
 msgid "An error has occurred. Please contact an administrator."
 msgstr ""
 "Ein Fehler ist aufgetreten. Bitte kontaktieren Sie einen Administrator."
 
-#: views/pages/page_actions.py:729
+#: views/pages/page_actions.py:727
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the editors of this page, "
@@ -5335,12 +5335,12 @@ msgstr ""
 "bearbeiten wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin bearbeiten."
 
-#: views/pages/page_actions.py:735
+#: views/pages/page_actions.py:733
 #, python-brace-format
 msgid "Success: The user {user} cannot edit this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr bearbeiten"
 
-#: views/pages/page_actions.py:746
+#: views/pages/page_actions.py:744
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the publishers of this "
@@ -5350,7 +5350,7 @@ msgstr ""
 "veröffentlichen wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen."
 
-#: views/pages/page_actions.py:752
+#: views/pages/page_actions.py:750
 #, python-brace-format
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"

--- a/src/cms/templates/events/event_form.html
+++ b/src/cms/templates/events/event_form.html
@@ -120,20 +120,33 @@
                         <span class="inline-block mb-2 font-bold">{% trans 'Status' %}:</span>
                         {{ event_translation_form.instance.get_status_display }}
                     {% endif %}
-                    <label for="{{ event_translation_form.title.id_for_label }}" class="block mb-2 mt-4 font-bold">{{ event_translation_form.title.label }}</label>
+                    <label for="{{ event_translation_form.title.id_for_label }}" 
+                        data-slugify-url="{% url 'slugify_ajax' region_slug=region.slug language_slug=language.slug model_type='event' %}{% if event_form.instance.id %}?model_id={{ event_form.instance.id }}{% endif %}"
+                        class="block mb-2 mt-4 font-bold">{{ event_translation_form.title.label }}</label>
                     {% render_field event_translation_form.title|add_error_class:"border-red-500" class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                    <label for="{{ event_translation_form.slug.id_for_label }}" class="block my-2 font-bold">{{ event_translation_form.slug.label }}</label>
-                    <div class="mb-2 text-s text-gray-600">{{ event_translation_form.slug.help_text }}</div>
-                    <div id="slug-div" class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400">
-                        {% spaceless %}
-                            <div style="display: table; white-space: nowrap;">
-                                <span style="display: table-cell;">https://integreat.app/{{ region.slug }}/{{ language.slug }}/events/</span>
-                                {% if event_translation_form.instance.ancestor_path %}
-                                    <span style="display: table-cell;">{{ event_translation_form.instance.ancestor_path }}/</span>
-                                {% endif %}
-                                <span style="display: table-cell; width: 100%;">{% render_field event_translation_form.slug|add_error_class:"slug-error" class="w-full rounded" %}</span>
-                            </div>
-                        {% endspaceless %}
+                    <div id="link-container" class="flex items-center mt-4">
+                        <label for="{{ event_translation_form.slug.id_for_label }}" class="block mr-2 font-bold">
+                            {{ event_translation_form.slug.label }}: 
+                        </label>
+                        <a href="{{ url_link }}{{ event_translation_form.instance.slug }}" class="mr-2 text-blue-500 hover:underline">{{ url_link }}{{ event_translation_form.instance.slug }}</a>
+                        <div class="flex mr-2 hidden flex-grow">
+                            {% spaceless %}
+                            <span>{{ url_link }}</span>
+                            {% render_field event_translation_form.slug|add_error_class:"slug-error" class="flex-grow appearance-none rounded bg-gray-200" %}
+                            {% endspaceless %}
+                        </div>
+                        <button id="edit-slug-btn" type="button" class="mr-2 text-gray-800 hover:text-blue-500">
+                            <i data-feather="edit-3"></i>
+                        </button>
+                        <button id="copy-slug-btn" type="button" class="text-gray-800 hover:text-blue-500">
+                            <i data-feather="copy"></i>
+                        </button>
+                        <button id="save-slug-btn" type="button" class="mr-2 text-gray-800 hover:text-blue-500 hidden">
+                            <i data-feather="save"></i>
+                        </button>
+                        <button id="restore-slug-btn" type="button" class="text-gray-800 hover:text-blue-500 hidden">
+                            <i data-feather="x-circle"></i>
+                        </button>
                     </div>
                     <label for="{{ event_translation_form.description.id_for_label }}" class="block mb-2 mt-4 font-bold">{{ event_translation_form.description.label }}</label>
                     {% render_field event_translation_form.description|add_error_class:"border-red-500" class="bg-gray-200 w-full p-2 border border-gray-200 focus:outline-none focus:bg-white focus:border-gray-400 rounded tinymce_textarea" %}

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -142,7 +142,7 @@
                 <div class="w-full p-4">
                     <div class="flex justify-between">
                         <label for="{{ page_translation_form.title.id_for_label }}"
-                            data-slugify-url="{% url 'slugify_ajax' region_slug=region.slug language_slug=language.slug %}{% if page_form.instance.id %}?page={{ page_form.instance.id }}{% endif %}"
+                            data-slugify-url="{% url 'slugify_ajax' region_slug=region.slug language_slug=language.slug model_type='page' %}{% if page_form.instance.id %}?model_id={{ page_form.instance.id }}{% endif %}"
                             class="mb-2 mt-4 font-bold">{{ page_translation_form.title.label }}
                         </label>
                         {% if page_translation_form.instance.id %}

--- a/src/cms/templates/pois/poi_form.html
+++ b/src/cms/templates/pois/poi_form.html
@@ -110,37 +110,36 @@
                         {{ poi_translation_form.instance.get_status_display }}
                     {% endif %}
                     <label for="{{ poi_translation_form.title.id_for_label }}" 
-                        data-slugify-url="{% url 'slugify_ajax' region_slug=region.slug language_slug=language.slug %}{% if poi_form.instance.id %}?page={{ poi_form.instance.id }}{% endif %}"
+                        data-slugify-url="{% url 'slugify_ajax' region_slug=region.slug language_slug=language.slug model_type='poi' %}{% if poi_form.instance.id %}?model_id={{ poi_form.instance.id }}{% endif %}"
                         class="block mb-2 mt-4 font-bold">{{ poi_translation_form.title.label }}
                     </label>
                     {% render_field poi_translation_form.title|add_error_class:"border-red-500" class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
-                    <label for="{{ poi_translation_form.slug.id_for_label }}" class="mr-2 font-bold"></label>
-                        <div id="link-container" class="flex items-center">
-                            <label for="{{ poi_translation_form.slug.id_for_label }}" class="block my-2 font-bold">
-                                {{ poi_translation_form.slug.label }}: 
-                            </label>
-                            {% spaceless %}
-                                <a href="https://integreat.app/{{ region.slug }}/{{ language.slug }}/" class="mr-2 text-blue-500 hover:underline">https://integreat.app/{{ region.slug }}/{{ language.slug }}/</a>
-                                <div class="flex mr-2 hidden flex-grow">
-                                    {% spaceless %}
-                                    <span>https://integreat.app/{{ region.slug }}/{{ language.slug }}/</span>
-                                    {% render_field poi_translation_form.slug|add_error_class:"slug-error" class="flex-grow appearance-none rounded bg-gray-200" %}
-                                    {% endspaceless %}
-                                </div>
-                                <button id="edit-slug-btn" type="button" class="mr-2 text-gray-800 hover:text-blue-500">
-                                    <i data-feather="edit-3"></i>
-                                </button>
-                                <button id="copy-slug-btn" type="button" class="text-gray-800 hover:text-blue-500">
-                                    <i data-feather="copy"></i>
-                                </button>
-                                <button id="save-slug-btn" type="button" class="mr-2 text-gray-800 hover:text-blue-500 hidden">
-                                    <i data-feather="save"></i>
-                                </button>
-                                <button id="restore-slug-btn" type="button" class="text-gray-800 hover:text-blue-500 hidden">
-                                    <i data-feather="x-circle"></i>
-                                </button>
+                    <div id="link-container" class="flex items-center mt-4">
+                        <label for="{{ poi_translation_form.slug.id_for_label }}" class="block mr-2 font-bold">
+                            {{ poi_translation_form.slug.label }}: 
+                        </label>
+                        {% spaceless %}
+                            <a href="https://integreat.app/{{ region.slug }}/{{ language.slug }}/{{ poi_translation_form.instance.slug }}" class="mr-2 text-blue-500 hover:underline">https://integreat.app/{{ region.slug }}/{{ language.slug }}/{{ poi_translation_form.instance.slug }}</a>
+                            <div class="flex mr-2 hidden flex-grow">
+                                {% spaceless %}
+                                <span>https://integreat.app/{{ region.slug }}/{{ language.slug }}/</span>
+                                {% render_field poi_translation_form.slug|add_error_class:"slug-error" class="flex-grow appearance-none rounded bg-gray-200" %}
+                                {% endspaceless %}
+                            </div>
+                            <button id="edit-slug-btn" type="button" class="mr-2 text-gray-800 hover:text-blue-500">
+                                <i data-feather="edit-3"></i>
+                            </button>
+                            <button id="copy-slug-btn" type="button" class="text-gray-800 hover:text-blue-500">
+                                <i data-feather="copy"></i>
+                            </button>
+                            <button id="save-slug-btn" type="button" class="mr-2 text-gray-800 hover:text-blue-500 hidden">
+                                <i data-feather="save"></i>
+                            </button>
+                            <button id="restore-slug-btn" type="button" class="text-gray-800 hover:text-blue-500 hidden">
+                                <i data-feather="x-circle"></i>
+                            </button>
                         {% endspaceless %}
-                        </div>
+                    </div>
                     <label for="{{ poi_translation_form.short_description.id_for_label }}" class="block mb-2 mt-4 font-bold">{{ poi_translation_form.short_description.label }}</label>
                     {% render_field poi_translation_form.short_description|add_error_class:"border-red-500" class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
                     <label for="{{ poi_translation_form.description.id_for_label }}" class="block mb-2 mt-4 font-bold">{{ poi_translation_form.description.label }}</label>

--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -30,6 +30,7 @@ from .views import (
     settings,
     statistics,
     users,
+    utils,
     feedback,
 )
 
@@ -423,8 +424,8 @@ urlpatterns = [
                 ),
                 url(r"^search_poi$", events.search_poi_ajax, name="search_poi_ajax"),
                 url(
-                    r"^(?P<region_slug>[-\w]+)/(?P<language_slug>[-\w]+)/slugify$",
-                    pages.slugify_ajax,
+                    r"^(?P<region_slug>[-\w]+)/(?P<language_slug>[-\w]+)/(?P<model_type>event|page|poi)/slugify$",
+                    utils.slugify_ajax,
                     name="slugify_ajax",
                 ),
             ]

--- a/src/cms/views/events/event_view.py
+++ b/src/cms/views/events/event_view.py
@@ -9,6 +9,8 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
 
+from backend.settings import WEBAPP_URL
+
 from ...constants import status
 from ...decorators import region_permission_required
 from ...forms import EventForm, EventTranslationForm, RecurrenceRuleForm
@@ -85,6 +87,7 @@ class EventView(PermissionRequiredMixin, TemplateView, EventContextMixin):
             instance=recurrence_rule_instance, disabled=disabled
         )
         context = self.get_context_data(**kwargs)
+        url_link = f"{WEBAPP_URL}/{region.slug}/{language.slug}/events/"
         return render(
             request,
             self.template_name,
@@ -97,6 +100,7 @@ class EventView(PermissionRequiredMixin, TemplateView, EventContextMixin):
                 "poi": poi_instance,
                 "language": language,
                 "languages": region.languages if event_instance else [language],
+                "url_link": url_link,
             },
         )
 
@@ -256,5 +260,5 @@ class EventView(PermissionRequiredMixin, TemplateView, EventContextMixin):
                 "event_id": event.id,
                 "region_slug": region.slug,
                 "language_slug": language.slug,
-            }
+            },
         )

--- a/src/cms/views/pages/__init__.py
+++ b/src/cms/views/pages/__init__.py
@@ -20,7 +20,6 @@ from .page_actions import (
     get_new_page_order_table_ajax,
     render_mirrored_page_field,
     post_translation_state_ajax,
-    slugify_ajax,
 )
 from .page_sbs_view import PageSideBySideView
 from .page_revision_view import PageRevisionView

--- a/src/cms/views/pages/page_actions.py
+++ b/src/cms/views/pages/page_actions.py
@@ -14,7 +14,6 @@ from django.contrib.auth.decorators import login_required, permission_required
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseNotFound, JsonResponse
 from django.shortcuts import render, redirect, get_object_or_404, get_list_or_404
-from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.views.static import serve
 from django.views.decorators.http import require_POST
@@ -26,7 +25,6 @@ from ...forms import PageForm
 from ...models import Page, Language, Region, PageTranslation
 from ...page_xliff_converter import PageXliffHelper, XLIFFS_DIR
 from ...utils.pdf_utils import generate_pdf
-from ...utils.slug_utils import generate_unique_slug
 
 logger = logging.getLogger(__name__)
 
@@ -893,40 +891,3 @@ def render_mirrored_page_field(request):
             "page_form": page_form,
         },
     )
-
-
-@login_required
-@region_permission_required
-@permission_required("cms.edit_pages", raise_exception=True)
-# pylint: disable=unused-argument
-def slugify_ajax(request, region_slug, language_slug):
-    """checks the current user input for page title and generates unique slug for permalink
-
-    :param request: The current request
-    :type request: ~django.http.HttpResponse
-    :param region_slug: region identifier
-    :type region_slug: str
-    :param language_slug: language slug
-    :type language_slug: str
-    :return: unique page translation slug
-    :rtype: str
-    """
-    json_data = json.loads(request.body)
-    form_title = slugify(json_data["title"], allow_unicode=True)
-    region = Region.get_current_region(request)
-    language = get_object_or_404(region.languages, slug=language_slug)
-    page = region.pages.filter(id=request.GET.get("page")).first()
-    page_translation = PageTranslation.objects.filter(
-        page=page,
-        language=language,
-    ).first()
-    kwargs = {
-        "slug": form_title,
-        "manager": PageTranslation.objects,
-        "object_instance": page_translation,
-        "foreign_model": "page",
-        "region": region,
-        "language": language,
-    }
-    unique_slug = generate_unique_slug(**kwargs)
-    return JsonResponse({"unique_slug": unique_slug})

--- a/src/cms/views/utils/__init__.py
+++ b/src/cms/views/utils/__init__.py
@@ -1,0 +1,1 @@
+from .slugify_ajax import slugify_ajax

--- a/src/cms/views/utils/slugify_ajax.py
+++ b/src/cms/views/utils/slugify_ajax.py
@@ -1,0 +1,65 @@
+import json
+
+from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from django.utils.text import slugify
+
+from ...decorators import region_permission_required
+from ...models import Region, PageTranslation, EventTranslation, POITranslation
+from ...utils.slug_utils import generate_unique_slug
+
+
+@login_required
+@region_permission_required
+# pylint: disable=unused-argument
+def slugify_ajax(request, region_slug, language_slug, model_type):
+    """checks the current user input for title and generates unique slug for permalink
+
+    :param request: The current request
+    :type request: ~django.http.HttpResponse
+    :param region_slug: region identifier
+    :type region_slug: str
+    :param language_slug: language slug
+    :type language_slug: str
+    :param model_type: The type of model to generate a unique slug for, one of `event|page|poi`
+    :type model_type: str
+    :return: unique translation slug
+    :rtype: str
+    :raises ~django.core.exceptions.PermissionDenied: If the user does not have the permission to access this function
+    """
+    required_permission = {
+        "event": "cms.edit_events",
+        "page": "cms.edit_pages",
+        "poi": "cms.manage_pois",
+    }[model_type]
+    if not request.user.has_perms((required_permission,)):
+        raise PermissionDenied
+
+    json_data = json.loads(request.body)
+    form_title = slugify(json_data["title"], allow_unicode=True)
+    region = Region.get_current_region(request)
+    language = get_object_or_404(region.languages, slug=language_slug)
+    model_id = request.GET.get("model_id")
+
+    managers = {
+        "event": EventTranslation,
+        "page": PageTranslation,
+        "poi": POITranslation,
+    }
+    manager = managers[model_type].objects
+    object_instance = manager.filter(
+        **{model_type: model_id, "language": language}
+    ).first()
+
+    kwargs = {
+        "slug": form_title,
+        "manager": manager,
+        "object_instance": object_instance,
+        "foreign_model": model_type,
+        "region": region,
+        "language": language,
+    }
+    unique_slug = generate_unique_slug(**kwargs)
+    return JsonResponse({"unique_slug": unique_slug})


### PR DESCRIPTION
### Short description
This pr makes the design of the slug input field of page form, event form and poi form more inline with each other.
Additionally, the methods `slugify_ajax` can now work for pois and events too, while it previously just worked for pages.


### Proposed changes
- Update the slug input field of events
- Make the design of the slug input field uniform across pages, events and pois
- Make the `slugify_ajax` function more generic in order to allow it to also function with events and pois

### Resolved issues
Fixes: #804 
