### PR TITLE
Fix API page response format for url and path

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-30 10:06+0000\n"
+"POT-Creation-Date: 2021-09-03 10:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1249,7 +1249,7 @@ msgid "Hidden"
 msgstr "Versteckt"
 
 #: constants/region_status.py:18 models/pages/page.py:237
-#: models/pages/page_translation.py:311 models/regions/region.py:390
+#: models/pages/page_translation.py:335 models/regions/region.py:390
 #: templates/pages/page_form.html:150
 #: templates/pages/page_tree_archived_node.html:13
 msgid "Archived"
@@ -2075,8 +2075,8 @@ msgid "offer list feedback"
 msgstr "Angebotslisten-Feedback"
 
 #: models/feedback/page_feedback.py:18
-#: models/pages/abstract_base_page_translation.py:325
-#: models/pages/page_translation.py:317
+#: models/pages/abstract_base_page_translation.py:326
+#: models/pages/page_translation.py:341
 msgid "page translation"
 msgstr "Seiten-Übersetzung"
 
@@ -2354,8 +2354,8 @@ msgstr "Seiten"
 msgid "version"
 msgstr "Version"
 
-#: models/pages/abstract_base_page_translation.py:327
-#: models/pages/page_translation.py:319
+#: models/pages/abstract_base_page_translation.py:328
+#: models/pages/page_translation.py:343
 msgid "page translations"
 msgstr "Seiten-Übersetzungen"
 
@@ -2469,11 +2469,11 @@ msgstr "Titel der Seite"
 msgid "content of the page"
 msgstr "Inhalt der Seite"
 
-#: models/pages/page_translation.py:195
+#: models/pages/page_translation.py:219
 msgid "Live content"
 msgstr "Live-Inhalt"
 
-#: models/pages/page_translation.py:198
+#: models/pages/page_translation.py:222
 msgid "Empty"
 msgstr "Leer"
 

--- a/src/cms/models/pages/abstract_base_page_translation.py
+++ b/src/cms/models/pages/abstract_base_page_translation.py
@@ -137,7 +137,8 @@ class AbstractBasePageTranslation(models.Model):
             if other_translation:
                 available_languages[language.slug] = {
                     "id": other_translation.id,
-                    "url": other_translation.permalink,
+                    "url": other_translation.backend_base_link,
+                    "path": "/" + other_translation.permalink + "/",
                 }
         return available_languages
 

--- a/src/cms/models/pages/page_translation.py
+++ b/src/cms/models/pages/page_translation.py
@@ -126,6 +126,30 @@ class PageTranslation(AbstractBasePageTranslation):
         )
 
     @property
+    def backend_base_link(self):
+        """
+        This property calculates the absolute page link on the CMS domain
+
+        :return: The base link of the page
+        :rtype: str
+        """
+        return (
+            "/".join(
+                filter(
+                    None,
+                    [
+                        BASE_URL,
+                        self.page.region.slug,
+                        self.language.slug,
+                        self.ancestor_path,
+                        self.slug,
+                    ],
+                )
+            )
+            + "/"
+        )
+
+    @property
     def short_url(self):
         """
         This function returns the absolute short url to the page translation


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix API page response format for url and path

### Proposed changes
<!-- Describe this PR in more detail. -->

- Prepends domain of backend to url translation path, reads domain from settings value `BASE_URL` (or is `WEBAPP_URL` expected here?)
- Sets path to permalink surrounded by slashes

Also updates url and path for these objects (included in page/children response):
1. parent
2. available_languages (path was not present before)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #928
