### PR TITLE
Fix crash when creating a new page/event/poi with an empty description

### DIFF
--- a/src/cms/forms/custom_content_model_form.py
+++ b/src/cms/forms/custom_content_model_form.py
@@ -2,6 +2,7 @@ import logging
 
 from urllib.parse import urlparse
 
+from lxml.etree import LxmlError
 from lxml.html import fromstring, tostring
 
 from django.db.models import Q
@@ -31,7 +32,11 @@ class CustomContentModelForm(CustomModelForm):
         :return: The valid content
         :rtype: str
         """
-        content = fromstring(self.cleaned_data[field_name])
+        try:
+            content = fromstring(self.cleaned_data[field_name])
+        except LxmlError:
+            # The content is not guaranteed to be valid html, for example it may be empty
+            return self.cleaned_data[field_name]
 
         # Convert heading 1 to heading 2
         for heading in content.iter("h1"):

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-06 06:50+0000\n"
+"POT-Creation-Date: 2021-07-16 12:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1406,15 +1406,15 @@ msgstr "Dritte Woche"
 msgid "Fourth week"
 msgstr "Vierte Woche"
 
-#: forms/custom_content_model_form.py:77
+#: forms/custom_content_model_form.py:82
 msgid "{} \"{}\" was successfully saved as draft"
 msgstr "{} \"{}\" wurde erfolgreich als Entwurf gespeichert"
 
-#: forms/custom_content_model_form.py:84
+#: forms/custom_content_model_form.py:89
 msgid "{} \"{}\" was successfully updated"
 msgstr "{} \"{}\" wurde erfolgreich aktualisiert"
 
-#: forms/custom_content_model_form.py:91
+#: forms/custom_content_model_form.py:96
 msgid "{} \"{}\" was successfully published"
 msgstr "{} \"{}\" wurde erfolgreich veröffentlicht"
 


### PR DESCRIPTION
### Short description
This pr fixes the crash that occurs when creating a page/event/poi that has an empty description or a description that is for any other reason no valid html.

### Proposed changes
- Handle exceptions thrown by the function that parses html strings and return the string unmodified in case of an error

### Resolved issues
Fixes: #895 
