### PR TITLE
Change translation title length

### DIFF
--- a/src/cms/models/events/event_translation.py
+++ b/src/cms/models/events/event_translation.py
@@ -24,7 +24,7 @@ class EventTranslation(models.Model):
         verbose_name=_("event"),
     )
     slug = models.SlugField(
-        max_length=200,
+        max_length=1024,
         allow_unicode=True,
         verbose_name=_("URL parameter"),
         help_text=__(
@@ -40,7 +40,7 @@ class EventTranslation(models.Model):
         default=status.DRAFT,
         verbose_name=_("status"),
     )
-    title = models.CharField(max_length=250, verbose_name=_("title"))
+    title = models.CharField(max_length=1024, verbose_name=_("title"))
     description = models.TextField(blank=True, verbose_name=_("description"))
     language = models.ForeignKey(
         Language,

--- a/src/cms/models/pages/imprint_page_translation.py
+++ b/src/cms/models/pages/imprint_page_translation.py
@@ -32,7 +32,7 @@ class ImprintPageTranslation(AbstractBasePageTranslation):
         verbose_name=_("language"),
     )
     title = models.CharField(
-        max_length=250,
+        max_length=1024,
         verbose_name=_("title of the imprint"),
     )
     text = models.TextField(

--- a/src/cms/models/pages/page_translation.py
+++ b/src/cms/models/pages/page_translation.py
@@ -27,7 +27,7 @@ class PageTranslation(AbstractBasePageTranslation):
     """
 
     slug = models.SlugField(
-        max_length=200,
+        max_length=1024,
         allow_unicode=True,
         verbose_name=_("Page link"),
         help_text=__(
@@ -49,7 +49,7 @@ class PageTranslation(AbstractBasePageTranslation):
         verbose_name=_("language"),
     )
     title = models.CharField(
-        max_length=250,
+        max_length=1024,
         verbose_name=_("title of the page"),
     )
     text = models.TextField(

--- a/src/cms/models/pois/poi_translation.py
+++ b/src/cms/models/pois/poi_translation.py
@@ -17,9 +17,9 @@ class POITranslation(models.Model):
     Data model representing a POI translation
     """
 
-    title = models.CharField(max_length=250, verbose_name=_("title"))
+    title = models.CharField(max_length=1024, verbose_name=_("title"))
     slug = models.SlugField(
-        max_length=200,
+        max_length=1024,
         allow_unicode=True,
         verbose_name=_("URL parameter"),
         help_text=__(
@@ -42,7 +42,7 @@ class POITranslation(models.Model):
         verbose_name=_("status"),
     )
     short_description = models.CharField(
-        max_length=250, verbose_name=_("short description")
+        max_length=2048, verbose_name=_("short description")
     )
     description = models.TextField(blank=True, verbose_name=_("content"))
     language = models.ForeignKey(


### PR DESCRIPTION
As UTF-8 characters can take up to 4 bytes, a limit of 250 bytes is very limiting for some languages. Migrating existing titles requires about 1024 bytes in length.