### PR TITLE
Use fork of flagpack with support for `dart-sass`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "core-js": "^3.15.1",
         "element-closest": "^3.0.2",
         "feather-icons": "^4.28.0",
-        "flagpack": "^1.0.5",
+        "flagpack-dart-sass": "^1.1.0",
         "history": "^5.0.0",
         "preact": "^10.5.13",
         "preact-feather": "^4.2.1",
@@ -5810,10 +5810,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/flagpack": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/flagpack/-/flagpack-1.0.5.tgz",
-      "integrity": "sha512-jrb3OEoVXPBXjmhwZq6C9DTH6Axarh+rfnT3kA5T4xQ2FD9MogwCasqNJnMvhHHkaEVryXwQf1MQvqVv8UsK3g=="
+    "node_modules/flagpack-dart-sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/flagpack-dart-sass/-/flagpack-dart-sass-1.1.0.tgz",
+      "integrity": "sha512-skW7nihVZ94i2cYM8curBKbt4RxSXMxZa0ZTbHJZJF7dIcTzccvZGqxVwdF5tTEf669nCuElIAYwPF1KwdcvDQ=="
     },
     "node_modules/flatten": {
       "version": "1.0.3",
@@ -20490,10 +20490,10 @@
         }
       }
     },
-    "flagpack": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/flagpack/-/flagpack-1.0.5.tgz",
-      "integrity": "sha512-jrb3OEoVXPBXjmhwZq6C9DTH6Axarh+rfnT3kA5T4xQ2FD9MogwCasqNJnMvhHHkaEVryXwQf1MQvqVv8UsK3g=="
+    "flagpack-dart-sass": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/flagpack-dart-sass/-/flagpack-dart-sass-1.1.0.tgz",
+      "integrity": "sha512-skW7nihVZ94i2cYM8curBKbt4RxSXMxZa0ZTbHJZJF7dIcTzccvZGqxVwdF5tTEf669nCuElIAYwPF1KwdcvDQ=="
     },
     "flatten": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "core-js": "^3.15.1",
     "element-closest": "^3.0.2",
     "feather-icons": "^4.28.0",
-    "flagpack": "^1.0.5",
+    "flagpack-dart-sass": "^1.1.0",
     "history": "^5.0.0",
     "preact": "^10.5.13",
     "preact-feather": "^4.2.1",

--- a/src/frontend/css/style.scss
+++ b/src/frontend/css/style.scss
@@ -1,8 +1,8 @@
 // Country flags - define these before tailwind to make it possible to override
 $fp-prepend: true;
 $fp-enable-1x1: false;
-$fp-4x3-path: "flagpack/flags/4x3/";
-@import "flagpack/src/flagpack.scss";
+$fp-4x3-path: "flagpack-dart-sass/flags/4x3/";
+@import "flagpack-dart-sass/src/flagpack.scss";
 
 @import "tailwindcss/base";
 @import "tailwindcss/components";


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Since I got no reaction on my PR https://github.com/jackiboy/flagpack/pull/16, I published my own fork of flagpack:

https://github.com/timoludwig/flagpack-dart-sass
https://www.npmjs.com/package/flagpack-dart-sass

This should get rid of the warning in our webpack build:
```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
```

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use fork of flagpack with support for `dart-sass` instead of `node-sass`

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
