### PR TITLE
Provide default order for region model

### DIFF
--- a/src/cms/models/regions/region.py
+++ b/src/cms/models/regions/region.py
@@ -408,3 +408,5 @@ class Region(models.Model):
         verbose_name_plural = _("regions")
         #: The default permissions for this model
         default_permissions = ("change", "delete", "view")
+        #: The default sorting for this model
+        ordering = ["name"]

--- a/src/cms/views/regions/region_list_view.py
+++ b/src/cms/views/regions/region_list_view.py
@@ -44,7 +44,7 @@ class RegionListView(TemplateView):
         """
         regions = Region.objects.all()
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(regions.order_by("created_date"), PER_PAGE)
+        paginator = Paginator(regions, PER_PAGE)
         chunk = request.GET.get("page")
         region_chunk = paginator.get_page(chunk)
         return render(


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR contains a change to show regions alphabetically sorted by dafault.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Regions are now sorted by default when they are shown.
- Userlist was already sorted in region user list and network management.
-

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #893
