### PR TITLE
Fix autosave changing previous version to draft

### DIFF
--- a/src/cms/constants/status.py
+++ b/src/cms/constants/status.py
@@ -10,10 +10,13 @@ DRAFT = "DRAFT"
 REVIEW = "REVIEW"
 #: Public
 PUBLIC = "PUBLIC"
+#: Auto Save
+AUTO_SAVE = "AUTO_SAVE"
 
 #: Choices to use these constants in a database field
 CHOICES = (
     (DRAFT, _("Draft")),
     (REVIEW, _("Pending Review")),
     (PUBLIC, _("Published")),
+    (AUTO_SAVE, _("Auto Save")),
 )

--- a/src/cms/forms/events/event_translation_form.py
+++ b/src/cms/forms/events/event_translation_form.py
@@ -43,7 +43,9 @@ class EventTranslationForm(CustomContentModelForm):
             # Copy QueryDict because it is immutable
             data = kwargs.pop("data").copy()
             # Update the POST field with the status corresponding to the submitted button
-            if "submit_draft" in data:
+            if "submit_auto" in data:
+                data["status"] = status.AUTO_SAVE
+            elif "submit_draft" in data:
                 data["status"] = status.DRAFT
             elif "submit_review" in data:
                 data["status"] = status.REVIEW

--- a/src/cms/forms/imprint/imprint_translation_form.py
+++ b/src/cms/forms/imprint/imprint_translation_form.py
@@ -32,7 +32,9 @@ class ImprintTranslationForm(CustomContentModelForm):
             # Copy QueryDict because it is immutable
             data = kwargs.pop("data").copy()
             # Update the POST field with the status corresponding to the submitted button
-            if "submit_draft" in data:
+            if "submit_auto" in data:
+                data["status"] = status.AUTO_SAVE
+            elif "submit_draft" in data:
                 data["status"] = status.DRAFT
             elif "submit_public" in data:
                 data["status"] = status.PUBLIC

--- a/src/cms/forms/pages/page_translation_form.py
+++ b/src/cms/forms/pages/page_translation_form.py
@@ -44,7 +44,9 @@ class PageTranslationForm(CustomContentModelForm):
             # Copy QueryDict because it is immutable
             data = kwargs.pop("data").copy()
             # Update the POST field with the status corresponding to the submitted button
-            if "submit_draft" in data:
+            if "submit_auto" in data:
+                data["status"] = status.AUTO_SAVE
+            elif "submit_draft" in data:
                 data["status"] = status.DRAFT
             elif "submit_review" in data:
                 data["status"] = status.REVIEW

--- a/src/cms/forms/pois/poi_translation_form.py
+++ b/src/cms/forms/pois/poi_translation_form.py
@@ -49,7 +49,9 @@ class POITranslationForm(CustomContentModelForm):
             # Copy QueryDict because it is immutable
             data = kwargs.pop("data").copy()
             # Update the POST field with the status corresponding to the submitted button
-            if "submit_draft" in data:
+            if "submit_auto" in data:
+                data["status"] = status.AUTO_SAVE
+            elif "submit_draft" in data:
                 data["status"] = status.DRAFT
             elif "submit_public" in data:
                 data["status"] = status.PUBLIC

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-20 09:29+0000\n"
+"POT-Creation-Date: 2021-07-21 10:03+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1283,17 +1283,21 @@ msgstr "App-Team"
 msgid "Promo team"
 msgstr "Promo-Team"
 
-#: constants/status.py:16
+#: constants/status.py:18
 msgid "Draft"
 msgstr "Entwurf"
 
-#: constants/status.py:17
+#: constants/status.py:19
 msgid "Pending Review"
 msgstr "Review ausstehend"
 
-#: constants/status.py:18
+#: constants/status.py:20
 msgid "Published"
 msgstr "Veröffentlicht"
+
+#: constants/status.py:21
+msgid "Auto Save"
+msgstr "Automatische Speicherung"
 
 #: constants/text_directions.py:14
 msgid "Left to right"
@@ -5257,12 +5261,17 @@ msgstr ""
 "veröffentlichen, aber Sie können Änderungen vornehmen und diese zur "
 "Überprüfung vorlegen."
 
-#: views/events/event_view.py:196
+#: views/events/event_view.py:182 views/imprint/imprint_view.py:199
+#: views/pages/page_view.py:244 views/pois/poi_view.py:157
+msgid "No changes detected, autosave skipped"
+msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
+
+#: views/events/event_view.py:203
 msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
-#: views/events/event_view.py:213 views/pages/page_view.py:261
-#: views/pois/poi_view.py:173
+#: views/events/event_view.py:220 views/pages/page_view.py:268
+#: views/pois/poi_view.py:179
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
 
@@ -5316,7 +5325,7 @@ msgstr ""
 msgid "The revision was successfully restored"
 msgstr "Die Revision wurde erfolgreich wiederhergestellt"
 
-#: views/imprint/imprint_sbs_view.py:68 views/imprint/imprint_view.py:123
+#: views/imprint/imprint_sbs_view.py:68 views/imprint/imprint_view.py:124
 msgid "You don't have the permission to edit the imprint."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um das Impressum zu bearbeiten."
@@ -5341,17 +5350,17 @@ msgstr ""
 "Sie können die Side-by-Side-Ansicht nicht verwenden, wenn die Quell-"
 "Übersetzung (in diesem Fall {source_language}) nicht existiert."
 
-#: views/imprint/imprint_view.py:70 views/pages/page_tree_view.py:83
+#: views/imprint/imprint_view.py:71 views/pages/page_tree_view.py:83
 msgid "Please create at least one language node before creating pages."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie das Impressum "
 "verwalten."
 
-#: views/imprint/imprint_view.py:96
+#: views/imprint/imprint_view.py:97
 msgid "You cannot manage the imprint because it is archived."
 msgstr "Sie können das Impressum nicht bearbeiten, weil es archiviert ist."
 
-#: views/imprint/imprint_view.py:104
+#: views/imprint/imprint_view.py:105
 #, python-format
 msgid ""
 "This is <b>not</b> the most recent public revision of this translation. "
@@ -5362,11 +5371,11 @@ msgstr ""
 "Stattdessen wird die <a href='%(revision_url)s' class='underline hover:no-"
 "underline'>Revision %(revision)s</a> in den Apps angezeigt."
 
-#: views/imprint/imprint_view.py:203
+#: views/imprint/imprint_view.py:209
 msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
-#: views/imprint/imprint_view.py:257 views/pages/page_view.py:315
+#: views/imprint/imprint_view.py:263 views/pages/page_view.py:322
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -5763,7 +5772,7 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
 "aber Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: views/pages/page_view.py:247
+#: views/pages/page_view.py:254
 msgid "Page \"{}\" was successfully created"
 msgstr "Seite \"{}\" wurde erfolgreich erstellt"
 
@@ -5817,7 +5826,7 @@ msgstr "Sie können Orte nur in der Standard-Sprache (%(language)s) anlegen"
 msgid "You cannot edit this location because it is archived."
 msgstr "Sie können diesen Ort nicht bearbeiten, da er archiviert ist."
 
-#: views/pois/poi_view.py:160
+#: views/pois/poi_view.py:166
 msgid "Location \"{}\" was successfully created"
 msgstr "Ort \"{}\" wurde erfolgreich erstellt"
 

--- a/src/cms/models/events/event_translation.py
+++ b/src/cms/models/events/event_translation.py
@@ -35,7 +35,7 @@ class EventTranslation(models.Model):
     )
     #: Manage choices in :mod:`cms.constants.status`
     status = models.CharField(
-        max_length=6,
+        max_length=9,
         choices=status.CHOICES,
         default=status.DRAFT,
         verbose_name=_("status"),

--- a/src/cms/models/pages/abstract_base_page_translation.py
+++ b/src/cms/models/pages/abstract_base_page_translation.py
@@ -12,7 +12,7 @@ class AbstractBasePageTranslation(models.Model):
 
     #: Manage choices in :mod:`cms.constants.status`
     status = models.CharField(
-        max_length=6,
+        max_length=9,
         choices=status.CHOICES,
         default=status.DRAFT,
         verbose_name=_("status"),

--- a/src/cms/models/pois/poi_translation.py
+++ b/src/cms/models/pois/poi_translation.py
@@ -36,7 +36,7 @@ class POITranslation(models.Model):
     )
     #: Manage choices in :mod:`cms.constants.status`
     status = models.CharField(
-        max_length=6,
+        max_length=9,
         choices=status.CHOICES,
         default=status.DRAFT,
         verbose_name=_("status"),

--- a/src/cms/views/events/event_view.py
+++ b/src/cms/views/events/event_view.py
@@ -173,6 +173,13 @@ class EventView(TemplateView, EventContextMixin, MediaContextMixin):
             event_form.add_error_messages(request)
             event_translation_form.add_error_messages(request)
             recurrence_rule_form.add_error_messages(request)
+        elif (
+            event_translation_form.instance.status == status.AUTO_SAVE
+            and not event_form.has_changed()
+            and not event_translation_form.has_changed()
+            and not recurrence_rule_form.has_changed()
+        ):
+            messages.info(request, _("No changes detected, autosave skipped"))
         else:
             # Check publish permissions
             if event_translation_form.instance.status == status.PUBLIC:

--- a/src/cms/views/imprint/imprint_view.py
+++ b/src/cms/views/imprint/imprint_view.py
@@ -12,6 +12,7 @@ from backend.settings import IMPRINT_SLUG, WEBAPP_URL
 from ...decorators import region_permission_required, permission_required
 from ...forms import ImprintTranslationForm
 from ...models import ImprintPageTranslation, ImprintPage, Region
+from ...constants import status
 
 logger = logging.getLogger(__name__)
 
@@ -191,6 +192,11 @@ class ImprintView(TemplateView):
         if not imprint_translation_form.is_valid():
             # Add error messages
             imprint_translation_form.add_error_messages(request)
+        elif (
+            imprint_translation_form.instance.status == status.AUTO_SAVE
+            and not imprint_translation_form.has_changed()
+        ):
+            messages.info(request, _("No changes detected, autosave skipped"))
         else:
             # Create imprint instance if not exists
             imprint_translation_form.instance.page = (

--- a/src/cms/views/pages/page_view.py
+++ b/src/cms/views/pages/page_view.py
@@ -236,6 +236,13 @@ class PageView(TemplateView, PageContextMixin, MediaContextMixin):
             raise PermissionDenied(
                 f"{request.user.profile!r} does not have the permission to publish {page_form.instance!r}"
             )
+        elif (
+            page_translation_form.instance.status == status.AUTO_SAVE
+            and not page_form.has_changed()
+            and not page_translation_form.has_changed()
+        ):
+            messages.info(request, _("No changes detected, autosave skipped"))
+
         else:
             # Save forms
             page_translation_form.instance.page = page_form.save()

--- a/src/cms/views/pois/poi_view.py
+++ b/src/cms/views/pois/poi_view.py
@@ -15,7 +15,7 @@ from ...forms import POIForm, POITranslationForm
 from ...models import POI, POITranslation, Region, Language
 from .poi_context_mixin import POIContextMixin
 from ..media.media_context_mixin import MediaContextMixin
-
+from ...constants import status
 
 logger = logging.getLogger(__name__)
 
@@ -149,6 +149,12 @@ class POIView(TemplateView, POIContextMixin, MediaContextMixin):
             # Add error messages
             poi_form.add_error_messages(request)
             poi_translation_form.add_error_messages(request)
+        elif (
+            poi_translation_form.instance.status == status.AUTO_SAVE
+            and not poi_form.has_changed()
+            and not poi_translation_form.has_changed()
+        ):
+            messages.info(request, _("No changes detected, autosave skipped"))
         else:
             # Save forms
             poi_translation_form.instance.poi = poi_form.save()

--- a/src/frontend/js/forms/autosave.ts
+++ b/src/frontend/js/forms/autosave.ts
@@ -5,7 +5,7 @@ export async function autosaveEditor() {
   const form = document.getElementById("content_form") as HTMLFormElement;
   tinymce.triggerSave();
   let formData = new FormData(form);
-  formData.append("submit_draft", "true");
+  formData.append("submit_auto", "true");
   const data = await fetch(window.location.href, {
     method: "POST",
     headers: {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR proposes a solution to the problem that the status of page becomes Draft when some changes are made but then deleted before the autosave,

### Proposed changes
<!-- Describe this PR in more detail. -->

- when a POST request, which changes the status of a page to Draft, is sent by an auto save but the changes are deleted and therefore the contents have not changed, the status will be overwritten to Public.
-
-

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #714
