### PR TITLE
Fix `TypeError` in `EventView` caused by missing method arguments

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-23 15:32+0000\n"
+"POT-Creation-Date: 2021-07-24 10:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -5299,11 +5299,11 @@ msgstr ""
 msgid "No changes detected, autosave skipped"
 msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
 
-#: views/events/event_view.py:203
+#: views/events/event_view.py:205
 msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
-#: views/events/event_view.py:220 views/pages/page_view.py:268
+#: views/events/event_view.py:222 views/pages/page_view.py:268
 #: views/pois/poi_view.py:179
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"

--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-24 10:09+0000\n"
+"POT-Creation-Date: 2021-08-03 19:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -5299,11 +5299,11 @@ msgstr ""
 msgid "No changes detected, autosave skipped"
 msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
 
-#: views/events/event_view.py:205
+#: views/events/event_view.py:204
 msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
-#: views/events/event_view.py:222 views/pages/page_view.py:268
+#: views/events/event_view.py:221 views/pages/page_view.py:268
 #: views/pois/poi_view.py:179
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"

--- a/src/cms/views/events/event_view.py
+++ b/src/cms/views/events/event_view.py
@@ -191,7 +191,9 @@ class EventView(TemplateView, EventContextMixin, MediaContextMixin):
             if event_form.cleaned_data.get("is_recurring"):
                 # If event is recurring, save recurrence rule
                 event_form.instance.recurrence_rule = recurrence_rule_form.save()
-            elif event_form.fields["is_recurring"].has_changed():
+            elif event_instance and event_form.fields["is_recurring"].has_changed(
+                event_instance.is_recurring, event_form.cleaned_data.get("is_recurring")
+            ):
                 # If the event is not recurring but it was before, delete the associated recurrence rule
                 event_form.instance.recurrence_rule.delete()
             event_translation_form.instance.event = event_form.save()

--- a/src/cms/views/events/event_view.py
+++ b/src/cms/views/events/event_view.py
@@ -191,11 +191,10 @@ class EventView(TemplateView, EventContextMixin, MediaContextMixin):
             if event_form.cleaned_data.get("is_recurring"):
                 # If event is recurring, save recurrence rule
                 event_form.instance.recurrence_rule = recurrence_rule_form.save()
-            elif event_instance and event_form.fields["is_recurring"].has_changed(
-                event_instance.is_recurring, event_form.cleaned_data.get("is_recurring")
-            ):
+            elif event_form.instance.recurrence_rule:
                 # If the event is not recurring but it was before, delete the associated recurrence rule
                 event_form.instance.recurrence_rule.delete()
+                event_form.instance.recurrence_rule = None
             event_translation_form.instance.event = event_form.save()
             event_translation_form.save()
             # Add the success message and redirect to the edit page


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

This PR fixes a `TypeError` occurring when trying to save a newly created event. The error is due to missing arguments to the `has_changed` method invoked on a field of the form.

### Proposed changes
<!-- Describe this PR in more detail. -->

Steps to fix the error:

- Provide the necessary arguments to the method
- Check the arguments for validity (i.e., not invoking `NoneType` objects) before

Even though the `elif` clause looks a little bit messy and overloaded now, I chose to stick with the method call instead of another workaround because the method invoked on the field does checks that we'd have to account for in our workaround otherwise.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #887 
