### PR TITLE
Autosave on new page form creates multiple new pages

### DIFF
--- a/src/frontend/js/forms/autosave.ts
+++ b/src/frontend/js/forms/autosave.ts
@@ -6,11 +6,13 @@ export async function autosaveEditor() {
   tinymce.triggerSave();
   let formData = new FormData(form);
   formData.append("submit_auto", "true");
-  const data = await fetch(window.location.href, {
+  const data = await fetch(form.action, {
     method: "POST",
     headers: {
       "X-CSRFToken": getCsrfToken(),
     },
     body: formData
   });
+  // Set the form action to the url of the server response to make sure new pages aren't created multiple times
+  form.action = data.url;
 }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR solves the problem that the auto save creates multiple of new versions instead of update the first one.

### Proposed changes
<!-- Describe this PR in more detail. -->

- When there is a change made, the latest version of the translation will be checked.
- If it has status Autosave, this one will be deleted and replaced with the new version by not increasing the version number.

In the second commit changed
- autosave.ts is changed as in the comment suggested.
- Line 101 of forms.pages.page_translation_form.py, which was already commented out, is deleted.
- Now only one page is created also for a content which has no published version. The problem that auto save changes unversioned page (page without published version) will be solved in the issue #899.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #672
