### PR TITLE
Implement links to webapp for page, event and POI lists

### DIFF
--- a/src/cms/templates/events/event_list_row.html
+++ b/src/cms/templates/events/event_list_row.html
@@ -76,10 +76,16 @@
         <i data-feather="calendar"></i> {{ event.end_date|date:'d.m.Y'}}{% if not event.is_all_day %} <i data-feather="clock" class="ml-2"></i> {{ event.end_time|time:'H:i' }}{% endif %}
     </td>
     <td class="pl-2 pr-4 py-3 flex flex-nowrap justify-end gap-2">
-        <!-- TODO: add link to view event in web app -->
-        <a href="" class="btn-icon">
-            <i data-feather="eye"></i>
-        </a>
+        {% if event_translation.status == PUBLIC %}
+            <a href="{{ WEBAPP_URL }}{{ event_translation.get_absolute_url }}" 
+            rel="noopener noreferrer" target="_blank" title="{% trans 'Open event in web app' %}" class="btn-icon">
+                <i data-feather="external-link"></i>
+            </a>
+        {% else %}
+            <button title="{% trans 'This event cannot be opened in the web app, because it is not public.' %}" class="btn-icon" disabled>
+                <i data-feather="external-link"></i>
+            </button>
+        {% endif %}
         {% has_perm 'cms.change_event' request.user as can_edit_event %}
         {% if can_edit_event %}
             <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_slug=language.slug %}" class="btn-icon" title="{% trans 'Edit event' %}">

--- a/src/cms/templates/pages/page_tree_node.html
+++ b/src/cms/templates/pages/page_tree_node.html
@@ -108,11 +108,20 @@
         </a>
     </td>
     <td class="pl-2 pr-4 py-3 text-right flex flex-nowrap gap-2">
-        <!-- TODO: add link to view page in web app -->
         <a href="{% url 'view_page' page_id=page.id region_slug=region.slug language_slug=language.slug %}"
-           target="_blank" rel="noopener noreferrer" title="{% trans 'View page' %}" class="btn-icon">
+           target="_blank" rel="noopener noreferrer" title="{% trans 'View page as preview' %}" class="btn-icon">
             <i data-feather="eye"></i>
         </a>
+        {% if page_translation.status == PUBLIC %}
+            <a href="{{ WEBAPP_URL }}{{ page_translation.get_absolute_url }}"
+                rel="noopener noreferrer" target="_blank" title="{% trans 'Open page in web app' %}" class="btn-icon">
+                <i data-feather="external-link"></i>
+            </a>
+        {% else %}
+            <button title="{% trans 'This page cannot be opened in the web app, because it is not public.' %}" class="btn-icon" disabled>
+                <i data-feather="external-link"></i>
+            </button>
+        {% endif %}
         <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_slug=language.slug %}" title="{% trans 'Edit page' %}" class="btn-icon">
             <i data-feather="edit"></i>
         </a>

--- a/src/cms/templates/pois/poi_list_row.html
+++ b/src/cms/templates/pois/poi_list_row.html
@@ -77,10 +77,16 @@
         </a>
 	</td>
     <td class="pl-2 pr-4 py-3 min text-right flex flex-nowrap gap-2">
-        <!-- TODO: add link to view poi in web app -->
-        <a href="#" class="btn-icon">
-            <i data-feather="eye"></i>
-        </a>
+        {% if poi_translation.status == PUBLIC %}
+            <a href="{{ WEBAPP_URL }}{{ poi_translation.get_absolute_url }}" 
+            rel="noopener noreferrer" target="_blank" title="{% trans 'Open location in web app' %}" class="btn-icon">
+                <i data-feather="external-link"></i>
+            </a>
+        {% else %}
+            <button title="{% trans 'This location cannot be opened in the web app, because it is not public.' %}" class="btn-icon" disabled>
+                <i data-feather="external-link"></i>
+            </button>
+        {% endif %}
         <button title="{% trans 'Archive location' %}" class="confirmation-button btn-icon"
             data-confirmation-title="{{ archive_dialog_title }}"
             data-confirmation-text="{{ archive_dialog_text }}"

--- a/src/cms/views/events/event_list_view.py
+++ b/src/cms/views/events/event_list_view.py
@@ -9,9 +9,9 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
 
-from backend.settings import PER_PAGE
+from backend.settings import PER_PAGE, WEBAPP_URL
 
-from ...constants import all_day, recurrence
+from ...constants import all_day, recurrence, status
 from ...decorators import region_permission_required, permission_required
 from ...models import Region, EventTranslation
 from ...forms import EventFilterForm
@@ -189,6 +189,8 @@ class EventListView(TemplateView, EventContextMixin):
                 "filter_form": event_filter_form,
                 "filter_poi": poi,
                 "search_query": query,
+                "WEBAPP_URL": WEBAPP_URL,
+                "PUBLIC": status.PUBLIC,
             },
         )
 

--- a/src/cms/views/pages/page_tree_view.py
+++ b/src/cms/views/pages/page_tree_view.py
@@ -7,9 +7,10 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
 
+from backend.settings import WEBAPP_URL
 from cms.models.pages.page_translation import PageTranslation
 
-from ...constants import translation_status
+from ...constants import translation_status, status
 from ...decorators import region_permission_required, permission_required
 from ...forms import PageFilterForm
 from ...models import Region, Language, Page
@@ -150,6 +151,8 @@ class PageTreeView(TemplateView, PageContextMixin):
                 "filter_form": filter_form,
                 "enable_drag_and_drop": enable_drag_and_drop,
                 "search_query": query,
+                "PUBLIC": status.PUBLIC,
+                "WEBAPP_URL": WEBAPP_URL,
             },
         )
 

--- a/src/cms/views/pois/poi_list_view.py
+++ b/src/cms/views/pois/poi_list_view.py
@@ -8,9 +8,10 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
 
-from backend.settings import PER_PAGE
+from backend.settings import PER_PAGE, WEBAPP_URL
 from cms.models.pois.poi_translation import POITranslation
 
+from ...constants import status
 from ...decorators import region_permission_required, permission_required
 from ...models import Region, Language
 from ...forms import ObjectSearchForm
@@ -129,6 +130,8 @@ class POIListView(TemplateView, POIContextMixin):
                 "language": language,
                 "languages": region.languages,
                 "search_query": query,
+                "WEBAPP_URL": WEBAPP_URL,
+                "PUBLIC": status.PUBLIC,
                 **context,
             },
         )

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-28 07:25+0000\n"
+"POT-Creation-Date: 2021-10-29 15:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3679,7 +3679,7 @@ msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
 #: cms/templates/events/event_form.html:287
-#: cms/templates/events/event_list_row.html:94
+#: cms/templates/events/event_list_row.html:100
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
@@ -3689,7 +3689,7 @@ msgstr "Diese Veranstaltung archivieren"
 
 #: cms/templates/events/event_form.html:300
 #: cms/templates/events/event_list_archived_row.html:102
-#: cms/templates/events/event_list_row.html:103
+#: cms/templates/events/event_list_row.html:109
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
@@ -3780,11 +3780,21 @@ msgstr "Übersetzung nicht verfügbar"
 msgid "Not specified"
 msgstr "Nicht festgelegt"
 
+#: cms/templates/events/event_list_row.html:81
+msgid "Open event in web app"
+msgstr "Veranstaltung in der Web-App öffnen"
+
 #: cms/templates/events/event_list_row.html:85
+msgid "This event cannot be opened in the web app, because it is not public."
+msgstr ""
+"Diese Veranstaltung kann nicht in der Web-App geöffnet werden, weil sie "
+"nicht veröffentlicht ist."
+
+#: cms/templates/events/event_list_row.html:91
 msgid "Edit event"
 msgstr "Veranstaltung bearbeiten"
 
-#: cms/templates/events/event_list_row.html:90
+#: cms/templates/events/event_list_row.html:96
 msgid "Duplicate event"
 msgstr "Veranstaltung duplizieren"
 
@@ -4510,7 +4520,7 @@ msgstr[1] ""
 
 #: cms/templates/pages/page_form.html:323
 #: cms/templates/pages/page_form.html:324
-#: cms/templates/pages/page_tree_node.html:120
+#: cms/templates/pages/page_tree_node.html:129
 msgid "Archive page"
 msgstr "Seite archivieren"
 
@@ -4521,13 +4531,13 @@ msgstr "Diese Seite archivieren"
 #: cms/templates/pages/page_form.html:334
 #: cms/templates/pages/page_form.html:352
 #: cms/templates/pages/page_tree_archived_node.html:98
-#: cms/templates/pages/page_tree_node.html:133
+#: cms/templates/pages/page_tree_node.html:142
 msgid "Delete page"
 msgstr "Seite löschen"
 
 #: cms/templates/pages/page_form.html:338
 #: cms/templates/pages/page_tree_archived_node.html:94
-#: cms/templates/pages/page_tree_node.html:129
+#: cms/templates/pages/page_tree_node.html:138
 #: cms/views/pages/page_actions.py:223
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
@@ -4664,7 +4674,6 @@ msgstr ""
 "ist."
 
 #: cms/templates/pages/page_tree_archived_node.html:76
-#: cms/templates/pages/page_tree_node.html:113
 msgid "View page"
 msgstr "Seite ansehen"
 
@@ -4690,19 +4699,33 @@ msgstr "Drag & drop nicht möglich, wenn Filter aktiv sind"
 msgid "Collapse all subpages"
 msgstr "Alle Unterseiten einklappen"
 
-#: cms/templates/pages/page_tree_node.html:116
+#: cms/templates/pages/page_tree_node.html:112
+msgid "View page as preview"
+msgstr "Seite als Vorschau ansehen"
+
+#: cms/templates/pages/page_tree_node.html:117
+msgid "Open page in web app"
+msgstr "Seite in der Web-App öffnen"
+
+#: cms/templates/pages/page_tree_node.html:121
+msgid "This page cannot be opened in the web app, because it is not public."
+msgstr ""
+"Diese Seite kann nicht in der Web-App geöffnet werden, weil sie nicht "
+"veröffentlicht ist."
+
+#: cms/templates/pages/page_tree_node.html:125
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 
-#: cms/templates/pages/page_tree_node.html:129
+#: cms/templates/pages/page_tree_node.html:138
 msgid "This also involves archived subpages."
 msgstr "Dies betrifft auch archivierte Unterseiten."
 
-#: cms/templates/pages/page_tree_node.html:144
+#: cms/templates/pages/page_tree_node.html:153
 msgid "Copy short link"
 msgstr "Kurz-URL kopieren"
 
-#: cms/templates/pages/page_tree_node.html:148
+#: cms/templates/pages/page_tree_node.html:157
 msgid "You cannot copy a short link of a page which has no translation."
 msgstr "Sie können keine Kurz-URL zu einer fehlenden Übersetzung kopieren."
 
@@ -4749,7 +4772,7 @@ msgid "Restore this location"
 msgstr "Diesen Ort wiederherstellen"
 
 #: cms/templates/pois/poi_form.html:205 cms/templates/pois/poi_form.html:206
-#: cms/templates/pois/poi_list_row.html:84
+#: cms/templates/pois/poi_list_row.html:90
 msgid "Archive location"
 msgstr "Ort archivieren"
 
@@ -4759,7 +4782,7 @@ msgstr "Diesen Ort archivieren"
 
 #: cms/templates/pois/poi_form.html:217 cms/templates/pois/poi_form.html:218
 #: cms/templates/pois/poi_list_archived_row.html:62
-#: cms/templates/pois/poi_list_row.html:92
+#: cms/templates/pois/poi_list_row.html:98
 msgid "Delete location"
 msgstr "Ort löschen"
 
@@ -4788,6 +4811,17 @@ msgstr "Noch keine Orte vorhanden."
 #: cms/templates/pois/poi_list_archived.html:41
 msgid "No locations archived yet."
 msgstr "Noch keine Orte archiviert."
+
+#: cms/templates/pois/poi_list_row.html:82
+msgid "Open location in web app"
+msgstr "Ort in der Web-App öffnen"
+
+#: cms/templates/pois/poi_list_row.html:86
+msgid ""
+"This location cannot be opened in the web app, because it is not public."
+msgstr ""
+"Dieser Ort kann nicht in der Web-App geöffnet werden, weil er nicht "
+"veröffentlicht ist."
 
 #: cms/templates/push_notifications/push_notification_form.html:18
 #, python-format
@@ -5614,7 +5648,7 @@ msgstr ""
 msgid "No changes made"
 msgstr "Keine Änderungen vorgenommen"
 
-#: cms/views/imprint/imprint_view.py:72 cms/views/pages/page_tree_view.py:85
+#: cms/views/imprint/imprint_view.py:72 cms/views/pages/page_tree_view.py:86
 msgid "Please create at least one language node before creating pages."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie das Impressum "
@@ -6052,7 +6086,7 @@ msgid "You cannot restore revisions of this page because it is archived."
 msgstr ""
 "Sie können Revisionen dieser Seite nicht bearbeiten, weil sie archiviert ist."
 
-#: cms/views/pages/page_tree_view.py:96
+#: cms/views/pages/page_tree_view.py:97
 msgid "You don't have the permission to edit or create pages."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Seiten zu bearbeiten oder zu "
@@ -6137,12 +6171,12 @@ msgstr "Bitte bestätigen Sie, dass dieser Ort gelöscht werden soll"
 msgid "All translations of this location will also be deleted."
 msgstr "Alle Übersetzungen dieses Ortes werden gelöscht."
 
-#: cms/views/pois/poi_list_view.py:86
+#: cms/views/pois/poi_list_view.py:87
 msgid "Please create at least one language node before creating locations."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Orte verwalten."
 
-#: cms/views/pois/poi_list_view.py:100
+#: cms/views/pois/poi_list_view.py:101
 #, python-format
 msgid "You can only create locations in the default language (%(language)s)."
 msgstr "Sie können Orte nur in der Standard-Sprache (%(language)s) anlegen"
@@ -6341,6 +6375,18 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "Event is not public."
+#~ msgstr "Veranstaltung ist nicht veröffentlicht."
+
+#~ msgid "Page is not public."
+#~ msgstr "Seite ist nicht veröffentlicht."
+
+#~ msgid "Open POI in Webapp"
+#~ msgstr "POI in der Webapp öffnen"
+
+#~ msgid "POI is not public."
+#~ msgstr "POI ist nicht veröffentlicht."
 
 #~ msgid "Translation cannot be imported"
 #~ msgstr "Übersetzung kann nicht importiert werden"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR implements an external-link option for the page tree as well as the event and POI lists. 

### Proposed changes
<!-- Describe this PR in more detail. -->
- Implemented the link option as an addition to the Preview mode (pages only).
- Changed link icons in all cases from "eye" to "external link" to prevent ambiguity with the page tree view.
- Link icons are disabled, if the the page/event/POI is not published.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #965
