### PR TITLE
Add region setting for short urls

### DIFF
--- a/src/cms/forms/regions/region_form.py
+++ b/src/cms/forms/regions/region_form.py
@@ -56,6 +56,7 @@ class RegionForm(CustomModelForm):
             "icon",
             "administrative_division_included",
             "offers",
+            "short_urls_enabled",
         ]
         #: The widgets which are used in this form
         widgets = {

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-24 13:44+0000\n"
+"POT-Creation-Date: 2021-06-26 14:07+0000\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
 "Language: German\n"
@@ -1231,12 +1231,12 @@ msgstr "Einmalig stattfindende Veranstaltungen"
 msgid "Active"
 msgstr "Aktiv"
 
-#: constants/region_status.py:17 models/regions/region.py:379
+#: constants/region_status.py:17 models/regions/region.py:385
 msgid "Hidden"
 msgstr "Versteckt"
 
 #: constants/region_status.py:18 models/pages/page.py:202
-#: models/pages/page_translation.py:280 models/regions/region.py:382
+#: models/pages/page_translation.py:280 models/regions/region.py:388
 #: templates/pages/page_form.html:152
 #: templates/pages/page_tree_archived_node.html:13
 msgid "Archived"
@@ -1268,7 +1268,7 @@ msgstr "Rechts nach Links"
 #: templates/events/event_list_row.html:50
 #: templates/imprint/imprint_form.html:53
 #: templates/imprint/imprint_form.html:82 templates/imprint/imprint_sbs.html:46
-#: templates/imprint/imprint_sbs.html:101 templates/pages/page_form.html:75
+#: templates/imprint/imprint_sbs.html:96 templates/pages/page_form.html:75
 #: templates/pages/page_form.html:97 templates/pages/page_form.html:116
 #: templates/pages/page_sbs.html:53 templates/pages/page_sbs.html:112
 #: templates/pages/page_tree_archived_node.html:59
@@ -1283,7 +1283,7 @@ msgstr "Übersetzung ist aktuell"
 #: templates/events/event_list_row.html:42
 #: templates/imprint/imprint_form.html:49
 #: templates/imprint/imprint_form.html:78 templates/imprint/imprint_sbs.html:42
-#: templates/imprint/imprint_sbs.html:97 templates/pages/page_form.html:71
+#: templates/imprint/imprint_sbs.html:92 templates/pages/page_form.html:71
 #: templates/pages/page_form.html:112 templates/pages/page_sbs.html:49
 #: templates/pages/page_sbs.html:108
 #: templates/pages/page_tree_archived_node.html:51
@@ -1299,7 +1299,7 @@ msgstr "Wird derzeit übersetzt"
 #: templates/events/event_list_row.html:46
 #: templates/imprint/imprint_form.html:45
 #: templates/imprint/imprint_form.html:74 templates/imprint/imprint_sbs.html:38
-#: templates/imprint/imprint_sbs.html:93 templates/pages/page_form.html:67
+#: templates/imprint/imprint_sbs.html:88 templates/pages/page_form.html:67
 #: templates/pages/page_form.html:93 templates/pages/page_form.html:108
 #: templates/pages/page_sbs.html:45 templates/pages/page_sbs.html:104
 #: templates/pages/page_tree_archived_node.html:55
@@ -1463,8 +1463,8 @@ msgstr "Kategorie"
 #: templates/events/event_list_archived.html:38
 #: templates/imprint/imprint_form.html:105
 #: templates/imprint/imprint_revisions.html:45
-#: templates/imprint/imprint_sbs.html:58 templates/imprint/imprint_sbs.html:121
-#: templates/imprint/imprint_sbs.html:136
+#: templates/imprint/imprint_sbs.html:58 templates/imprint/imprint_sbs.html:116
+#: templates/imprint/imprint_sbs.html:131
 #: templates/linkcheck/links_by_filter.html:40
 #: templates/pages/page_form.html:150 templates/pages/page_revisions.html:49
 #: templates/pages/page_sbs.html:65 templates/pages/page_sbs.html:132
@@ -1510,13 +1510,13 @@ msgstr "Übersetzungsstatus"
 msgid "Do no import initial content"
 msgstr "Keine Inhalte übernehmen"
 
-#: forms/regions/region_form.py:129
+#: forms/regions/region_form.py:130
 msgid "Statistics can only be enabled when a valid access token is supplied."
 msgstr ""
 "Statistiken können nur aktiviert werden, wenn ein gültiges Zugangstoken "
 "eingegeben wurde."
 
-#: forms/regions/region_form.py:141
+#: forms/regions/region_form.py:142
 msgid "The provided access token is invalid."
 msgstr "Das eingegebene Zugangstoken ist ungültig."
 
@@ -1607,7 +1607,7 @@ msgstr "Chat-Nachrichten"
 #: models/languages/language_tree_node.py:37 models/pages/imprint_page.py:22
 #: models/pages/page.py:44 models/pois/poi.py:18
 #: models/push_notifications/push_notification.py:17
-#: models/regions/region.py:398
+#: models/regions/region.py:404
 msgid "region"
 msgstr "Region"
 
@@ -2558,7 +2558,15 @@ msgstr ""
 "Frontend Anfragen gesendet werden, um die Ergebnisse in der Integreat App "
 "einzubetten."
 
-#: models/regions/region.py:400 models/users/user_profile.py:30
+#: models/regions/region.py:186
+msgid "Activate short urls"
+msgstr "Kurz-URLs aktivieren"
+
+#: models/regions/region.py:187
+msgid "Please check the box if you want to use short urls."
+msgstr "Kreuzen Sie an, wenn Sie Kurz-URLs benutzen wollen."
+
+#: models/regions/region.py:406 models/users/user_profile.py:30
 msgid "regions"
 msgstr "Regionen"
 
@@ -3250,7 +3258,7 @@ msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
 #: templates/events/event_form.html:79 templates/imprint/imprint_form.html:63
-#: templates/imprint/imprint_sbs.html:106 templates/pages/page_form.html:85
+#: templates/imprint/imprint_sbs.html:101 templates/pages/page_form.html:85
 #: templates/pages/page_sbs.html:117 templates/pois/poi_form.html:68
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
@@ -3259,21 +3267,21 @@ msgstr "Übersetzung erstellen"
 #: templates/events/event_list_archived.html:37
 #: templates/imprint/imprint_form.html:102
 #: templates/imprint/imprint_revisions.html:20
-#: templates/imprint/imprint_sbs.html:56 templates/imprint/imprint_sbs.html:119
-#: templates/imprint/imprint_sbs.html:134 templates/pages/page_form.html:134
+#: templates/imprint/imprint_sbs.html:56 templates/imprint/imprint_sbs.html:114
+#: templates/imprint/imprint_sbs.html:129 templates/pages/page_form.html:134
 #: templates/pages/page_revisions.html:24 templates/pages/page_sbs.html:63
 #: templates/pages/page_sbs.html:130 templates/pages/page_sbs.html:135
 #: templates/pois/poi_form.html:107
 msgid "Version"
 msgstr "Version"
 
-#: templates/events/event_form.html:153 templates/imprint/imprint_form.html:122
-#: templates/imprint/imprint_sbs.html:147 templates/pages/page_form.html:226
+#: templates/events/event_form.html:153 templates/imprint/imprint_form.html:124
+#: templates/imprint/imprint_sbs.html:142 templates/pages/page_form.html:228
 #: templates/pages/page_sbs.html:157 templates/pois/poi_form.html:147
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
-#: templates/events/event_form.html:166 templates/imprint/imprint_form.html:167
+#: templates/events/event_form.html:166 templates/imprint/imprint_form.html:169
 #: templates/pois/poi_form.html:160
 msgid "Settings for all translations"
 msgstr "Einstellungen für alle Übersetzungen"
@@ -3536,7 +3544,7 @@ msgid "No feedback available yet."
 msgstr "Noch kein Feedback vorhanden."
 
 #: templates/generic_confirmation_dialog.html:11
-#: templates/pages/page_form.html:171
+#: templates/pages/page_form.html:173
 msgid "Warning"
 msgstr "Warnung"
 
@@ -3588,8 +3596,8 @@ msgstr "Versionen anzeigen"
 #: templates/imprint/imprint_form.html:107
 #: templates/imprint/imprint_revisions.html:63
 #: templates/imprint/imprint_revisions.html:77
-#: templates/imprint/imprint_sbs.html:60 templates/imprint/imprint_sbs.html:123
-#: templates/imprint/imprint_sbs.html:138
+#: templates/imprint/imprint_sbs.html:60 templates/imprint/imprint_sbs.html:118
+#: templates/imprint/imprint_sbs.html:133
 #: templates/pages/page_revisions.html:67
 #: templates/pages/page_revisions.html:81 templates/pages/page_sbs.html:67
 #: templates/pages/page_sbs.html:140
@@ -3597,79 +3605,79 @@ msgid "Permalink"
 msgstr "Permalink"
 
 #: templates/imprint/imprint_form.html:109
-#: templates/imprint/imprint_form.html:114
-#: templates/imprint/imprint_sbs.html:62 templates/imprint/imprint_sbs.html:67
-#: templates/imprint/imprint_sbs.html:125
-#: templates/imprint/imprint_sbs.html:130 templates/pages/page_form.html:165
+#: templates/imprint/imprint_form.html:115
+#: templates/imprint/imprint_sbs.html:62 templates/imprint/imprint_sbs.html:120
+#: templates/imprint/imprint_sbs.html:125 templates/pages/page_form.html:166
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
-#: templates/imprint/imprint_form.html:112
-#: templates/imprint/imprint_sbs.html:65 templates/imprint/imprint_sbs.html:128
-#: templates/imprint/imprint_sbs.html:140 templates/pages/page_form.html:163
+#: templates/imprint/imprint_form.html:113
+#: templates/imprint/imprint_sbs.html:123
+#: templates/imprint/imprint_sbs.html:135 templates/pages/page_form.html:164
+#: templates/regions/region_form.html:166
 msgid "Short URL"
 msgstr "Kurz-URL"
 
-#: templates/imprint/imprint_form.html:136
+#: templates/imprint/imprint_form.html:138
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: templates/imprint/imprint_form.html:143 templates/pages/page_form.html:396
+#: templates/imprint/imprint_form.html:145 templates/pages/page_form.html:398
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
-#: templates/imprint/imprint_form.html:157
+#: templates/imprint/imprint_form.html:159
 msgid "Show translations side by side"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
-#: templates/imprint/imprint_form.html:176
-#: templates/imprint/imprint_form.html:177
+#: templates/imprint/imprint_form.html:178
+#: templates/imprint/imprint_form.html:179
 msgid "Restore imprint"
 msgstr "Impressum wiederherstellen"
 
-#: templates/imprint/imprint_form.html:178
+#: templates/imprint/imprint_form.html:180
 msgid "Please confirm that you really want to restore the imprint"
 msgstr "Bitte bestätigen Sie, dass das Impressum wiederhergestellt werden soll"
 
-#: templates/imprint/imprint_form.html:179
+#: templates/imprint/imprint_form.html:181
 msgid "All translations of the imprint will also be restored."
 msgstr "Alle Übersetzungen des Impressums werden wiederhergestellt."
 
-#: templates/imprint/imprint_form.html:183
+#: templates/imprint/imprint_form.html:185
 msgid "Restore the imprint"
 msgstr "Das Impressum wiederherstellen"
 
-#: templates/imprint/imprint_form.html:186
-#: templates/imprint/imprint_form.html:187
+#: templates/imprint/imprint_form.html:188
+#: templates/imprint/imprint_form.html:189
 msgid "Archive imprint"
 msgstr "Impressum archivieren"
 
-#: templates/imprint/imprint_form.html:188
+#: templates/imprint/imprint_form.html:190
 msgid "Please confirm that you really want to archive the imprint"
 msgstr "Bitte bestätigen Sie, dass das Impressum archiviert werden soll."
 
-#: templates/imprint/imprint_form.html:189
+#: templates/imprint/imprint_form.html:191
 msgid "All translations of the imprint will also be archived."
 msgstr "Es werden auch alle Übersetzungen des Impressums archiviert."
 
-#: templates/imprint/imprint_form.html:193
+#: templates/imprint/imprint_form.html:195
 msgid "Archive the imprint"
 msgstr "Das Impressum archivieren"
 
-#: templates/imprint/imprint_form.html:199
-#: templates/imprint/imprint_form.html:200
+#: templates/imprint/imprint_form.html:201
+#: templates/imprint/imprint_form.html:202
 msgid "Delete imprint"
 msgstr "Impressum löschen"
 
-#: templates/imprint/imprint_form.html:201
+#: templates/imprint/imprint_form.html:203
 msgid "Please confirm that you really want to delete the imprint"
 msgstr "Bitte bestätigen Sie, dass das Impressum gelöscht werden soll"
 
-#: templates/imprint/imprint_form.html:202
+#: templates/imprint/imprint_form.html:204
 msgid "All translations of the imprint will also be deleted."
 msgstr "Alle Übersetzungen des Impressums werden gelöscht."
 
-#: templates/imprint/imprint_form.html:206
+#: templates/imprint/imprint_form.html:208
 msgid "Delete the imprint"
 msgstr "Das Impressum löschen"
 
@@ -3701,7 +3709,7 @@ msgstr "Diese Version wird <b>nicht</b> in den Apps angezeigt."
 
 #: templates/imprint/imprint_revisions.html:65
 #: templates/imprint/imprint_revisions.html:78
-#: templates/imprint/imprint_sbs.html:70 templates/pages/page_revisions.html:69
+#: templates/imprint/imprint_sbs.html:65 templates/pages/page_revisions.html:69
 #: templates/pages/page_revisions.html:82 templates/pages/page_sbs.html:81
 #: templates/pages/page_xliff_confirm.html:41
 #: templates/pages/page_xliff_confirm.html:48
@@ -3711,7 +3719,7 @@ msgstr "Titel"
 
 #: templates/imprint/imprint_revisions.html:67
 #: templates/imprint/imprint_revisions.html:79
-#: templates/imprint/imprint_sbs.html:73 templates/pages/page_revisions.html:71
+#: templates/imprint/imprint_sbs.html:68 templates/pages/page_revisions.html:71
 #: templates/pages/page_revisions.html:83 templates/pages/page_sbs.html:84
 #: templates/pages/page_xliff_confirm.html:50
 msgid "Content"
@@ -3734,23 +3742,23 @@ msgid ""
 msgstr ""
 "Übersetze das Impressum von %(source_language)s nach %(target_language_name)s"
 
-#: templates/imprint/imprint_sbs.html:77 templates/imprint/imprint_sbs.html:78
+#: templates/imprint/imprint_sbs.html:72 templates/imprint/imprint_sbs.html:73
 #: templates/pages/page_sbs.html:88 templates/pages/page_sbs.html:89
 msgid "Copy content"
 msgstr "Inhalt kopieren"
 
-#: templates/imprint/imprint_sbs.html:80 templates/pages/page_sbs.html:91
+#: templates/imprint/imprint_sbs.html:75 templates/pages/page_sbs.html:91
 #, python-format
 msgid "Copy content of %(source_language)s to %(target_language_name)s"
 msgstr "Inhalt von %(source_language)s nach %(target_language_name)s kopieren"
 
-#: templates/imprint/imprint_sbs.html:135 templates/pages/page_sbs.html:136
+#: templates/imprint/imprint_sbs.html:130 templates/pages/page_sbs.html:136
 msgid "New"
 msgstr "Neu"
 
-#: templates/imprint/imprint_sbs.html:137
-#: templates/imprint/imprint_sbs.html:139
-#: templates/imprint/imprint_sbs.html:141 templates/pages/page_sbs.html:138
+#: templates/imprint/imprint_sbs.html:132
+#: templates/imprint/imprint_sbs.html:134
+#: templates/imprint/imprint_sbs.html:136 templates/pages/page_sbs.html:138
 msgid "Not saved yet"
 msgstr "Noch nicht gespeichert"
 
@@ -4044,39 +4052,39 @@ msgstr "Aktualisieren"
 msgid "Archived, because a parent page is archived"
 msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 
-#: templates/pages/page_form.html:172
+#: templates/pages/page_form.html:174
 msgid "Translation in progress"
 msgstr "Übersetzung wird durchgeführt"
 
-#: templates/pages/page_form.html:180
+#: templates/pages/page_form.html:182
 msgid "Abort translation process"
 msgstr "Übersetzungsprozess abbrechen"
 
-#: templates/pages/page_form.html:220
+#: templates/pages/page_form.html:222
 msgid "Minor edit"
 msgstr "Geringfügige Änderung"
 
-#: templates/pages/page_form.html:236
+#: templates/pages/page_form.html:238
 msgid "Settings of the page"
 msgstr "Einstellungen der Seite"
 
-#: templates/pages/page_form.html:243
+#: templates/pages/page_form.html:245
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: templates/pages/page_form.html:253
+#: templates/pages/page_form.html:255
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: templates/pages/page_form.html:258
+#: templates/pages/page_form.html:260
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: templates/pages/page_form.html:277
+#: templates/pages/page_form.html:279
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: templates/pages/page_form.html:278
+#: templates/pages/page_form.html:280
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -4084,22 +4092,22 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: templates/pages/page_form.html:306 templates/regions/region_list.html:30
+#: templates/pages/page_form.html:308 templates/regions/region_list.html:30
 #: templates/settings/user.html:98
 msgid "Actions"
 msgstr "Aktionen"
 
-#: templates/pages/page_form.html:314 templates/pages/page_form.html:315
-#: templates/pages/page_form.html:323
+#: templates/pages/page_form.html:316 templates/pages/page_form.html:317
+#: templates/pages/page_form.html:325
 #: templates/pages/page_tree_archived_node.html:80
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: templates/pages/page_form.html:320
+#: templates/pages/page_form.html:322
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: templates/pages/page_form.html:326
+#: templates/pages/page_form.html:328
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -4110,28 +4118,28 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
-#: templates/pages/page_form.html:339 templates/pages/page_form.html:340
+#: templates/pages/page_form.html:341 templates/pages/page_form.html:342
 #: templates/pages/page_tree_node.html:120
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: templates/pages/page_form.html:346
+#: templates/pages/page_form.html:348
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: templates/pages/page_form.html:352 templates/pages/page_form.html:370
+#: templates/pages/page_form.html:354 templates/pages/page_form.html:372
 #: templates/pages/page_tree_archived_node.html:98
 #: templates/pages/page_tree_node.html:133
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: templates/pages/page_form.html:356
+#: templates/pages/page_form.html:358
 #: templates/pages/page_tree_archived_node.html:94
 #: templates/pages/page_tree_node.html:129 views/pages/page_actions.py:217
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: templates/pages/page_form.html:357
+#: templates/pages/page_form.html:359
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -4142,15 +4150,15 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: templates/pages/page_form.html:376
+#: templates/pages/page_form.html:378
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: templates/pages/page_form.html:389
+#: templates/pages/page_form.html:391
 msgid "Translator view"
 msgstr "Übersetzeransicht"
 
-#: templates/pages/page_form.html:410
+#: templates/pages/page_form.html:412
 msgid "Show translator view"
 msgstr "Übersetzeransicht anzeigen"
 
@@ -4280,11 +4288,11 @@ msgstr "Seite bearbeiten"
 msgid "This also involves archived subpages."
 msgstr "Dies betrifft auch archivierte Unterseiten."
 
-#: templates/pages/page_tree_node.html:143
+#: templates/pages/page_tree_node.html:144
 msgid "Copy short link"
 msgstr "Kurz-URL kopieren"
 
-#: templates/pages/page_tree_node.html:147
+#: templates/pages/page_tree_node.html:148
 msgid "You cannot copy a short link of a page which has no translation."
 msgstr "Sie können keine Kurz-URL zu einer fehlenden Übersetzung kopieren."
 
@@ -4454,38 +4462,38 @@ msgstr "Push-Benachrichtigungen"
 msgid "Page permissions"
 msgstr "Seiten-Berechtigungen"
 
-#: templates/regions/region_form.html:178
+#: templates/regions/region_form.html:184
 msgid "Duplicate content of another region"
 msgstr "Inhalte aus einer anderen Region duplizieren"
 
-#: templates/regions/region_form.html:181
+#: templates/regions/region_form.html:187
 msgid "Copy languages, pages and media from another region"
 msgstr "Sprachen, Seiten und Medien aus einer anderen Region kopieren"
 
-#: templates/regions/region_form.html:194
+#: templates/regions/region_form.html:200
 msgid "Delete region"
 msgstr "Region löschen"
 
-#: templates/regions/region_form.html:195
+#: templates/regions/region_form.html:201
 msgid "Please confirm that you really want to delete this region."
 msgstr "Bitte bestätigen Sie, dass diese Region gelöscht werden soll"
 
-#: templates/regions/region_form.html:196
+#: templates/regions/region_form.html:202
 msgid "This can not be reversed."
 msgstr "Dies kann nicht rückgängig gemacht werden."
 
-#: templates/regions/region_form.html:196
+#: templates/regions/region_form.html:202
 msgid "All pages, events and locations of this region will also be deleted."
 msgstr ""
 "Alle Seiten, Veranstaltungen und Orte dieser Region werden ebenfalls "
 "gelöscht."
 
-#: templates/regions/region_form.html:196
+#: templates/regions/region_form.html:202
 msgid "Users, who only have access to this region, will be removed as well."
 msgstr ""
 "Benutzer, die nur Zugriff auf diese Region besitzen, werden auch entfernt."
 
-#: templates/regions/region_form.html:200
+#: templates/regions/region_form.html:206
 msgid "Delete this region"
 msgstr "Diese Region löschen"
 

--- a/src/cms/models/regions/region.py
+++ b/src/cms/models/regions/region.py
@@ -181,6 +181,12 @@ class Region(models.Model):
         ),
     )
 
+    short_urls_enabled = models.BooleanField(
+        default=False,
+        verbose_name=_("Activate short urls"),
+        help_text=_("Please check the box if you want to use short urls."),
+    )
+
     @property
     def languages(self):
         """

--- a/src/cms/templates/imprint/imprint_form.html
+++ b/src/cms/templates/imprint/imprint_form.html
@@ -109,11 +109,13 @@
                         <a href="#" data-copy-to-clipboard="{{ WEBAPP_URL }}/{{ region.slug }}/{{ language.slug }}/{{ IMPRINT_SLUG }}" title="{% trans 'Copy to clipboard' %}" class="px-2 text-gray-800 hover:text-blue-500">
                             <i data-feather="copy"></i>
                         </a><br>
+                        {% if region.short_urls_enabled and request.user.profile.expert_mode %}
                         <span class="inline-block mb-2 font-bold">{% trans 'Short URL' %}:</span>
                         <a href="{{ imprint_translation_form.instance.short_url }}" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">{{ imprint_translation_form.instance.short_url }}</a>
                         <a href="#" data-copy-to-clipboard="{{ imprint_translation_form.instance.short_url }}" title="{% trans 'Copy to clipboard' %}" class="px-2 text-gray-800 hover:text-blue-500">
                             <i data-feather="copy"></i>
                         </a>
+                        {% endif %}
                     {% endif %}
                     <label for="{{ imprint_translation_form.title.id_for_label }}" class="block mb-2 mt-4 font-bold">{{ imprint_translation_form.title.label }}</label>
                     {% render_field imprint_translation_form.title class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}

--- a/src/cms/templates/imprint/imprint_sbs.html
+++ b/src/cms/templates/imprint/imprint_sbs.html
@@ -62,11 +62,6 @@
                 <a href="#" data-copy-to-clipboard="{{ WEBAPP_URL }}/{{ region.slug }}/{{ source_imprint_translation.language.slug }}/{{ IMPRINT_SLUG }}" title="{% trans 'Copy to clipboard' %}" class="px-2 text-gray-800 hover:text-blue-600">
                     <i data-feather="copy"></i>
                 </a><br>
-                <label class="inline-block mb-2 font-bold">{% trans 'Short URL' %}:</label>
-                <a href="{{ source_imprint_translation.short_url }}" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:underline">{{ source_imprint_translation.short_url }}</a>
-                <a href="#" data-copy-to-clipboard="{{ source_imprint_translation.short_url }}" title="{% trans 'Copy to clipboard' %}" class="px-2 text-gray-800 hover:text-blue-600">
-                    <i data-feather="copy"></i>
-                </a>
                 <label class="block mb-2 font-bold">{% trans 'Title' %}</label>
                 <input type="text" value="{{source_imprint_translation.title}}" class="appearance-none block w-full bg-gray-200 text-xl border border-gray-200 rounded py-3 px-4 leading-tight" disabled>
 	            <div class="mt-4">

--- a/src/cms/templates/pages/page_form.html
+++ b/src/cms/templates/pages/page_form.html
@@ -160,11 +160,13 @@
                     </div>
                     {% render_field page_translation_form.title class="appearance-none block w-full bg-gray-200 text-xl text-gray-800 border border-gray-200 rounded py-3 px-4 mb-2 leading-tight focus:outline-none focus:bg-white focus:border-gray-400" %}
                     {% if page_translation_form.instance.id %}
+                        {% if region.short_urls_enabled and request.user.profile.expert_mode %}
                         <span class="inline-block mb-2 font-bold">{% trans 'Short URL' %}:</span>
                         <a href="{{ page_translation_form.instance.short_url }}" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">{{ page_translation_form.instance.short_url }}</a>
                         <a href="#" data-copy-to-clipboard="{{ page_translation_form.instance.short_url }}" title="{% trans 'Copy to clipboard' %}" class="px-2 text-gray-800 hover:text-blue-500">
                             <i data-feather="copy"></i>
                         </a><br>
+                        {% endif %}
                         {% if page_translation_form.instance.currently_in_translation %}
                             <div id="trans-warn">
                                 <i data-feather="alert-triangle" class="text-red-800"></i>

--- a/src/cms/templates/pages/page_tree_node.html
+++ b/src/cms/templates/pages/page_tree_node.html
@@ -139,14 +139,16 @@
                 </button>
             {% endif %}
         {% endif %}
-        {% if page_translation %}
-        <a href="#" data-copy-to-clipboard="{{ page_translation.short_url }}" title="{% trans 'Copy short link' %}" class="py-3 px-2">
-            <i data-feather="copy" class="text-gray-800"></i>
-        </a>
-        {% else %}
-        <a title="{% trans 'You cannot copy a short link of a page which has no translation.' %}" class="py-3 px-2">
-            <i data-feather="copy" class="text-gray-400"></i>
-        </a>
+        {% if region.short_urls_enabled and request.user.profile.expert_mode %}
+            {% if page_translation %}
+            <a href="#" data-copy-to-clipboard="{{ page_translation.short_url }}" title="{% trans 'Copy short link' %}" class="py-3 px-2">
+                <i data-feather="copy" class="text-gray-800"></i>
+            </a>
+            {% else %}
+            <a title="{% trans 'You cannot copy a short link of a page which has no translation.' %}" class="py-3 px-2">
+                <i data-feather="copy" class="text-gray-400"></i>
+            </a>
+            {% endif %}
         {% endif %}
     </td>
 </tr>

--- a/src/cms/templates/regions/region_form.html
+++ b/src/cms/templates/regions/region_form.html
@@ -163,12 +163,18 @@
                     <div class="my-2 text-s text-gray-600">{{ form.page_permissions_enabled.help_text }}</div>
                 </div>
 
+                <span class="block p-2 mt-2 text-xl font-bold">{% trans 'Short URL' %}</span>
+                <div class="p-2 border-b solid border-gray-400">
+                    {% render_field form.short_urls_enabled %}
+                    <label for="{{ form.short_url.id_for_label }}" class="font-bold cursor-pointer p-2">{{ form.short_url.label }}</label>
+                    <div class="my-2 text-s text-gray-600">{{ form.short_url.help_text }}</div>
+                </div>
+
                 <div class="p-2">
                     <label for="{{ form.offers.id_for_offers }}" class="block font-bold py-2 text-xl">{{ form.offers.label }}</label>
                     {% render_field form.offers %}
                     <div class="my-2 text-s text-gray-600">{{ form.offers.help_text }}</div>
                 </div>
-
             </div>
             
         </div>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR contains changes for the issue "Add region setting for short urls".

### Proposed changes
<!-- Describe this PR in more detail. -->

-A new field "short_url" is added to the model and form of page.
-Short url is shown only when the expert mode is enabled for the user and the short url is activated for the region.
-the icon of short url copy is removed in the page list.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #685
