### PR TITLE
Make pagination chunk size configurable

### DIFF
--- a/src/cms/fixtures/test_users.json
+++ b/src/cms/fixtures/test_users.json
@@ -1,0 +1,2302 @@
+[
+  {
+    "model": "cms.user",
+    "pk": 10,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user0",
+      "first_name": "user0",
+      "last_name": "user0",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 11,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user1",
+      "first_name": "user1",
+      "last_name": "user1",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 12,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user2",
+      "first_name": "user2",
+      "last_name": "user2",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 13,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user3",
+      "first_name": "user3",
+      "last_name": "user3",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 14,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user4",
+      "first_name": "user4",
+      "last_name": "user4",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 15,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user5",
+      "first_name": "user5",
+      "last_name": "user5",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 16,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user6",
+      "first_name": "user6",
+      "last_name": "user6",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 17,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user7",
+      "first_name": "user7",
+      "last_name": "user7",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 18,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user8",
+      "first_name": "user8",
+      "last_name": "user8",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 19,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user9",
+      "first_name": "user9",
+      "last_name": "user9",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 20,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user10",
+      "first_name": "user10",
+      "last_name": "user10",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 21,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user11",
+      "first_name": "user11",
+      "last_name": "user11",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 22,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user12",
+      "first_name": "user12",
+      "last_name": "user12",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 23,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user13",
+      "first_name": "user13",
+      "last_name": "user13",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 24,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user14",
+      "first_name": "user14",
+      "last_name": "user14",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 25,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user15",
+      "first_name": "user15",
+      "last_name": "user15",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 26,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user16",
+      "first_name": "user16",
+      "last_name": "user16",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 27,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user17",
+      "first_name": "user17",
+      "last_name": "user17",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 28,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user18",
+      "first_name": "user18",
+      "last_name": "user18",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 29,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user19",
+      "first_name": "user19",
+      "last_name": "user19",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 30,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user20",
+      "first_name": "user20",
+      "last_name": "user20",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 31,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user21",
+      "first_name": "user21",
+      "last_name": "user21",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 32,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user22",
+      "first_name": "user22",
+      "last_name": "user22",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 33,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user23",
+      "first_name": "user23",
+      "last_name": "user23",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 34,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user24",
+      "first_name": "user24",
+      "last_name": "user24",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 35,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user25",
+      "first_name": "user25",
+      "last_name": "user25",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 36,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user26",
+      "first_name": "user26",
+      "last_name": "user26",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 37,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user27",
+      "first_name": "user27",
+      "last_name": "user27",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 38,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user28",
+      "first_name": "user28",
+      "last_name": "user28",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 39,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user29",
+      "first_name": "user29",
+      "last_name": "user29",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 40,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user30",
+      "first_name": "user30",
+      "last_name": "user30",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 41,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user31",
+      "first_name": "user31",
+      "last_name": "user31",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 42,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user32",
+      "first_name": "user32",
+      "last_name": "user32",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 43,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user33",
+      "first_name": "user33",
+      "last_name": "user33",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 44,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user34",
+      "first_name": "user34",
+      "last_name": "user34",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 45,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user35",
+      "first_name": "user35",
+      "last_name": "user35",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 46,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user36",
+      "first_name": "user36",
+      "last_name": "user36",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 47,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user37",
+      "first_name": "user37",
+      "last_name": "user37",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 48,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user38",
+      "first_name": "user38",
+      "last_name": "user38",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 49,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user39",
+      "first_name": "user39",
+      "last_name": "user39",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 50,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user40",
+      "first_name": "user40",
+      "last_name": "user40",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 51,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user41",
+      "first_name": "user41",
+      "last_name": "user41",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 52,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user42",
+      "first_name": "user42",
+      "last_name": "user42",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 53,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user43",
+      "first_name": "user43",
+      "last_name": "user43",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 54,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user44",
+      "first_name": "user44",
+      "last_name": "user44",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 55,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user45",
+      "first_name": "user45",
+      "last_name": "user45",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 56,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user46",
+      "first_name": "user46",
+      "last_name": "user46",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 57,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user47",
+      "first_name": "user47",
+      "last_name": "user47",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 58,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user48",
+      "first_name": "user48",
+      "last_name": "user48",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 59,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user49",
+      "first_name": "user49",
+      "last_name": "user49",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 60,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user50",
+      "first_name": "user50",
+      "last_name": "user50",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 61,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user51",
+      "first_name": "user51",
+      "last_name": "user51",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 62,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user52",
+      "first_name": "user52",
+      "last_name": "user52",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 63,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user53",
+      "first_name": "user53",
+      "last_name": "user53",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 64,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user54",
+      "first_name": "user54",
+      "last_name": "user54",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 65,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user55",
+      "first_name": "user55",
+      "last_name": "user55",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 66,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user56",
+      "first_name": "user56",
+      "last_name": "user56",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 67,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user57",
+      "first_name": "user57",
+      "last_name": "user57",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 68,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user58",
+      "first_name": "user58",
+      "last_name": "user58",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 69,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user59",
+      "first_name": "user59",
+      "last_name": "user59",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 70,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user60",
+      "first_name": "user60",
+      "last_name": "user60",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 71,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user61",
+      "first_name": "user61",
+      "last_name": "user61",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 72,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user62",
+      "first_name": "user62",
+      "last_name": "user62",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 73,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user63",
+      "first_name": "user63",
+      "last_name": "user63",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 74,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user64",
+      "first_name": "user64",
+      "last_name": "user64",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 75,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user65",
+      "first_name": "user65",
+      "last_name": "user65",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 76,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user66",
+      "first_name": "user66",
+      "last_name": "user66",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 77,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user67",
+      "first_name": "user67",
+      "last_name": "user67",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 78,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user68",
+      "first_name": "user68",
+      "last_name": "user68",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 79,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user69",
+      "first_name": "user69",
+      "last_name": "user69",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 80,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user70",
+      "first_name": "user70",
+      "last_name": "user70",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 81,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user71",
+      "first_name": "user71",
+      "last_name": "user71",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 82,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user72",
+      "first_name": "user72",
+      "last_name": "user72",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 83,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user73",
+      "first_name": "user73",
+      "last_name": "user73",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 84,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user74",
+      "first_name": "user74",
+      "last_name": "user74",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 85,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user75",
+      "first_name": "user75",
+      "last_name": "user75",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 86,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user76",
+      "first_name": "user76",
+      "last_name": "user76",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 87,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user77",
+      "first_name": "user77",
+      "last_name": "user77",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 88,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user78",
+      "first_name": "user78",
+      "last_name": "user78",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 89,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user79",
+      "first_name": "user79",
+      "last_name": "user79",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 90,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user80",
+      "first_name": "user80",
+      "last_name": "user80",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 91,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user81",
+      "first_name": "user81",
+      "last_name": "user81",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 92,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user82",
+      "first_name": "user82",
+      "last_name": "user82",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 93,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user83",
+      "first_name": "user83",
+      "last_name": "user83",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 94,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user84",
+      "first_name": "user84",
+      "last_name": "user84",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 95,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user85",
+      "first_name": "user85",
+      "last_name": "user85",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 96,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user86",
+      "first_name": "user86",
+      "last_name": "user86",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 97,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user87",
+      "first_name": "user87",
+      "last_name": "user87",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 98,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user88",
+      "first_name": "user88",
+      "last_name": "user88",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 99,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user89",
+      "first_name": "user89",
+      "last_name": "user89",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 100,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user90",
+      "first_name": "user90",
+      "last_name": "user90",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 101,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user91",
+      "first_name": "user91",
+      "last_name": "user91",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 102,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user92",
+      "first_name": "user92",
+      "last_name": "user92",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 103,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user93",
+      "first_name": "user93",
+      "last_name": "user93",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 104,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user94",
+      "first_name": "user94",
+      "last_name": "user94",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 105,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user95",
+      "first_name": "user95",
+      "last_name": "user95",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 106,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user96",
+      "first_name": "user96",
+      "last_name": "user96",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 107,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user97",
+      "first_name": "user97",
+      "last_name": "user97",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 108,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user98",
+      "first_name": "user98",
+      "last_name": "user98",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 109,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": true,
+      "username": "user99",
+      "first_name": "user99",
+      "last_name": "user99",
+      "email": "user@user.user",
+      "is_staff": true,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [
+        6
+      ],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [],
+      "expert_mode": true
+    }
+  }
+]

--- a/src/cms/templates/feedback/admin_feedback_list.html
+++ b/src/cms/templates/feedback/admin_feedback_list.html
@@ -121,8 +121,9 @@
         {% endfor %}
 
     </table>
-    <div class="flex justify-between mt-5">
-        <div class="flex gap-2">
+    <div class="flex flex-col">
+        {% include "pagination.html" with url=url chunk=admin_feedback %}
+        <div class="flex self-start gap-2 mt-2">
             <select id="bulk-action">
                 <option>{% trans 'Select bulk action' %}</option>
                 <option data-bulk-action="{% url 'mark_admin_feedback_as_read' %}">{% trans 'Mark as read' %}</option>
@@ -132,9 +133,6 @@
                 {% endif %}
             </select>
             <button id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
-        </div>
-        <div>
-            {% include "pagination.html" with url=url chunk=admin_feedback %}
         </div>
     </div>
 </form>

--- a/src/cms/templates/feedback/region_feedback_list.html
+++ b/src/cms/templates/feedback/region_feedback_list.html
@@ -114,8 +114,9 @@
         {% endfor %}
 
     </table>
-    <div class="flex justify-between mt-5">
-        <div class="flex gap-2">
+    <div class="flex flex-col">
+        {% include "pagination.html" with url=url chunk=region_feedback %}
+        <div class="flex self-start gap-2 mt-2">
             <select id="bulk-action">
                 <option>{% trans 'Select bulk action' %}</option>
                 <option data-bulk-action="{% url 'mark_region_feedback_as_read' region_slug=region.slug %}">{% trans 'Mark as read' %}</option>
@@ -125,9 +126,6 @@
                 {% endif %}
             </select>
             <button id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
-        </div>
-        <div>
-            {% include "pagination.html" with url=url chunk=region_feedback %}
         </div>
     </div>
 </form>

--- a/src/cms/templates/pagination.html
+++ b/src/cms/templates/pagination.html
@@ -1,20 +1,31 @@
+{% load i18n %}
 {% load arithmetic %}
 
 <!-- this document defines the navigation through paginated lists -->
 <!-- in general there are links for the 2 previous and next pages -->
 <!-- plus additional links to start, end, immediate next and immediate previous -->
 
-{% with num_pages=chunk.paginator.num_pages %}
-{% if num_pages > 1 %}
+{% with num_pages=chunk.paginator.num_pages chunk_size=request.GET.size %}
 <div class="pagination">
+    <div>
+        <label for="chunk-size"></label>
+        <select id="chunk-size">
+            <option value="">{% trans 'Number of entries per page' %}</option>
+            <option value="{{ url }}?size=10" {% if chunk_size == "10" %}selected{% endif %}>10</option>
+            <option value="{{ url }}?size=20" {% if chunk_size == "20" %}selected{% endif %}>20</option>
+            <option value="{{ url }}?size=50" {% if chunk_size == "50" %}selected{% endif %}>50</option>
+            <option value="{{ url }}?size=100" {% if chunk_size == "100" %}selected{% endif %}>100</option>
+        </select>
+    </div>
+    {% if num_pages > 1 %}
     <div class="step-links">
         <!-- pagination always contains left and right buttons -->
         <!-- in case the left/right outer bounds are reached these links are disabled -->
-        <a href="{% if chunk.has_previous %}{{ url }}?page={{ chunk.previous_page_number }}{% else %}#{% endif %}" class="arrow-link">
+        <a href="{% if chunk.has_previous %}{{ url }}?page={{ chunk.previous_page_number }}{% if chunk_size %}&size={{ chunk_size }}{% endif %}{% else %}#{% endif %}" class="arrow-link">
             <i data-feather="chevron-left"></i>
         </a>
         <!-- pagination always allows to jump to start page -->
-        <a href="{{ url }}?page=1" class="{% if chunk.number == 1 %}active{% endif %}">1</a>
+        <a href="{{ url }}?page=1{% if chunk_size %}&size={{ chunk_size }}{% endif %}" class="{% if chunk.number == 1 %}active{% endif %}">1</a>
         {% if chunk.number|diff:1 > 3 %}
             <!-- if current page is more than 2 pages after start, hide those pages -->
             <a href="#">...</a>
@@ -24,7 +35,7 @@
                 <a href="#" class="active">{{ i }}</a>
             {% elif i > chunk.number|diff:3 and i < chunk.number|add:3 %}
                 <!-- show only links to at most 2 previous/next pages -->
-                <a href="{{ url }}?page={{ i }}">{{ i }}</a>
+                <a href="{{ url }}?page={{ i }}{% if chunk_size %}&size={{ chunk_size }}{% endif %}">{{ i }}</a>
             {% endif %}
         {% endfor %}
         {% if num_pages|diff:chunk.number > 3 %}
@@ -32,11 +43,11 @@
             <a href="#">...</a>
         {% endif %}
         <!-- pagination always allows to jump to last page -->
-        <a href="{{ url }}?page={{ num_pages }}" class="{% if chunk.number == num_pages %}active{% endif %}">{{ num_pages }}</a>
-        <a href="{% if chunk.has_next %}{{ url }}?page={{ chunk.next_page_number }}{% else %}#{% endif %}" class="arrow-link">
+        <a href="{{ url }}?page={{ num_pages }}{% if chunk_size %}&size={{ chunk_size }}{% endif %}" class="{% if chunk.number == num_pages %}active{% endif %}">{{ num_pages }}</a>
+        <a href="{% if chunk.has_next %}{{ url }}?page={{ chunk.next_page_number }}{% if chunk_size %}&size={{ chunk_size }}{% endif %}{% else %}#{% endif %}" class="arrow-link">
             <i data-feather="chevron-right"></i>
         </a>
     </div>
+    {% endif %}
 </div>
-{% endif %}
 {% endwith %}

--- a/src/cms/views/events/event_list_view.py
+++ b/src/cms/views/events/event_list_view.py
@@ -171,8 +171,9 @@ class EventListView(TemplateView, EventContextMixin):
             event_filter_form = EventFilterForm()
             event_filter_form.changed_data.clear()
             poi = None
+        chunk_size = int(request.GET.get("size", PER_PAGE))
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(events.order_by("start_date", "start_time"), PER_PAGE)
+        paginator = Paginator(events.order_by("start_date", "start_time"), chunk_size)
         chunk = request.GET.get("page")
         event_chunk = paginator.get_page(chunk)
         context = self.get_context_data(**kwargs)

--- a/src/cms/views/feedback/admin_feedback_list_view.py
+++ b/src/cms/views/feedback/admin_feedback_list_view.py
@@ -111,7 +111,8 @@ class AdminFeedbackListView(TemplateView):
             filter_form = AdminFeedbackFilterForm()
             filter_form.changed_data.clear()
 
-        paginator = Paginator(admin_feedback, PER_PAGE)
+        chunk_size = int(request.GET.get("size", PER_PAGE))
+        paginator = Paginator(admin_feedback, chunk_size)
         chunk = request.GET.get("page")
         admin_feedback_chunk = paginator.get_page(chunk)
 

--- a/src/cms/views/feedback/region_feedback_list_view.py
+++ b/src/cms/views/feedback/region_feedback_list_view.py
@@ -112,7 +112,8 @@ class RegionFeedbackListView(TemplateView):
             filter_form = RegionFeedbackFilterForm()
             filter_form.changed_data.clear()
 
-        paginator = Paginator(region_feedback, PER_PAGE)
+        chunk_size = int(request.GET.get("size", PER_PAGE))
+        paginator = Paginator(region_feedback, chunk_size)
         chunk = request.GET.get("page")
         region_feedback_chunk = paginator.get_page(chunk)
 

--- a/src/cms/views/languages/language_list_view.py
+++ b/src/cms/views/languages/language_list_view.py
@@ -43,8 +43,9 @@ class LanguageListView(TemplateView):
         :rtype: ~django.template.response.TemplateResponse
         """
         languages = Language.objects.all()
+        chunk_size = int(request.GET.get("size", PER_PAGE))
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(languages.order_by("slug"), PER_PAGE)
+        paginator = Paginator(languages.order_by("slug"), chunk_size)
         chunk = request.GET.get("page")
         language_chunk = paginator.get_page(chunk)
         return render(

--- a/src/cms/views/offer_templates/offer_template_list_view.py
+++ b/src/cms/views/offer_templates/offer_template_list_view.py
@@ -43,8 +43,9 @@ class OfferTemplateListView(TemplateView):
         :rtype: ~django.template.response.TemplateResponse
         """
         offer_templates = OfferTemplate.objects.all()
+        chunk_size = int(request.GET.get("size", PER_PAGE))
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(offer_templates.order_by("slug"), PER_PAGE)
+        paginator = Paginator(offer_templates.order_by("slug"), chunk_size)
         chunk = request.GET.get("page")
         offer_templates_chunk = paginator.get_page(chunk)
         return render(

--- a/src/cms/views/organizations/organization_list_view.py
+++ b/src/cms/views/organizations/organization_list_view.py
@@ -44,8 +44,9 @@ class OrganizationListView(TemplateView, OrganizationContextMixin):
         :rtype: ~django.template.response.TemplateResponse
         """
         organizations = Organization.objects.all()
+        chunk_size = int(request.GET.get("size", PER_PAGE))
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(organizations.order_by("slug"), PER_PAGE)
+        paginator = Paginator(organizations.order_by("slug"), chunk_size)
         chunk = request.GET.get("page")
         organization_chunk = paginator.get_page(chunk)
 

--- a/src/cms/views/pois/poi_list_view.py
+++ b/src/cms/views/pois/poi_list_view.py
@@ -115,8 +115,9 @@ class POIListView(TemplateView, POIContextMixin):
             )
             pois = pois.filter(pk__in=poi_keys)
 
+        chunk_size = int(request.GET.get("size", PER_PAGE))
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(pois.order_by("region__slug"), PER_PAGE)
+        paginator = Paginator(pois.order_by("region__slug"), chunk_size)
         chunk = request.GET.get("page")
         poi_chunk = paginator.get_page(chunk)
         context = self.get_context_data(**kwargs)

--- a/src/cms/views/push_notifications/push_notification_list_view.py
+++ b/src/cms/views/push_notifications/push_notification_list_view.py
@@ -30,6 +30,7 @@ class PushNotificationListView(TemplateView):
     #: The context dict passed to the template (see :class:`~django.views.generic.base.ContextMixin`)
     base_context = {"current_menu_item": "push_notifications"}
 
+    # pylint: disable=too-many-locals
     def get(self, request, *args, **kwargs):
         """
         Create a list that shows existing push notifications and translations
@@ -90,8 +91,9 @@ class PushNotificationListView(TemplateView):
                 pk__in=push_notification_keys
             )
 
+        chunk_size = int(request.GET.get("size", PER_PAGE))
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(push_notifications.order_by("created_date"), PER_PAGE)
+        paginator = Paginator(push_notifications.order_by("created_date"), chunk_size)
         chunk = request.GET.get("page")
         push_notifications_chunk = paginator.get_page(chunk)
         return render(

--- a/src/cms/views/regions/region_list_view.py
+++ b/src/cms/views/regions/region_list_view.py
@@ -54,8 +54,9 @@ class RegionListView(TemplateView):
             region_keys = Region.search(query).values("pk")
             regions = regions.filter(pk__in=region_keys)
 
+        chunk_size = int(request.GET.get("size", PER_PAGE))
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(regions, PER_PAGE)
+        paginator = Paginator(regions, chunk_size)
         chunk = request.GET.get("page")
         region_chunk = paginator.get_page(chunk)
         return render(

--- a/src/cms/views/roles/role_list_view.py
+++ b/src/cms/views/roles/role_list_view.py
@@ -43,8 +43,9 @@ class RoleListView(TemplateView):
         :rtype: ~django.template.response.TemplateResponse
         """
         roles = Role.objects.all()
+        chunk_size = int(request.GET.get("size", PER_PAGE))
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(roles.order_by("group__name"), PER_PAGE)
+        paginator = Paginator(roles.order_by("group__name"), chunk_size)
         chunk = request.GET.get("page")
         role_chunk = paginator.get_page(chunk)
         return render(

--- a/src/cms/views/users/region_user_list_view.py
+++ b/src/cms/views/users/region_user_list_view.py
@@ -61,8 +61,9 @@ class RegionUserListView(TemplateView):
             user_keys = search_users(region, query).values("pk")
             users = users.filter(pk__in=user_keys)
 
+        chunk_size = int(request.GET.get("size", PER_PAGE))
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(users, PER_PAGE)
+        paginator = Paginator(users, chunk_size)
         chunk = request.GET.get("page")
         user_chunk = paginator.get_page(chunk)
         return render(

--- a/src/cms/views/users/user_list_view.py
+++ b/src/cms/views/users/user_list_view.py
@@ -60,8 +60,9 @@ class UserListView(TemplateView):
             user_keys = search_users(region=None, query=query).values("pk")
             users = users.filter(pk__in=user_keys)
 
+        chunk_size = int(request.GET.get("size", PER_PAGE))
         # for consistent pagination querysets should be ordered
-        paginator = Paginator(users, PER_PAGE)
+        paginator = Paginator(users, chunk_size)
         chunk = request.GET.get("page")
         user_chunk = paginator.get_page(chunk)
         return render(

--- a/src/frontend/css/style.scss
+++ b/src/frontend/css/style.scss
@@ -494,8 +494,9 @@ datalist option {
 /* styling for pagination links */
 .pagination {
   display: flex;
-  flex-direction: row-reverse;
   margin-top: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
   .step-links {
     display: flex;
     a {

--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -61,6 +61,7 @@ import "./js/media-management/index.tsx";
 import "./js/media-management/select-media.tsx";
 import "./js/forms/icon-field.tsx";
 
+import "./js/pagination/pagination.ts";
 
 window.addEventListener('load',() => {
     feather.replace({ class: 'inline-block' });

--- a/src/frontend/js/pagination/pagination.ts
+++ b/src/frontend/js/pagination/pagination.ts
@@ -1,0 +1,10 @@
+window.addEventListener("load", () => {
+    const paginationChoice = document.getElementById("chunk-size") as HTMLSelectElement;
+    if (paginationChoice) {
+        paginationChoice.addEventListener("change", () => {
+            if (paginationChoice.value) {
+                window.location.href = paginationChoice.value;
+            }
+        });
+    }
+});

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-09 13:40+0000\n"
+"POT-Creation-Date: 2021-11-10 17:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3866,31 +3866,31 @@ msgstr "Kein technisches Feedback mit diesen Filtern gefunden."
 msgid "No technical feedback available yet."
 msgstr "Noch kein technisches Feedback vorhanden."
 
-#: cms/templates/feedback/admin_feedback_list.html:127
-#: cms/templates/feedback/region_feedback_list.html:120
+#: cms/templates/feedback/admin_feedback_list.html:128
+#: cms/templates/feedback/region_feedback_list.html:121
 #: cms/templates/linkcheck/links_by_filter.html:72
 #: cms/templates/pages/page_tree.html:112
 msgid "Select bulk action"
 msgstr "Mehrfachaktion auswählen"
 
-#: cms/templates/feedback/admin_feedback_list.html:128
-#: cms/templates/feedback/region_feedback_list.html:121
+#: cms/templates/feedback/admin_feedback_list.html:129
+#: cms/templates/feedback/region_feedback_list.html:122
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: cms/templates/feedback/admin_feedback_list.html:129
-#: cms/templates/feedback/region_feedback_list.html:122
+#: cms/templates/feedback/admin_feedback_list.html:130
+#: cms/templates/feedback/region_feedback_list.html:123
 msgid "Mark as unread"
 msgstr "Als ungelesen markieren"
 
-#: cms/templates/feedback/admin_feedback_list.html:131
-#: cms/templates/feedback/region_feedback_list.html:124
+#: cms/templates/feedback/admin_feedback_list.html:132
+#: cms/templates/feedback/region_feedback_list.html:125
 #: cms/templates/language_tree/language_tree.html:30
 msgid "Delete"
 msgstr "Löschen"
 
-#: cms/templates/feedback/admin_feedback_list.html:134
-#: cms/templates/feedback/region_feedback_list.html:127
+#: cms/templates/feedback/admin_feedback_list.html:135
+#: cms/templates/feedback/region_feedback_list.html:128
 #: cms/templates/linkcheck/links_by_filter.html:80
 #: cms/templates/pages/page_tree.html:131
 msgid "Execute"
@@ -4752,6 +4752,10 @@ msgstr ""
 #: cms/templates/pages/page_xliff_import_view.html:18
 msgid "Abort"
 msgstr "Abbrechen"
+
+#: cms/templates/pagination.html:13
+msgid "Number of entries per page"
+msgstr "Anzahl Einträge pro Seite"
 
 #: cms/templates/pois/poi_form.html:20
 #, python-format
@@ -6197,7 +6201,7 @@ msgstr "Sie können diesen Ort nicht bearbeiten, da er archiviert ist."
 msgid "Location \"{}\" was successfully created"
 msgstr "Ort \"{}\" wurde erfolgreich erstellt"
 
-#: cms/views/push_notifications/push_notification_list_view.py:69
+#: cms/views/push_notifications/push_notification_list_view.py:70
 msgid ""
 "Please create at least one language node before creating push notifications."
 msgstr ""


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Make pagination chunk size configurable

### Proposed changes
<!-- Describe this PR in more detail. -->

- Pagination chunk size is send via query string like chunk index
- Switching between the chunk sizes via selected option dropdown
- I chose to place the html select tag on the same height like rest of the the pagination tags, because this pagination html document is already included on all necessary list views. If wished we can move the position, but this will need an additional template + include statements (to prevent to much duplication).
![configurable-pagination](https://user-images.githubusercontent.com/47010475/140918088-53c8221e-cb9c-4ce5-86e1-feed9ea55144.png)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #994 

