### PR TITLE
Fix push notifications API token

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -98,7 +98,7 @@ API_EVENTS_MAX_TIME_SPAN_DAYS = 31
 ###############################
 
 #: Authentification Token for the Firebase API. This needs to be set for a correct usage of the Messages Feature.
-FCM_KEY = ""
+FCM_KEY = None
 
 ###########
 # GVZ API #

--- a/src/cms/views/push_notifications/push_notification_sender.py
+++ b/src/cms/views/push_notifications/push_notification_sender.py
@@ -38,7 +38,10 @@ class PushNotificationSender:
         if len(self.primary_pnt.title) > 0:
             self.prepared_pnts.append(self.primary_pnt)
         self.load_secondary_pnts()
-        self.auth_key = self.get_auth_key()
+
+        self.auth_key = settings.FCM_KEY
+        if not self.auth_key:
+            logger.warning("Could not get a proper fcm_auth_key")
 
     def load_secondary_pnts(self):
         """
@@ -65,27 +68,13 @@ class PushNotificationSender:
         :return: all prepared push notification translations are valid
         :rtype: bool
         """
-        if self.auth_key is None:
+        if not self.auth_key:
             return False
         for pnt in self.prepared_pnts:
             if not pnt.title:
                 logger.debug("%r has no title", pnt)
                 return False
         return True
-
-    @staticmethod
-    def get_auth_key():
-        """
-        Get FCM API auth key
-
-        :return: FCM API auth key
-        :rtype: str
-        """
-        auth_key = settings.FCM_KEY
-        if auth_key and isinstance(auth_key, str):
-            return auth_key
-        logger.warning("Could not get a proper fcm_auth_key")
-        return None
 
     def send_pn(self, pnt):
         """

--- a/src/cms/views/push_notifications/push_notification_sender.py
+++ b/src/cms/views/push_notifications/push_notification_sender.py
@@ -81,14 +81,10 @@ class PushNotificationSender:
         :return: FCM API auth key
         :rtype: str
         """
-        fcm_auth_config_key = "fcm_auth_key"
         auth_key = settings.FCM_KEY
-        if auth_key.exists():
-            logger.debug("Got fcm_auth_key from database")
-            return auth_key.first().value
-        logger.warning(
-            "Could not get %r from configuration database", fcm_auth_config_key
-        )
+        if auth_key and isinstance(auth_key, str):
+            return auth_key
+        logger.warning("Could not get a proper fcm_auth_key")
         return None
 
     def send_pn(self, pnt):


### PR DESCRIPTION
### Short description
This should fix the server crash when trying to send a push notification.


### Proposed changes
- The parsing of the fcm-authentification-token was deprecated. Now it will handle the token as a string and not as a database entry.


Fixes: #927
