### PR TITLE
Fixes Attribute Error and change detection

### DIFF
--- a/src/cms/forms/custom_content_model_form.py
+++ b/src/cms/forms/custom_content_model_form.py
@@ -60,7 +60,7 @@ class CustomContentModelForm(CustomModelForm):
                 logger.debug("Image alt text replaced: %r", media_file.alt_text)
                 image.attrib["alt"] = media_file.alt_text
 
-        return tostring(content, with_tail=False, pretty_print=True).decode("utf-8")
+        return tostring(content, with_tail=False).decode("utf-8")
 
     def add_success_message(self, request):
         """

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-05 12:57+0000\n"
+"POT-Creation-Date: 2021-07-06 06:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -5257,7 +5257,7 @@ msgstr ""
 "veröffentlichen, aber Sie können Änderungen vornehmen und diese zur "
 "Überprüfung vorlegen."
 
-#: views/events/event_view.py:195
+#: views/events/event_view.py:196
 msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
-#: views/imprint/imprint_view.py:257 views/pages/page_view.py:314
+#: views/imprint/imprint_view.py:257 views/pages/page_view.py:315
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -5758,11 +5758,11 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
 "aber Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: views/pages/page_view.py:246
+#: views/pages/page_view.py:247
 msgid "Page \"{}\" was successfully created"
 msgstr "Seite \"{}\" wurde erfolgreich erstellt"
 
-#: views/pages/page_view.py:260
+#: views/pages/page_view.py:261
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
 
@@ -5816,7 +5816,7 @@ msgstr "Sie können Orte nur in der Standard-Sprache (%(language)s) anlegen"
 msgid "You cannot edit this location because it is archived."
 msgstr "Sie können diesen Ort nicht bearbeiten, da er archiviert ist."
 
-#: views/pois/poi_view.py:159
+#: views/pois/poi_view.py:160
 msgid "Location \"{}\" was successfully created"
 msgstr "Ort \"{}\" wurde erfolgreich erstellt"
 

--- a/src/cms/utils/slug_utils.py
+++ b/src/cms/utils/slug_utils.py
@@ -41,8 +41,8 @@ def generate_unique_slug_helper(form_object, foreign_model):
     if foreign_model in ["page", "event", "poi"]:
         kwargs.update(
             {
-                "region": form_object.region,
-                "language": form_object.language,
+                "region": form_object.instance.foreign_object.region,
+                "language": form_object.instance.language,
                 "fallback": "title",
             }
         )

--- a/src/cms/views/events/event_view.py
+++ b/src/cms/views/events/event_view.py
@@ -157,6 +157,7 @@ class EventView(TemplateView, EventContextMixin, MediaContextMixin):
             additional_instance_attributes={
                 "creator": request.user,
                 "language": language,
+                "event": event_form.instance,
             },
         )
 

--- a/src/cms/views/pages/page_view.py
+++ b/src/cms/views/pages/page_view.py
@@ -220,6 +220,7 @@ class PageView(TemplateView, PageContextMixin, MediaContextMixin):
             additional_instance_attributes={
                 "creator": request.user,
                 "language": language,
+                "page": page_form.instance,
             },
         )
 

--- a/src/cms/views/pois/poi_view.py
+++ b/src/cms/views/pois/poi_view.py
@@ -141,6 +141,7 @@ class POIView(TemplateView, POIContextMixin, MediaContextMixin):
             additional_instance_attributes={
                 "creator": request.user,
                 "language": language,
+                "poi": poi_form.instance,
             },
         )
 

--- a/src/frontend/js/forms/tinymce-init.ts
+++ b/src/frontend/js/forms/tinymce-init.ts
@@ -154,6 +154,7 @@ window.addEventListener("load", () => {
       content_style: tinymceConfig.getAttribute("data-content-style"),
       language: tinymceConfig.getAttribute("data-language"),
       directionality: tinymceConfig.getAttribute("data-directionality") as 'ltr' | 'rtl',
+      element_format: 'html',
       setup: (editor: Editor) => {
         addIcon(editor, tinymceConfig, "pin");
         addIcon(editor, tinymceConfig, "www");


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes Attribute Error at event translation form and change detection at page translation form

### Proposed changes
<!-- Describe this PR in more detail. -->

cfcb7a6:
Initializes forms with `additional_instance_attributes` , necessary to generating unique slugs for distinct region/language
The forms instance (and its related object, e.g. PageTranslation - Page) is not used for calling the region object, because the instance might not exist yet.

9a0c192:
- Converts tiny mce content to html (default is xhtml), necessary because [content_clean_method](https://github.com/Integreat/integreat-cms/blob/82eec7f98bdc62c0d14406ed189211911cc0c862/src/cms/forms/custom_content_model_form.py#L63) outputs html format, which causes change detection (`<br>` compared to `<br />`)
- Removes pretty print, because options appends additional line breaks to html tag, which causes detected changes too.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #882 
Fixes: #883
