### PR TITLE
Fix redirect to region user settings

### DIFF
--- a/src/cms/views/settings/user_settings_view.py
+++ b/src/cms/views/settings/user_settings_view.py
@@ -10,6 +10,7 @@ from django.shortcuts import render, redirect
 from django.views.decorators.cache import never_cache
 
 from ...forms import UserEmailForm, UserPasswordForm
+from ...models import Region
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +76,7 @@ class UserSettingsView(TemplateView):
         :return: The rendered template response
         :rtype: ~django.template.response.TemplateResponse
         """
+        region = Region.get_current_region(request)
 
         user = request.user
 
@@ -114,4 +116,5 @@ class UserSettingsView(TemplateView):
                 update_session_auth_hash(request, user)
                 messages.success(request, _("Password was successfully saved"))
 
-        return redirect("user_settings")
+        kwargs = {"region_slug": region.slug} if region else {}
+        return redirect("user_settings", **kwargs)

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-30 12:50+0000\n"
+"POT-Creation-Date: 2021-10-31 07:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -5642,8 +5642,8 @@ msgstr ""
 #: cms/views/offer_templates/offer_template_view.py:81
 #: cms/views/organizations/organization_view.py:86
 #: cms/views/pages/page_sbs_view.py:196 cms/views/regions/region_view.py:88
-#: cms/views/roles/role_view.py:92 cms/views/settings/user_settings_view.py:93
-#: cms/views/settings/user_settings_view.py:110
+#: cms/views/roles/role_view.py:92 cms/views/settings/user_settings_view.py:95
+#: cms/views/settings/user_settings_view.py:112
 #: cms/views/users/region_user_view.py:99 cms/views/users/user_view.py:105
 msgid "No changes made"
 msgstr "Keine Änderungen vorgenommen"
@@ -6283,11 +6283,11 @@ msgstr ""
 "Der 2-Faktor-Authentifizierungsschlüssel \"{}\" wurde erfolgreich "
 "registriert."
 
-#: cms/views/settings/user_settings_view.py:96
+#: cms/views/settings/user_settings_view.py:98
 msgid "E-mail-address was successfully saved"
 msgstr "E-Mail-Adresse wurde erfolgreich geändert"
 
-#: cms/views/settings/user_settings_view.py:115
+#: cms/views/settings/user_settings_view.py:117
 msgid "Password was successfully saved"
 msgstr "Passwort wurde erfolgreich geändert"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This fixes the redirect after a region user changed his email or password to make sure the menu sidebar shows the region menu instead of the network management area.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Redirect to region user settings after form submission

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #997
