### PR TITLE
Show missing api feedback documentation

### DIFF
--- a/src/api/decorators.py
+++ b/src/api/decorators.py
@@ -21,6 +21,7 @@ def feedback_handler(func):
     """
 
     @csrf_exempt
+    @wraps(func)
     def handle_feedback(request, region_slug, language_slug):
         """
         Parse feedback API request parameters


### PR DESCRIPTION
### Short description
This pr fixes a bug where documentation for some functions of the feedback api was not generated.

### Proposed changes
- Fix the decorator `feedback_handler` to correctly wrap the decorated functions

### Resolved issues
Fixes: #595 
