### PR TITLE
Include subpages in filtered page results

### DIFF
--- a/src/cms/locale/de/LC_MESSAGES/django.po
+++ b/src/cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-09-23 17:24+0000\n"
+"POT-Creation-Date: 2021-09-26 18:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3778,7 +3778,7 @@ msgstr "Noch kein technisches Feedback vorhanden."
 #: templates/feedback/admin_feedback_list.html:127
 #: templates/feedback/region_feedback_list.html:121
 #: templates/linkcheck/links_by_filter.html:61
-#: templates/pages/page_tree.html:110
+#: templates/pages/page_tree.html:111
 msgid "Select bulk action"
 msgstr "Mehrfachaktion auswählen"
 
@@ -3801,7 +3801,7 @@ msgstr "Löschen"
 #: templates/feedback/admin_feedback_list.html:134
 #: templates/feedback/region_feedback_list.html:128
 #: templates/linkcheck/links_by_filter.html:73
-#: templates/pages/page_tree.html:118
+#: templates/pages/page_tree.html:119
 msgid "Execute"
 msgstr "Ausführen"
 
@@ -4454,27 +4454,27 @@ msgstr "Sie können Seiten nur in der Standard-Sprache anlegen"
 msgid "Tags"
 msgstr "Tags"
 
-#: templates/pages/page_tree.html:101
+#: templates/pages/page_tree.html:102
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
-#: templates/pages/page_tree.html:111
+#: templates/pages/page_tree.html:112
 msgid "Archive pages"
 msgstr "Seiten archivieren"
 
-#: templates/pages/page_tree.html:113
+#: templates/pages/page_tree.html:114
 msgid "Export as PDF"
 msgstr "Als PDF Exportieren"
 
-#: templates/pages/page_tree.html:115
+#: templates/pages/page_tree.html:116
 msgid "Export XLIFF for translation to"
 msgstr "Exportiere XLIFF für Übersetzung nach"
 
-#: templates/pages/page_tree.html:124
+#: templates/pages/page_tree.html:125
 msgid "Upload XLIFF File"
 msgstr "XLIFF-Datei hochladen"
 
-#: templates/pages/page_tree.html:134 views/media/media_context_mixin.py:37
+#: templates/pages/page_tree.html:135 views/media/media_context_mixin.py:37
 msgid "Upload"
 msgstr "Hochladen"
 
@@ -6058,15 +6058,6 @@ msgstr ""
 
 #~ msgid "Help"
 #~ msgstr "Hilfe"
-
-#~ msgid "JPEG document"
-#~ msgstr "JPEG-Dokument"
-
-#~ msgid "GIF document"
-#~ msgstr "GIF-Dokument"
-
-#~ msgid "SVG document"
-#~ msgstr "SVG Dokument"
 
 #~ msgid "Read more"
 #~ msgstr "Weiterlesen"

--- a/src/cms/templates/pages/page_tree.html
+++ b/src/cms/templates/pages/page_tree.html
@@ -86,6 +86,7 @@
             {% get_last_root_page pages as last_root_page %}
             {% recursetree pages %}
                 {% get_translation node language.slug as page_translation %}
+                {% get_depth_in node pages as page_depth %}
                 {% include "pages/page_tree_node.html" with page=node %}
                 {% if not node.is_leaf_node %}
                     {{children}}

--- a/src/cms/templates/pages/page_tree_node.html
+++ b/src/cms/templates/pages/page_tree_node.html
@@ -2,8 +2,8 @@
 {% load content_filters %}
 {% load page_filters %}
 {% load tree_filters %}
-<tr id="page-{{ page.id }}-drop-left" data-drop-id="{{ page.id }}" data-drop-position="left" class="drop {% if page.depth == 0 %} drop-between {% endif %} h-3 -m-3 hidden level-{{page.depth}}"><td colspan="9"><div><span></span></div></td></tr>
-<tr id="page-{{ page.id }}" data-drop-id="{{ page.id }}" data-drop-position="last-child" class="drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100 child {% if page.depth > 0 %} hidden level-{{page.depth}}{% endif %}">
+<tr id="page-{{ page.id }}-drop-left" data-drop-id="{{ page.id }}" data-drop-position="left" class="drop {% if page_depth == 0 %} drop-between {% endif %} h-3 -m-3 hidden level-{{page_depth}}"><td colspan="9"><div><span></span></div></td></tr>
+<tr id="page-{{ page.id }}" data-drop-id="{{ page.id }}" data-drop-position="last-child" class="drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100 child {% if page_depth > 0 %} hidden level-{{page_depth}}{% endif %}">
     <td class="pl-4">
         <input type="checkbox" name="selected_ids[]" value="{{ page.id }}" class="bulk-select-item">
     </td>

--- a/src/cms/templatetags/page_filters.py
+++ b/src/cms/templatetags/page_filters.py
@@ -19,3 +19,40 @@ def get_last_root_page(pages):
     """
     root_pages = list(filter(lambda p: not p.parent, pages))
     return root_pages[-1] if root_pages else None
+
+
+@register.simple_tag
+def get_depth_in(node, pageset):
+    """
+    This tag returns the depth of node whithin the tree/pages in pageset.
+
+    :param node : the page
+    :type node : ~cms.models.pages.page.Page
+
+    :param pageset: The pages (all pages or pages chosen by filter)
+    :type pageset: list [ ~cms.models.pages.page.Page ]
+
+    :return: the depth of node whithin the tree/pages in pageset
+    :rtype: int
+    """
+    if not node.parent in pageset:
+        return 0
+    return node.depth - get_highest_anscentor_in(node, pageset).depth
+
+
+def get_highest_anscentor_in(node, pageset):
+    """
+    This tag returns the highest (farthest) anscestor of node whithin the tree/pages in pageset.
+
+    :param node : the page
+    :type node : ~cms.models.pages.page.Page
+
+    :param pageset: The pages (all pages or pages chosen by filter)
+    :type pageset: list [ ~cms.models.pages.page.Page ]
+
+    :return: the highest (farthest) anscestor of node whithin the tree/pages in pageset
+    :rtype:  ~cms.models.pages.page.Page
+    """
+    if node.parent in pageset:
+        return get_highest_anscentor_in(node.parent, pageset)
+    return node

--- a/src/cms/templatetags/tree_filters.py
+++ b/src/cms/templatetags/tree_filters.py
@@ -32,4 +32,4 @@ def get_children(node):
     :return: The list of all the node's children's ids
     :rtype: list [ int ]
     """
-    return [child.id for child in node.children.all()]
+    return [child.id for child in node.get_children()]

--- a/src/cms/views/pages/page_tree_view.py
+++ b/src/cms/views/pages/page_tree_view.py
@@ -10,7 +10,7 @@ from django.views.generic import TemplateView
 from ...constants import translation_status
 from ...decorators import region_permission_required, permission_required
 from ...forms import PageFilterForm
-from ...models import Region, Language
+from ...models import Region, Language, Page
 from .page_context_mixin import PageContextMixin
 
 logger = logging.getLogger(__name__)
@@ -118,7 +118,8 @@ class PageTreeView(TemplateView, PageContextMixin):
                             return translation_status.OUTDATED in selected_status
                         return translation_status.UP_TO_DATE in selected_status
 
-                    pages = list(filter(page_filter, pages))
+                    pages = map(lambda p: p.id, list(filter(page_filter, pages)))
+                    pages = Page.objects.filter(id__in=pages).order_by()
         else:
             filter_form = PageFilterForm()
             filter_form.changed_data.clear()


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR is to fix the problem that subpages are not shown when the filter is applied.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Subpages are now shown too
- Pages are shown even when their root page and/or parent page is filterd out.
- 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #934 
