### PR TITLE
Improve browser compatibility of automatic file download

### DIFF
--- a/src/cms/views/pages/page_actions.py
+++ b/src/cms/views/pages/page_actions.py
@@ -351,7 +351,7 @@ def download_xliff(request, region_slug, language_slug):
                 _(
                     "If the download does not start automatically, please click {}here{}."
                 ).format(
-                    f"<a data-auto-download href='{xliff_file_url}' class='font-bold underline hover:no-underline'>",
+                    f"<a data-auto-download href='{xliff_file_url}' class='font-bold underline hover:no-underline' download>",
                     "</a>",
                 ),
             ),

--- a/src/frontend/js/auto-file-download.ts
+++ b/src/frontend/js/auto-file-download.ts
@@ -1,7 +1,7 @@
 window.addEventListener("load", () => {
     document.querySelectorAll("[data-auto-download]").forEach((node) => {
         setTimeout(function() {
-            window.location.href = node.getAttribute('href');
+            (node as HTMLLinkElement).click();
         }, 500);
     });
 });


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
On some browsers, I noticed that the automatic download doesn't work - instead, the xliff file is directly opened as XML file in the browser.


### Proposed changes
<!-- Describe this PR in more detail. -->
- Use `download` link attribute
- Trigger click of link instead of setting `window.location.href`

