### PR TITLE
Use preact router only for specific links

### DIFF
--- a/src/frontend/js/media-management/component/breadcrumbs.tsx
+++ b/src/frontend/js/media-management/component/breadcrumbs.tsx
@@ -26,6 +26,7 @@ export default function Breadcrumbs({ breadCrumbs, mediaTranslations }: Props) {
               <Link
                 href={`/${directory.id}/`}
                 className={"block hover:bg-blue-600 px-3 py-2 rounded break-all"}
+                media-library-link
               >
                 {directory.name}
               </Link>

--- a/src/frontend/js/media-management/component/directory-content.tsx
+++ b/src/frontend/js/media-management/component/directory-content.tsx
@@ -30,7 +30,7 @@ export default function DirectoryContent({
     <div className="grid grid-cols-gallery max-h-full gap-1">
       {directoryContent.map((entry: MediaLibraryEntry, index: number) =>
         entry.type === "directory" ? (
-          <Link href={`/${entry.id}/`}>
+          <Link href={`/${entry.id}/`} media-library-link>
             <DirectoryEntry
               directory={entry as Directory}
               mediaTranslations={mediaTranslations}

--- a/src/frontend/js/media-management/index.tsx
+++ b/src/frontend/js/media-management/index.tsx
@@ -93,6 +93,10 @@ document.addEventListener("DOMContentLoaded", () => {
       el
     );
   });
+  // mark all non-media-library-links as "native" so they are routed by the browser instead of preact
+  document.querySelectorAll("a:not([media-library-link])").forEach((link) => {
+    link.setAttribute("native", "");
+  });
 });
 
 (window as any).IntegreatMediaManagement = MediaManagement;


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Use preact router only for specific links

### Proposed changes
<!-- Describe this PR in more detail. -->
Instead of going opt-out on preact routing links by adding the attribute `native` to all non-preact-links, I made preact routing opt-in by adding the attribute `media-library-link`.
All links without the `media-library-link` attribute now get the `native` attribute by default.
This means that only directory links are opened in preact, and all other links work as expected.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #877
