### PR TITLE
Use simple logging in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,11 +86,11 @@ jobs:
       - run:
           name: Migrate database
           command: |
-            pipenv run integreat-cms-cli makemigrations cms
-            pipenv run integreat-cms-cli migrate
+            pipenv run integreat-cms-cli makemigrations cms --settings=backend.circleci_settings
+            pipenv run integreat-cms-cli migrate --settings=backend.circleci_settings
       - run:
           name: Run tests
-          command: pipenv run integreat-cms-cli test cms --set=COVERAGE
+          command: pipenv run integreat-cms-cli test cms --set=COVERAGE --settings=backend.circleci_settings
       - store_artifacts:
           path: htmlcov
   check-translations:
@@ -119,7 +119,7 @@ jobs:
           name: Compile translation file
           command: |
             cd src/cms
-            pipenv run integreat-cms-cli compilemessages
+            pipenv run integreat-cms-cli compilemessages --settings=backend.circleci_settings
       - persist_to_workspace:
           root: .
           paths:

--- a/src/backend/circleci_settings.py
+++ b/src/backend/circleci_settings.py
@@ -1,0 +1,14 @@
+"""
+Django settings for our CircleCI workflow.
+All configuration is imported from :mod:`backend.settings` except it sets all logging to simple console output.
+For more information on this file, see :doc:`topics/settings`.
+For the full list of settings and their values, see :doc:`ref/settings`.
+"""
+# pylint: disable=wildcard-import
+# pylint: disable=unused-wildcard-import
+from .settings import *
+
+
+# Use simple non-colored logging in circleci
+for logger in LOGGING["loggers"].values():
+    logger["handlers"] = ["console"]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Don't use the logfile or colored output on circleci


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
This might fix some problems with logging on CircleCI:
```
.....--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/logging/handlers.py", line 934, in emit
    self.socket.send(msg)
OSError: [Errno 9] Bad file descriptor

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/logging/handlers.py", line 855, in _connect_unixsocket
    self.socket.connect(address)
FileNotFoundError: [Errno 2] No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/logging/handlers.py", line 937, in emit
    self._connect_unixsocket(self.address)
  File "/usr/local/lib/python3.7/logging/handlers.py", line 866, in _connect_unixsocket
    self.socket.connect(address)
FileNotFoundError: [Errno 2] No such file or directory
Call stack:
  File "/home/circleci/project/.venv/bin/integreat-cms-cli", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/home/circleci/project/src/integreat-cms-cli", line 50, in <module>
    main()
  File "/home/circleci/project/src/integreat-cms-cli", line 39, in main
    execute_from_command_line(sys.argv)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/core/management/commands/test.py", line 23, in run_from_argv
    super().run_from_argv(argv)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/core/management/commands/test.py", line 55, in handle
    failures = test_runner.run_tests(test_labels)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/test/runner.py", line 729, in run_tests
    result = self.run_suite(suite)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/test/runner.py", line 670, in run_suite
    return runner.run(suite)
  File "/usr/local/lib/python3.7/unittest/runner.py", line 176, in run
    test(result)
  File "/usr/local/lib/python3.7/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/local/lib/python3.7/unittest/suite.py", line 122, in run
    test(result)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/test/testcases.py", line 245, in __call__
    self._setup_and_call(result)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/test/testcases.py", line 281, in _setup_and_call
    super().__call__(result)
  File "/usr/local/lib/python3.7/unittest/case.py", line 676, in __call__
    return self.run(*args, **kwds)
  File "/usr/local/lib/python3.7/unittest/case.py", line 624, in run
    self.setUp()
  File "/home/circleci/project/src/cms/tests/views/admin_view_test.py", line 40, in setUp
    self.client.force_login(user)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/test/client.py", line 619, in force_login
    self._login(user, backend)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/test/client.py", line 631, in _login
    login(request, user, backend)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/contrib/auth/__init__.py", line 135, in login
    user_logged_in.send(sender=user.__class__, request=request, user=user)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/dispatch/dispatcher.py", line 182, in send
    for receiver in self._live_receivers(sender)
  File "/home/circleci/project/.venv/lib/python3.7/site-packages/django/dispatch/dispatcher.py", line 182, in <listcomp>
    for receiver in self._live_receivers(sender)
  File "/home/circleci/project/src/cms/apps.py", line 67, in user_logged_in_callback
    authlog.info("login user=%s, ip=%s", user, ip)
Message: 'login user=%s, ip=%s'
Arguments: (<User: root>, None)
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/logging/handlers.py", line 934, in emit
    self.socket.send(msg)
OSError: [Errno 9] Bad file descriptor
```
