### PR TITLE
Add internal link suggestions for tinymce editor

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -2276,7 +2276,7 @@ msgstr ""
 msgid "thumbnail URL"
 msgstr "Vorschaubild-URL"
 
-#: models/offers/offer_template.py:30
+#: models/offers/offer_template.py:30 templates/_tinymce_config.html:43
 #: templates/linkcheck/links_by_filter.html:39
 #: templates/offer_templates/offer_template_list.html:22
 #: views/media/media_context_mixin.py:56
@@ -2905,7 +2905,7 @@ msgid "Contents"
 msgstr "Inhalte"
 
 #: templates/_base.html:133 templates/_base.html:275
-#: templates/_tinymce_config.html:35 views/media/media_context_mixin.py:31
+#: templates/_tinymce_config.html:49 views/media/media_context_mixin.py:31
 msgid "Media Library"
 msgstr "Medienbibliothek"
 
@@ -3017,40 +3017,81 @@ msgstr "Angebots-Vorlagen"
 msgid "Integreat Editorial System"
 msgstr "Integreat Redaktionssystem"
 
-#: templates/_tinymce_config.html:18
+#: templates/_tinymce_config.html:20
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: templates/_tinymce_config.html:19
+#: templates/_tinymce_config.html:21
 msgid "Do not translate"
 msgstr "Nicht übersetzen"
 
-#: templates/_tinymce_config.html:20
+#: templates/_tinymce_config.html:22
 #: templates/events/_event_filter_form.html:34
 msgid "Location"
 msgstr "Ort"
 
-#: templates/_tinymce_config.html:22
+#: templates/_tinymce_config.html:24
 msgid "Link"
 msgstr "Link"
 
-#: templates/_tinymce_config.html:24
+#: templates/_tinymce_config.html:26
 msgid "Email"
 msgstr "Email"
 
-#: templates/_tinymce_config.html:26
+#: templates/_tinymce_config.html:28
 msgid "Phone"
 msgstr "Telefon"
 
-#: templates/_tinymce_config.html:28
+#: templates/_tinymce_config.html:30
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: templates/_tinymce_config.html:30
+#: templates/_tinymce_config.html:32
 msgid "Hint"
 msgstr "Tipp"
 
+#: templates/_tinymce_config.html:34 templates/pages/page_form.html:45
+msgid "Update"
+msgstr "Aktualisieren"
+
+#: templates/_tinymce_config.html:35 views/media/media_context_mixin.py:52
+msgid "Submit"
+msgstr "Speichern"
+
 #: templates/_tinymce_config.html:36
+#: templates/generic_confirmation_dialog.html:22
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: templates/_tinymce_config.html:37
+msgid "- no results -"
+msgstr "- keine Ergebnisse -"
+
+#: templates/_tinymce_config.html:39
+msgid "Link..."
+msgstr "Link..."
+
+#: templates/_tinymce_config.html:40
+msgid "Remove link"
+msgstr "Link entfernen"
+
+#: templates/_tinymce_config.html:41
+msgid "Open link"
+msgstr "Link öffnen"
+
+#: templates/_tinymce_config.html:42
+msgid "Add Link"
+msgstr "Link hinzufügen"
+
+#: templates/_tinymce_config.html:44
+msgid "Text to display"
+msgstr "Anzuzeigender Text"
+
+#: templates/_tinymce_config.html:45
+msgid "Or link to existing content"
+msgstr "Oder auf bestehende Inhalte verlinken"
+
+#: templates/_tinymce_config.html:50
 msgid "Media Library..."
 msgstr "Medienbibliothek..."
 
@@ -3729,10 +3770,6 @@ msgstr "Warnung"
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: templates/generic_confirmation_dialog.html:22
-msgid "Cancel"
-msgstr "Abbrechen"
-
 #: templates/icon_widget.html:15
 #, python-format
 msgid "Set %(label)s"
@@ -4213,10 +4250,6 @@ msgstr "Neue Übersetzung erstellen"
 #: templates/pages/page_form.html:32
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
-
-#: templates/pages/page_form.html:45
-msgid "Update"
-msgstr "Aktualisieren"
 
 #: templates/pages/page_form.html:152
 #: templates/pages/page_tree_archived_node.html:17
@@ -5532,10 +5565,6 @@ msgstr "Zurück"
 msgid "Close detail view"
 msgstr "Detailansicht schließen"
 
-#: views/media/media_context_mixin.py:52
-msgid "Submit"
-msgstr "Absenden"
-
 #: views/media/media_context_mixin.py:53
 msgid "Select"
 msgstr "Auswählen"
@@ -6016,6 +6045,13 @@ msgstr ""
 #~ msgstr ""
 #~ "Es ist ein Fehler aufgetreten! Aktivierungslink konnte nicht per Mail "
 #~ "gesendet werden."
+
+#~ msgid ""
+#~ "The URL you entered seems to be an external link. Do you want to add the "
+#~ "required https:// prefix?"
+#~ msgstr ""
+#~ "Die eingegebene URL scheint auf eine externe Seite zu verweisen. Soll das "
+#~ "notwendige Präfix https:// hinzugefügt werden?"
 
 #~ msgid ""
 #~ "You don't have the permission to edit this page, but you can propose "
@@ -6540,9 +6576,6 @@ msgstr ""
 
 #~ msgid "Change icon"
 #~ msgstr "Icon ändern"
-
-#~ msgid "Remove icon"
-#~ msgstr "Icon entfernen"
 
 #~ msgid "Restore icon"
 #~ msgstr "Icon wiederherstellen"

--- a/src/cms/models/events/event_translation.py
+++ b/src/cms/models/events/event_translation.py
@@ -310,6 +310,6 @@ class EventTranslation(models.Model):
         #: The plural verbose name of the model
         verbose_name_plural = _("event translations")
         #: The fields which are used to sort the returned objects of a QuerySet
-        ordering = ["event", "-version"]
+        ordering = ["event__pk", "-version"]
         #: The default permissions for this model
         default_permissions = ()

--- a/src/cms/models/pages/page_translation.py
+++ b/src/cms/models/pages/page_translation.py
@@ -318,6 +318,6 @@ class PageTranslation(AbstractBasePageTranslation):
         #: The plural verbose name of the model
         verbose_name_plural = _("page translations")
         #: The fields which are used to sort the returned objects of a QuerySet
-        ordering = ["page", "-version"]
+        ordering = ["page__pk", "-version"]
         #: The default permissions for this model
         default_permissions = ()

--- a/src/cms/models/pois/poi_translation.py
+++ b/src/cms/models/pois/poi_translation.py
@@ -311,6 +311,6 @@ class POITranslation(models.Model):
         #: The plural verbose name of the model
         verbose_name_plural = _("location translations")
         #: The fields which are used to sort the returned objects of a QuerySet
-        ordering = ["poi", "-version"]
+        ordering = ["poi__pk", "-version"]
         #: The default permissions for this model
         default_permissions = ()

--- a/src/cms/templates/_tinymce_config.html
+++ b/src/cms/templates/_tinymce_config.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 {% load static %}
+{% load settings_tags %}
 
 {% get_current_language as LANGUAGE_CODE %}
 
@@ -13,24 +14,37 @@
 
 <div
         id="tinymce-config-options"
+        data-webapp-url="{% get_webapp_url %}"
         data-language="{{ LANGUAGE_CODE|slice:'0:2' }}"
         data-directionality="{% if right_to_left %}rtl{% else %}ltr{% endif %}"
         data-no-translate-tooltip="{% trans 'Do not translate the selected text.' %}"
         data-no-translate-text="{% trans 'Do not translate' %}"
         data-pin-icon-text="{% trans 'Location' %}"
-        data-pin-icon-src="{% static 'svg/pin.svg' %}"
+        data-pin-icon-src="{% get_base_url %}{% static 'svg/pin.svg' %}"
         data-www-icon-text="{% trans 'Link' %}"
-        data-www-icon-src="{% static 'svg/www.svg' %}"
+        data-www-icon-src="{% get_base_url %}{% static 'svg/www.svg' %}"
         data-email-icon-text="{% trans 'Email' %}"
-        data-email-icon-src="{% static 'svg/email.svg' %}"
+        data-email-icon-src="{% get_base_url %}{% static 'svg/email.svg' %}"
         data-call-icon-text="{% trans 'Phone' %}"
-        data-call-icon-src="{% static 'svg/call.svg' %}"
+        data-call-icon-src="{% get_base_url %}{% static 'svg/call.svg' %}"
         data-clock-icon-text="{% trans 'Opening Hours' %}"
-        data-clock-icon-src="{% static 'svg/clock.svg' %}"
+        data-clock-icon-src="{% get_base_url %}{% static 'svg/clock.svg' %}"
         data-idea-icon-text="{% trans 'Hint' %}"
-        data-idea-icon-src="{% static 'svg/idea.svg' %}"
-        data-custom-plugins="{% static 'editor_content.js' %}"
-        data-content-css="{% static 'editor_content.css' %}"
+        data-idea-icon-src="{% get_base_url %}{% static 'svg/idea.svg' %}"
+        data-update-text="{% trans 'Update' %}"
+        data-dialog-submit-text="{% trans 'Submit' %}"
+        data-dialog-cancel-text="{% trans 'Cancel' %}"
+        data-link-no-results-text="{% trans '- no results -' %}"
+        data-link-ajax-url="{% url 'search_content_ajax' region_slug=region.slug language_slug=language.slug %}"
+        data-link-menu-text="{% trans 'Link...' %}"
+        data-link-remove-text="{% trans 'Remove link' %}"
+        data-link-open-text="{% trans 'Open link' %}"
+        data-link-dialog-title-text="{% trans 'Add Link' %}"
+        data-link-dialog-url-text="{% trans 'URL' %}"
+        data-link-dialog-text-text="{% trans 'Text to display' %}"
+        data-link-dialog-internal_link-text="{% trans 'Or link to existing content' %}"
+        data-custom-plugins="{% get_base_url %}{% static 'editor_content.js' %}"
+        data-content-css="{% get_base_url %}{% static 'editor_content.css' %}"
         data-content-style="{{ content_style }}"
         data-media-button-translation="{% trans 'Media Library' %}"
         data-media-item-translation="{% trans 'Media Library...' %}"

--- a/src/cms/templatetags/settings_tags.py
+++ b/src/cms/templatetags/settings_tags.py
@@ -1,0 +1,31 @@
+"""
+This contains tags for accessing settings
+"""
+from django import template
+
+from backend.settings import BASE_URL, WEBAPP_URL
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_webapp_url():
+    """
+    This tag returns the ``WEBAPP_URL``
+
+    :return: The url of the current web application
+    :rtype: str
+    """
+    return WEBAPP_URL
+
+
+@register.simple_tag
+def get_base_url():
+    """
+    This tag returns the ``BASE_URL``
+
+    :return: The base url of the current web application
+    :rtype: str
+    """
+    return BASE_URL

--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -475,6 +475,11 @@ urlpatterns = [
                 ),
                 url(r"^search_poi$", events.search_poi_ajax, name="search_poi_ajax"),
                 url(
+                    r"^(?P<region_slug>[-\w]+)/(?P<language_slug>[-\w]+)/search_content$",
+                    utils.search_content_ajax,
+                    name="search_content_ajax",
+                ),
+                url(
                     r"^(?P<region_slug>[-\w]+)/(?P<language_slug>[-\w]+)/(?P<model_type>event|page|poi)/slugify$",
                     utils.slugify_ajax,
                     name="slugify_ajax",

--- a/src/cms/views/utils/__init__.py
+++ b/src/cms/views/utils/__init__.py
@@ -1,1 +1,2 @@
 from .slugify_ajax import slugify_ajax
+from .search_content_ajax import search_content_ajax

--- a/src/cms/views/utils/search_content_ajax.py
+++ b/src/cms/views/utils/search_content_ajax.py
@@ -1,0 +1,126 @@
+import logging
+import json
+
+from django.contrib.auth.decorators import login_required
+from django.db.models import Q
+from django.http import JsonResponse
+from django.views.decorators.http import require_POST
+
+from backend.settings import WEBAPP_URL
+from ...constants import status
+from ...decorators import region_permission_required
+from ...models import Region, EventTranslation, PageTranslation, POITranslation
+
+logger = logging.getLogger(__name__)
+
+# The maximum number of results returned by `search_content_ajax`
+MAX_RESULT_COUNT = 20
+
+
+def format_object_translation(object_translation, typ):
+    """
+    Formats the [poi/event/page]-translation as json
+
+    :param object_translation: A translation object which has a title and a permalink
+    :type object_translation: ~cms.models.events.event.Event or ~cms.models.pages.page.Page or ~cms.models.pois.poi.POI
+    :param typ: The type of this object
+    :type typ: str
+    :return: A dictionary with the title, url and type of the translation object
+    :rtype: dict
+    """
+    return {
+        "title": object_translation.title,
+        "url": f"{WEBAPP_URL}/{object_translation.permalink}",
+        "type": typ,
+    }
+
+
+def find_objects(manager, obj_type, region, language_slug, query, hierarchical=False):
+    """
+    Filters all object translations from ``manager`` of this language that match the ``query``
+
+    :param manager: The manager for a specific model
+    :type manager: ~django.db.models.Manager
+    :param obj_type: The content type of the queried translations
+    :type obj_type: str
+    :param region: The current region
+    :type region: ~cms.models.regions.region.Region
+    :param language_slug: The language slug
+    :type language_slug: str
+    :param query: The query string used for filtering the objects
+    :type query: str
+    :param hierarchical: Whether or not the given model is hiearchical (which impacts the method for filtering out
+                         archived results)
+    :type hierarchical: bool
+    :return: A list of translation objects (formatted as dict)
+    :rtype: list [ dict ]
+    """
+    archived_flag = "explicitly_archived" if hierarchical else "archived"
+    result = (
+        manager.objects.filter(
+            **{
+                obj_type + "__region": region,
+                obj_type + "__" + archived_flag: False,
+                "language__slug": language_slug,
+                "status": status.PUBLIC,
+            }
+        )
+        .filter(Q(slug__icontains=query) | Q(title__icontains=query))
+        .distinct(obj_type)
+    )
+    # If the object type is hierarchical, filter out implicitly archived objects (objects with archived ancestors)
+    if hierarchical:
+        result = filter(lambda x: not getattr(x, obj_type).implicitly_archived, result)
+    return [format_object_translation(obj, obj_type) for obj in result]
+
+
+@require_POST
+@login_required
+@region_permission_required
+# pylint: disable=unused-argument
+def search_content_ajax(request, region_slug, language_slug):
+    """Searches all pois, events and pages for the current region and returns all that
+    match the search query. Results which match the query in the title or slug get ranked
+    higher than results which only match through their text content.
+
+    :param request: The current request
+    :type request: ~django.http.HttpResponse
+    :param region_slug: region identifier
+    :type region_slug: str
+    :param language_slug: language slug
+    :type language_slug: str
+    :return: Json object containing all matching elements, of shape {title: str, url: str, type: str}
+    :rtype: ~django.http.JsonResponse
+    """
+
+    region = Region.get_current_region(request)
+    query = json.loads(request.body.decode("utf-8"))["query_string"]
+
+    logger.debug(
+        "Ajax call: Live search for pois, events and pages with query %r", query
+    )
+
+    results = []
+
+    user = request.user
+    if user.has_perm("cms.view_event"):
+        results.extend(
+            find_objects(EventTranslation, "event", region, language_slug, query)
+        )
+
+    if user.has_perm("cms.view_page"):
+        results.extend(
+            find_objects(
+                PageTranslation, "page", region, language_slug, query, hierarchical=True
+            )
+        )
+
+    if user.has_perm("cms.view_poi"):
+        results.extend(
+            find_objects(POITranslation, "poi", region, language_slug, query)
+        )
+
+    # sort alphabetically by title
+    results.sort(key=lambda k: k["title"])
+
+    return JsonResponse({"data": results[:MAX_RESULT_COUNT]})

--- a/src/frontend/editor_content.ts
+++ b/src/frontend/editor_content.ts
@@ -5,6 +5,7 @@
 
 /* Custom tincymce plugins */
 import './js/tinymce-plugins/autolink_tel/plugin.js';
+import './js/tinymce-plugins/custom_link_input/plugin.js';
 import './js/tinymce-plugins/mediacenter/plugin.js';
 
 /* Custom tinymce content css */

--- a/src/frontend/js/forms/tinymce-init.ts
+++ b/src/frontend/js/forms/tinymce-init.ts
@@ -86,22 +86,24 @@ window.addEventListener("load", () => {
         },
         insert: {
           title: "Insert",
-          items: "openmediacenter link image media "
+          items: "openmediacenter add_link image media "
         }
       },
       link_title: false,
-      contextmenu: "paste link",
+      contextmenu: "paste add_link",
       autosave_interval: "120s",
       forced_root_block: false,
       plugins:
-        "code paste fullscreen autosave link preview media image lists directionality wordcount",
+        "code paste fullscreen autosave preview media image lists directionality wordcount",
       external_plugins: {
         autolink_tel: tinymceConfig.getAttribute("data-custom-plugins"),
         mediacenter: tinymceConfig.getAttribute("data-custom-plugins"),
+        custom_link_input: tinymceConfig.getAttribute("data-custom-plugins"),
       },
       link_default_protocol: "https",
       target_list: false,
       default_link_target: '',
+      document_base_url: tinymceConfig.getAttribute("data-webapp-url"),
       relative_urls: false,
       remove_script_host: false,
       branding: false,

--- a/src/frontend/js/tinymce-plugins/custom_link_input/plugin.js
+++ b/src/frontend/js/tinymce-plugins/custom_link_input/plugin.js
@@ -1,0 +1,320 @@
+import { getCsrfToken } from "../../utils/csrf-token";
+
+(function () {
+    'use strict'
+
+    const tinymceConfig = document.getElementById("tinymce-config-options");
+
+    async function getCompletions(query, id) {
+        const url = tinymceConfig.getAttribute("data-link-ajax-url");
+        const response = await fetch(url, {
+            method: "POST",
+            headers: {
+                "X-CSRFToken": getCsrfToken(),
+            },
+            body: JSON.stringify({
+                query_string: query
+            })
+        });
+        if (response.status != 200) {
+            return [];
+        }
+
+        const data = await response.json();
+        return [data.data, id];
+    }
+
+    // Checks if the url is likely missing the https:// prefix and add it if that is the case
+    function checkUrlHttps(url) {
+        // This regex matches domains without protocol (strings which contain a dot without a preceding colon or slash)
+        const re = new RegExp("^[^:/]+[.].+");
+        if (re.test(url)) {
+            return "https://" + url;
+        }
+        return url;
+    }
+
+    function updateLink(editor, anchorElm, text, linkAttrs) {
+        anchorElm.textContent = text;
+
+        editor.dom.setAttribs(anchorElm, linkAttrs);
+        editor.selection.select(anchorElm);
+    };
+
+
+    tinymce.PluginManager.add('custom_link_input', function (editor, _url) {
+        function isAnchor(node) {
+            return node.nodeName.toLowerCase() === 'a' && node.href;
+        }
+        function getAnchor() {
+            var node = editor.selection.getNode();
+            return isAnchor(node) ? node : null;
+        };
+
+        const openDialog = function () {
+            const initial_text = getAnchor() ? getAnchor().innerText : editor.selection.getContent({ format: "text" });
+            const initial_url = editor.selection.getStart().getAttribute("href") || "";
+
+            let prev_search_text = "";
+            let prev_link_url = initial_url;
+            let prev_selected_completion = "";
+
+            // Store the custom user data separately, so that they can be restored when required
+            let user_data = { url: "", text: "" };
+
+            // Stores the current request id, so that outdated requests get ignored
+            let ajax_request_id = 0;
+            const default_completion_item = { text: tinymceConfig.getAttribute("data-link-no-results-text"), value: "" };
+            let completion_items = [default_completion_item];
+            let current_completion_text = "";
+
+            function updateDialog(api) {
+                let data = api.getData();
+
+                let url_changed_by_search = false;
+                // Check if the selected completion changed
+                if (prev_selected_completion != data.completions) {
+                    // find the correct thext currently shown in the completion items box
+                    if (completion_items.length > 0) {
+                        const current_completion = completion_items.find((completion) => completion.value == data.completions);
+                        // Don't set the completion text to `- no results -`
+                        if (current_completion.value != "") {
+                            current_completion_text = current_completion.text;
+                        } else {
+                            current_completion_text = "";
+                        }
+                    } else {
+                        current_completion_text = "";
+                    }
+
+                    // Set the url either to the selected internal link or to the user link
+                    if (data.completions != "") {
+                        url_changed_by_search = true;
+                        api.setData({ url: data.completions });
+                        // if the text is not defined by the user, set it to the current completion item
+                        if (!data.text || user_data.text != data.text) {
+                            api.setData({ text: current_completion_text });
+                        }
+                    } else {
+                        // restore the original user data
+                        api.setData({ url: user_data.url, text: user_data.text });
+                    }
+                }
+                prev_selected_completion = data.completions;
+
+                // Automatically update the text input to the url by default
+                data = api.getData();
+                if (!url_changed_by_search && data.url != data.text && prev_link_url != data.url && (data.text != user_data.text || !data.text)) {
+                    api.setData({ text: data.url });
+                }
+                prev_link_url = data.url;
+
+                // Update the user link
+                if (data.url != data.completions) {
+                    user_data.url = data.url;
+                }
+                if (data.text != data.url && data.text != current_completion_text) {
+                    user_data.text = data.text;
+                }
+
+                // Disable the submit button if either of url and text are empty
+                data = api.getData();
+                if (data.url.trim() && data.text.trim()) {
+                    api.enable("submit");
+                } else {
+                    api.disable("submit");
+                }
+
+                // make new ajax request on user input
+                if (data.search != prev_search_text && data.search != "") {
+                    ajax_request_id += 1;
+                    getCompletions(data.search, ajax_request_id).then(([new_completions, request_id]) => {
+                        if (request_id != ajax_request_id) return;
+
+                        completion_items.length = 0;
+                        for (const completion of new_completions) {
+                            completion_items.push({
+                                text: completion.title,
+                                value: completion.url,
+                            });
+                        }
+
+                        let completions_disabled = false;
+                        if (completion_items.length == 0) {
+                            completions_disabled = true;
+                            completion_items.push(default_completion_item);
+                        }
+
+                        // It seems like there is no better way to update the completion list 
+                        api.redial(dialog_config);
+                        api.setData(data);
+                        api.focus("search");
+                        prev_search_text = data.search;
+
+                        if (completions_disabled)
+                            api.disable("completions");
+                        else
+                            api.enable("completions");
+
+                        updateDialog(api);
+                    });
+                } else if (data.search == "" && prev_search_text != "") {
+                    // force an update so that the original user url can get restored
+                    completion_items.length = 0;
+                    completion_items.push(default_completion_item);
+                    api.redial(dialog_config);
+                    api.setData(data);
+                    api.focus("search");
+                    prev_search_text = data.search;
+                    api.disable("completions");
+                    updateDialog(api);
+                }
+            }
+
+            const dialog_config = {
+                title: tinymceConfig.getAttribute("data-link-dialog-title-text"),
+                body: {
+                    type: "panel",
+                    items: [
+                        {
+                            type: "input",
+                            name: "url",
+                            label: tinymceConfig.getAttribute("data-link-dialog-url-text")
+                        },
+                        {
+                            type: "input",
+                            name: "text",
+                            label: tinymceConfig.getAttribute("data-link-dialog-text-text")
+                        },
+                        {
+                            type: "label",
+                            label: tinymceConfig.getAttribute("data-link-dialog-internal_link-text"),
+                            items: [
+                                {
+                                    type: "input",
+                                    name: "search",
+                                },
+                                {
+                                    type: "selectbox",
+                                    name: "completions",
+                                    items: completion_items,
+                                    disabled: true,
+                                }
+                            ]
+                        }
+                    ]
+                },
+                buttons: [
+                    {
+                        type: "cancel",
+                        text: tinymceConfig.getAttribute("data-dialog-cancel-text")
+                    },
+                    {
+                        type: "submit",
+                        name: "submit",
+                        text: tinymceConfig.getAttribute("data-dialog-submit-text"),
+                        primary: true,
+                        disabled: true
+                    },
+                ],
+                initialData: {
+                    text: initial_text,
+                    url: initial_url,
+                },
+                onSubmit: function (api) {
+                    const data = api.getData();
+                    let url = data.url;
+                    const text = data.text || url;
+
+                    if (data.url.trim() == "") {
+                        return;
+                    }
+                    api.close();
+
+                    let real_url = checkUrlHttps(url);
+                    // Either insert a new link or update the existing one
+                    let anchor = getAnchor();
+                    if (!anchor) {
+                        editor.insertContent(`<a href=${real_url}>${text}</a>`)
+                    } else {
+                        updateLink(editor, anchor, text, { 'href': real_url });
+                    }
+
+                },
+                onChange: updateDialog
+            };
+
+            return editor.windowManager.open(dialog_config);
+        };
+
+        editor.addShortcut("Meta+K", tinymceConfig.getAttribute("data-link-menu-text"), openDialog);
+
+        editor.ui.registry.addMenuItem('add_link', {
+            text: tinymceConfig.getAttribute("data-link-menu-text"),
+            icon: "link",
+            shortcut: "Meta+K",
+            onAction: openDialog,
+        });
+
+        // This form opens when a link is current selected with the cursor
+        editor.ui.registry.addContextForm("link_context_form", {
+            predicate: isAnchor,
+            initValue: function () {
+                var elm = getAnchor();
+                return !!elm ? elm.href : '';
+            },
+            position: "node",
+            commands: [
+                {
+                    type: 'contextformbutton',
+                    icon: "link",
+                    tooltip: tinymceConfig.getAttribute("data-update-text"),
+                    primary: true,
+                    onSetup: function (buttonApi) {
+                        let nodeChangeHandler = function () {
+                            buttonApi.setDisabled(editor.readonly);
+                        };
+                        editor.on('nodechange', nodeChangeHandler);
+                        return function () {
+                            editor.off('nodechange', nodeChangeHandler);
+                        }
+                    },
+                    onAction: (formApi) => {
+                        const url = formApi.getValue();
+                        const real_url = checkUrlHttps(url);
+                        const anchor = getAnchor();
+                        updateLink(editor, anchor, anchor.innerText, { 'href': real_url });
+                        formApi.hide();
+                    }
+                },
+                {
+                    type: 'contextformbutton',
+                    icon: 'unlink',
+                    tooltip: tinymceConfig.getAttribute("data-link-remove-text"),
+                    active: false,
+                    onAction: (formApi) => {
+                        let elm = getAnchor();
+                        if (!!elm) {
+                            elm.replaceWith(elm.innerHTML)
+                        }
+                        formApi.hide();
+                    }
+                },
+                {
+                    type: 'contextformbutton',
+                    icon: 'new-tab',
+                    tooltip: tinymceConfig.getAttribute("data-link-open-text"),
+                    active: false,
+                    onAction: (formApi) => {
+                        let elm = getAnchor();
+                        if (!!elm) {
+                            window.open(elm.getAttribute('href'), '_blank');
+                        }
+                    }
+                }
+            ]
+        });
+
+        return {};
+    })
+})();


### PR DESCRIPTION
### Short description
This pr adds support for searching internal links for pois, events and pages in the tinymce editor.
![image](https://user-images.githubusercontent.com/78504586/125204386-4a48b380-e27d-11eb-9f6f-c3ce6f301b48.png)
![image](https://user-images.githubusercontent.com/78504586/125204394-59c7fc80-e27d-11eb-8611-f7d1e7578d48.png)



### Proposed changes
- Replace the link plugin with a custom implementation of similar functionality
- Add an ajax endpoint for querying pois, events and pages for the current region that match a query string

### Resolved issues
Fixes: #590
