### PR TITLE
Autosave changes unversioned Page model

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-25 15:43+0000\n"
+"POT-Creation-Date: 2021-08-30 10:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -5319,7 +5319,7 @@ msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
 msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
-#: views/events/event_view.py:223 views/pages/page_view.py:268
+#: views/events/event_view.py:223 views/pages/page_view.py:273
 #: views/pois/poi_view.py:179
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
@@ -5424,7 +5424,7 @@ msgstr ""
 msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
-#: views/imprint/imprint_view.py:266 views/pages/page_view.py:322
+#: views/imprint/imprint_view.py:266 views/pages/page_view.py:327
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -5817,7 +5817,7 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
 "aber Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: views/pages/page_view.py:254
+#: views/pages/page_view.py:259
 msgid "Page \"{}\" was successfully created"
 msgstr "Seite \"{}\" wurde erfolgreich erstellt"
 

--- a/src/cms/views/pages/page_view.py
+++ b/src/cms/views/pages/page_view.py
@@ -244,8 +244,13 @@ class PageView(TemplateView, PageContextMixin, MediaContextMixin):
             messages.info(request, _("No changes detected, autosave skipped"))
 
         else:
-            # Save forms
-            page_translation_form.instance.page = page_form.save()
+            # Only save page form if page does not yet exist or if translation is no auto save
+            if (
+                not page_instance
+                or page_translation_form.instance.status != status.AUTO_SAVE
+            ):
+                page_translation_form.instance.page = page_form.save()
+            # Save page translation form
             page_translation_form.save()
             # Add the success message and redirect to the edit page
             if not page_instance:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR contains a suggestion to solve the problem that autosave changes unversioned page models.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Before saving page and pagetranslation objects, it will be checked in page_view.py, whether the save is triggered by an auto save, a page objects already exisits, and there is a public version backup.-


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #899
