### PR TITLE
Add missing access control to link checker

### DIFF
--- a/src/cms/views/linkcheck/linkcheck.py
+++ b/src/cms/views/linkcheck/linkcheck.py
@@ -1,6 +1,8 @@
 from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.db.models import OuterRef, Subquery
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
 from django.views.generic import ListView
@@ -9,12 +11,15 @@ from django.views.generic.base import RedirectView
 from linkcheck.models import Link
 from backend.settings import PER_PAGE
 
+from ...decorators import region_permission_required
 from ...models.pages.page_translation import PageTranslation
 from ...models.events.event_translation import EventTranslation
 from ...models.pois.poi_translation import POITranslation
 from ...utils.filter_links import filter_links
 
-# pylint: disable=too-many-ancestors
+
+@method_decorator(login_required, name="dispatch")
+@method_decorator(region_permission_required, name="dispatch")
 class LinkListView(ListView):
     """
     View for retrieving a list of links grouped by their state
@@ -101,6 +106,8 @@ class LinkListView(ListView):
         return redirect("linkcheck", region_slug=region_slug, link_filter=link_filter)
 
 
+@method_decorator(login_required, name="dispatch")
+@method_decorator(region_permission_required, name="dispatch")
 class LinkListRedirectView(RedirectView):
     """
     View for redirecting to main page of the broken link checker

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-31 07:38+0000\n"
+"POT-Creation-Date: 2021-10-31 13:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -5722,15 +5722,15 @@ msgstr "Sprache \"{}\" wurde erfolgreich erstellt"
 msgid "Language \"{}\" was successfully saved"
 msgstr "Sprache \"{}\" wurde erfolgreich gespeichert"
 
-#: cms/views/linkcheck/linkcheck.py:93
+#: cms/views/linkcheck/linkcheck.py:98
 msgid "Links were successfully ignored"
 msgstr "Links wurden erfolgreich ignoriert"
 
-#: cms/views/linkcheck/linkcheck.py:96
+#: cms/views/linkcheck/linkcheck.py:101
 msgid "Links were successfully unignored"
 msgstr "Links werden nicht mehr ignoriert"
 
-#: cms/views/linkcheck/linkcheck.py:100
+#: cms/views/linkcheck/linkcheck.py:105
 msgid "Links were successfully checked"
 msgstr "Links wurden erfolgreich geprüft"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
At the moment, there is no access control for the broken link checker.
Since the links itself are publicly available via the API, the worst that can happen is that unauthorized users trigger a re-check of links or ignore/unignore broken links. Nonetheless, we should fix this asap.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Only allow link checker page for logged in users
- Only allow link checker page for users of that region

