### PR TITLE
Fix `compgen` usage in `run.sh`

### DIFF
--- a/dev-tools/run.sh
+++ b/dev-tools/run.sh
@@ -36,10 +36,8 @@ echo -e "Starting WebPack dev server in background..." | print_info | print_pref
 deescalate_privileges npm run dev 2>&1 | print_prefix "webpack" 36 &
 
 # Waiting for initial WebPack dev build
-compgen -G "${BASE_DIR}/src/cms/static/main.*.js" > /dev/null
-while [[ $? -eq 1 ]]; do 
+while [[ -z $(compgen -G "${BASE_DIR}/src/cms/static/main.*.js") ]]; do
     sleep 1
-    compgen -G "${BASE_DIR}/src/cms/static/main.*.js" > /dev/null
 done
 
 # Show success message once dev server is up


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
`compgen` does not exit with code 1 when no matches are found on all distros, therefore we should inspect the standard output rather than the exit code.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check whether output is empty instead of whether exit code is 1

