### PR TITLE
Fix translator view

### DIFF
--- a/src/cms/templates/imprint/imprint_sbs.html
+++ b/src/cms/templates/imprint/imprint_sbs.html
@@ -140,9 +140,9 @@
 </form>
 
 {% if not perms.cms.change_imprintpage or imprint_translation_form.instance.id and imprint_translation_form.instance.page.archived %}
-    {% include '../_tinymce_config.html' with readonly=1 %}
+    {% include '../_tinymce_config.html' with readonly=1 language=target_language %}
 {% else %}
-    {% include '../_tinymce_config.html' %}
+    {% include '../_tinymce_config.html' with language=target_language %}
 {% endif %}
 
 {% endblock %}

--- a/src/cms/templates/pages/page_sbs.html
+++ b/src/cms/templates/pages/page_sbs.html
@@ -20,9 +20,9 @@
             <a href="{% url 'edit_page' page_id=source_page_translation.page.id region_slug=region.slug language_slug=target_language.slug %}" class="bg-gray-400 hover:bg-gray-500 cursor-pointer text-white font-bold py-3 px-4 rounded mr-2">
                 {% trans 'Go Back to Page Editor' %}
             </a>
-            {% has_perm 'cms.change_page_object' request.user source_page_translation.page as can_edit_page %}
+            {% has_perm 'cms.change_page_object' request.user source_page_translation.page as can_change_page_object %}
             {% if not source_page_translation.page.archived %}
-            {% if can_edit_page %}
+            {% if can_change_page_object %}
             <input type="submit" name="submit_draft" class="bg-gray-500 hover:bg-gray-600 cursor-pointer text-white font-bold py-3 px-4 rounded mr-2" value="{% trans 'Save as draft' %}" />
             {% endif %}
             {% has_perm 'cms.publish_page_object' request.user source_page_translation.page as can_publish_page %}
@@ -150,9 +150,9 @@
 </form>
 
 {% if not can_change_page_object or page_translation_form.instance.id and page_translation_form.instance.page.archived %}
-    {% include '../_tinymce_config.html' with readonly=1 %}
+    {% include '../_tinymce_config.html' with readonly=1 language=target_language %}
 {% else %}
-    {% include '../_tinymce_config.html' %}
+    {% include '../_tinymce_config.html' with language=target_language %}
 {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
### Short description
This pr fixes the error that shows up when trying to open the page translation view.
Additionally, this pr fixes a problem where the page translation loads as readonly, even if the user has all required permissions.

### Proposed changes
- Provide the target language to `_tinymce_config.html` in the sbs view
- Fix the variable `can_change_page_object` not getting set at all

### Resolved issues
Fixes: #907 
