### PR TITLE
Fix Drap&Drop in Language Tree

### DIFF
--- a/src/cms/urls.py
+++ b/src/cms/urls.py
@@ -946,7 +946,7 @@ urlpatterns = [
                                         ),
                                         # warning: the move url is also hardcoded in src/cms/static/js/tree_drag_and_drop.js
                                         url(
-                                            r"^move/(?P<target_id>[0-9]+)/(?P<position>[-\w]+)$",
+                                            r"^move/(?P<target_id>[0-9]+)/(?P<target_position>[-\w]+)$",
                                             language_tree.move_language_tree_node,
                                             name="move_language_tree_node",
                                         ),

--- a/src/frontend/js/tree-drag-and-drop.ts
+++ b/src/frontend/js/tree-drag-and-drop.ts
@@ -128,9 +128,9 @@ function drop(event: DragEvent) {
   // get target node if from dropped region
   const target = (event.target as HTMLElement).closest("tr");
   const target_id = target.getAttribute("data-drop-id");
-  const position = target.getAttribute("data-drop-position");
+  const target_position = target.getAttribute("data-drop-position");
   // abuse confirmation dialog form to perform action
   let form = document.getElementById("confirmation-dialog").querySelector("form");
-  form.action = window.location.href + node_id + "/move/" + target_id + "/" + position;
+  form.action = window.location.href + node_id + "/move/" + target_id + "/" + target_position;
   form.submit();
 }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR solved the problem that drag and drop did was not working in the language tree.

### Proposed changes
<!-- Describe this PR in more detail. -->

- the related URL and variable name in TypeScript were fixed


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #996
