### PR TITLE
Children API: use root pages as ancestors per default

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 07:57+0000\n"
+"POT-Creation-Date: 2021-08-25 15:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1248,7 +1248,7 @@ msgstr "Aktiv"
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: constants/region_status.py:18 models/pages/page.py:224
+#: constants/region_status.py:18 models/pages/page.py:237
 #: models/pages/page_translation.py:311 models/regions/region.py:390
 #: templates/pages/page_form.html:150
 #: templates/pages/page_tree_archived_node.html:13
@@ -2341,12 +2341,12 @@ msgstr "explizit archiviert"
 msgid "Whether or not the page is explicitly archived"
 msgstr "Ob die Seite explizit archiviert ist oder nicht"
 
-#: models/pages/abstract_base_page.py:139 models/pages/page.py:230
+#: models/pages/abstract_base_page.py:139 models/pages/page.py:243
 #: models/pages/page_translation.py:43
 msgid "page"
 msgstr "Seite"
 
-#: models/pages/abstract_base_page.py:141 models/pages/page.py:232
+#: models/pages/abstract_base_page.py:141 models/pages/page.py:245
 msgid "pages"
 msgstr "Seiten"
 

--- a/src/cms/models/pages/page.py
+++ b/src/cms/models/pages/page.py
@@ -154,6 +154,19 @@ class Page(MPTTModel, AbstractBasePage):
         """
         return len(self.get_ancestors())
 
+    @classmethod
+    def get_root_pages(cls, region_slug):
+        """
+        Gets all root pages
+
+        :param region_slug: Slug defining the region
+        :type region_slug: str
+
+        :return: All root pages i.e. pages without parents
+        :rtype: ~mptt.querysets.TreeQuerySet [ ~cms.models.pages.page.Page ]
+        """
+        return Page.objects.filter(region__slug=region_slug, parent=None)
+
     def get_previous_sibling(self, *filter_args, **filter_kwargs):
         # Only consider siblings from this region
         filter_kwargs["region"] = self.region


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes API error when no query string is supplied

### Proposed changes
<!-- Describe this PR in more detail. -->

When neither id nor url is supplied by API children request, use all root pages + their children (with specified depth)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #925
