### PR TITLE
Handle empty `creator` fields correctly 

### DIFF
--- a/integreat_cms/cms/fixtures/roles.json
+++ b/integreat_cms/cms/fixtures/roles.json
@@ -219,7 +219,7 @@
     "model": "auth.group",
     "pk": 6,
     "fields": {
-      "name": "cms_TEAM",
+      "name": "CMS_TEAM",
       "permissions": [
         58,
         4,
@@ -264,7 +264,7 @@
     "pk": 6,
     "fields": {
       "group": 6,
-      "name": "cms_TEAM",
+      "name": "CMS_TEAM",
       "staff_role": true
     }
   },

--- a/integreat_cms/cms/models/events/event_translation.py
+++ b/integreat_cms/cms/models/events/event_translation.py
@@ -67,6 +67,7 @@ class EventTranslation(models.Model):
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         null=True,
+        blank=True,
         on_delete=models.SET_NULL,
         related_name="event_translations",
         verbose_name=_("creator"),

--- a/integreat_cms/cms/models/pages/imprint_page_translation.py
+++ b/integreat_cms/cms/models/pages/imprint_page_translation.py
@@ -41,6 +41,7 @@ class ImprintPageTranslation(AbstractBasePageTranslation):
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         null=True,
+        blank=True,
         on_delete=models.SET_NULL,
         related_name="imprint_translations",
         verbose_name=_("creator"),

--- a/integreat_cms/cms/models/pages/page_translation.py
+++ b/integreat_cms/cms/models/pages/page_translation.py
@@ -59,6 +59,7 @@ class PageTranslation(AbstractBasePageTranslation):
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         null=True,
+        blank=True,
         on_delete=models.SET_NULL,
         related_name="page_translations",
         verbose_name=_("creator"),

--- a/integreat_cms/cms/models/pois/poi_translation.py
+++ b/integreat_cms/cms/models/pois/poi_translation.py
@@ -74,6 +74,7 @@ class POITranslation(models.Model):
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         null=True,
+        blank=True,
         on_delete=models.SET_NULL,
         related_name="poi_translations",
         verbose_name=_("creator"),

--- a/integreat_cms/cms/templates/imprint/imprint_revisions.html
+++ b/integreat_cms/cms/templates/imprint/imprint_revisions.html
@@ -40,8 +40,9 @@
         </datalist>
     </div>
 
+    {% trans 'deleted user' as deleted_user_text %}
     {% for imprint_translation in imprint_translations %}
-    <div class="w-full hidden revision-wrapper" id="revision-{{ imprint_translation.version }}" data-date="{{ imprint_translation.last_updated }}" data-editor="{{ imprint_translation.creator.full_user_name }}">
+    <div class="w-full hidden revision-wrapper" id="revision-{{ imprint_translation.version }}" data-date="{{ imprint_translation.last_updated }}" data-editor="{% firstof imprint_translation.creator deleted_user_text %}">
         <label class="inline-block mb-2 font-bold">{% trans 'Status' %}:</label>
         {{ imprint_translation.get_status_display }}
         {% if imprint_translation == api_revision %}
@@ -51,13 +52,7 @@
         {% endif %}
         <span class="float-right">
             <label class="inline-block mb-2 font-bold">{% trans 'Author' %}:</label>
-            {% with imprint_translation.creator as editor %}
-                {% if editor.first_name or editor.last_name %}
-                    {{ editor.first_name }} {{ editor.last_name }}
-                {% else %}
-                    {{ editor.username }}
-                {% endif %}
-            {% endwith %}
+            {% firstof imprint_translation.creator deleted_user_text %}
         </span>
         <div class="revision-plain hidden">
             <label>{% trans 'Permalink' %}:</label>

--- a/integreat_cms/cms/templates/pages/_page_xliff_import_diff.html
+++ b/integreat_cms/cms/templates/pages/_page_xliff_import_diff.html
@@ -31,10 +31,11 @@
                 {{ diff.existing.language }}
             </div>
             {% if diff.existing.id %}
+            {% trans 'deleted user' as deleted_user_text %}
             <div>
                 <label class="block font-bold text-lg">{% trans 'Last updated' %}:</label>
                 <i data-feather="calendar"></i> {{ diff.existing.last_updated }} {% trans 'by' %}
-                <i data-feather="user"></i> {{ diff.existing.creator.full_user_name }}
+                <i data-feather="user"></i> {% firstof diff.existing.creator deleted_user_text %}
             </div>
             <div>
                 <label class="block font-bold text-lg">{% trans 'Versions' %}:</label>

--- a/integreat_cms/cms/templates/pages/page_revisions.html
+++ b/integreat_cms/cms/templates/pages/page_revisions.html
@@ -44,8 +44,9 @@
         </datalist>
     </div>
 
+    {% trans 'deleted user' as deleted_user_text %}
     {% for page_translation in page_translations %}
-    <div class="w-full hidden revision-wrapper" id="revision-{{ page_translation.version }}" data-date="{{ page_translation.last_updated }}" data-editor="{{ page_translation.creator.full_user_name }}">
+    <div class="w-full hidden revision-wrapper" id="revision-{{ page_translation.version }}" data-date="{{ page_translation.last_updated }}" data-editor="{% firstof page_translation.creator deleted_user_text %}">
         <label class="inline-block">{% trans 'Status' %}:</label>
         {{ page_translation.get_status_display }}
         {% if page_translation == api_revision %}
@@ -55,13 +56,7 @@
         {% endif %}
         <span class="float-right">
             <label class="inline-block">{% trans 'Author' %}:</label>
-            {% with page_translation.creator as editor %}
-                {% if editor.first_name or editor.last_name %}
-                    {{ editor.first_name }} {{ editor.last_name }}
-                {% else %}
-                    {{ editor.username }}
-                {% endif %}
-            {% endwith %}
+            {% firstof page_translation.creator deleted_user_text %}
         </span>
         <div class="revision-plain hidden">
             <label>{% trans 'Permalink' %}:</label>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-20 13:45+0000\n"
+"POT-Creation-Date: 2021-11-23 19:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1286,7 +1286,7 @@ msgid "Hidden"
 msgstr "Versteckt"
 
 #: cms/constants/region_status.py:18 cms/models/pages/page.py:270
-#: cms/models/pages/page_translation.py:376 cms/models/regions/region.py:456
+#: cms/models/pages/page_translation.py:377 cms/models/regions/region.py:456
 #: cms/templates/pages/page_form.html:153
 #: cms/templates/pages/page_tree_archived_node.html:13
 msgid "Archived"
@@ -1583,13 +1583,13 @@ msgstr "Kategorie"
 #: cms/templates/events/event_list.html:46
 #: cms/templates/events/event_list_archived.html:31
 #: cms/templates/imprint/imprint_form.html:107
-#: cms/templates/imprint/imprint_revisions.html:45
+#: cms/templates/imprint/imprint_revisions.html:46
 #: cms/templates/imprint/imprint_sbs.html:59
 #: cms/templates/imprint/imprint_sbs.html:116
 #: cms/templates/imprint/imprint_sbs.html:125
 #: cms/templates/linkcheck/links_by_filter.html:52
 #: cms/templates/pages/page_form.html:151
-#: cms/templates/pages/page_revisions.html:49
+#: cms/templates/pages/page_revisions.html:50
 #: cms/templates/pages/page_sbs.html:66 cms/templates/pages/page_sbs.html:123
 #: cms/templates/pages/page_sbs.html:128 cms/templates/pages/page_tree.html:77
 #: cms/templates/pages/page_tree_archived.html:36
@@ -1966,14 +1966,14 @@ msgstr ""
 "Kreuzen Sie an, wenn diese Änderung keine Aktualisierung der Übersetzungen "
 "in anderen Sprachen erfordert"
 
-#: cms/models/events/event_translation.py:72
-#: cms/models/pages/imprint_page_translation.py:46
-#: cms/models/pages/page_translation.py:64
-#: cms/models/pois/poi_translation.py:79
+#: cms/models/events/event_translation.py:73
+#: cms/models/pages/imprint_page_translation.py:47
+#: cms/models/pages/page_translation.py:65
+#: cms/models/pois/poi_translation.py:80
 msgid "creator"
 msgstr "Ersteller"
 
-#: cms/models/events/event_translation.py:76
+#: cms/models/events/event_translation.py:77
 #: cms/models/languages/language.py:87
 #: cms/models/languages/language_tree_node.py:55
 #: cms/models/offers/offer_template.py:59
@@ -1984,12 +1984,12 @@ msgstr "Ersteller"
 msgid "modification date"
 msgstr "Änderungsdatum"
 
-#: cms/models/events/event_translation.py:364
+#: cms/models/events/event_translation.py:365
 #: cms/models/feedback/event_feedback.py:18
 msgid "event translation"
 msgstr "Veranstaltungs-Übersetzung"
 
-#: cms/models/events/event_translation.py:366
+#: cms/models/events/event_translation.py:367
 msgid "event translations"
 msgstr "Veranstaltungs-Übersetzungen"
 
@@ -2163,7 +2163,7 @@ msgstr "Angebotslisten-Feedback"
 
 #: cms/models/feedback/page_feedback.py:18
 #: cms/models/pages/abstract_base_page_translation.py:362
-#: cms/models/pages/page_translation.py:382
+#: cms/models/pages/page_translation.py:383
 msgid "page translation"
 msgstr "Seiten-Übersetzung"
 
@@ -2173,7 +2173,7 @@ msgid "page feedback"
 msgstr "Seiten-Feedback"
 
 #: cms/models/feedback/poi_feedback.py:18
-#: cms/models/pois/poi_translation.py:362
+#: cms/models/pois/poi_translation.py:363
 msgid "location translation"
 msgstr "Orts-Übersetzung"
 
@@ -2467,7 +2467,7 @@ msgid "with the title in"
 msgstr "mit dem Titel auf"
 
 #: cms/models/pages/abstract_base_page_translation.py:364
-#: cms/models/pages/page_translation.py:384
+#: cms/models/pages/page_translation.py:385
 msgid "page translations"
 msgstr "Seiten-Übersetzungen"
 
@@ -2488,11 +2488,11 @@ msgstr "Titel des Impressums"
 msgid "content of the imprint"
 msgstr "Inhalt des Impressums"
 
-#: cms/models/pages/imprint_page_translation.py:108
+#: cms/models/pages/imprint_page_translation.py:109
 msgid "imprint translation"
 msgstr "Impressums-Übersetzung"
 
-#: cms/models/pages/imprint_page_translation.py:110
+#: cms/models/pages/imprint_page_translation.py:111
 msgid "imprint translations"
 msgstr "Impressums-Übersetzungen"
 
@@ -2582,11 +2582,11 @@ msgstr "Seitenlink"
 msgid "content of the page"
 msgstr "Inhalt der Seite"
 
-#: cms/models/pages/page_translation.py:236
+#: cms/models/pages/page_translation.py:237
 msgid "Live content"
 msgstr "Live-Inhalt"
 
-#: cms/models/pages/page_translation.py:239
+#: cms/models/pages/page_translation.py:240
 msgid "Empty"
 msgstr "Leer"
 
@@ -2651,7 +2651,7 @@ msgstr ""
 "Kreuzen Sie an, wenn diese Änderung keine Aktualisierung der Übersetzungen "
 "in anderen Sprachen erfordert."
 
-#: cms/models/pois/poi_translation.py:364
+#: cms/models/pois/poi_translation.py:365
 msgid "location translations"
 msgstr "Orts-Übersetzungen"
 
@@ -4053,53 +4053,59 @@ msgid "Go back to imprint editor"
 msgstr "Zurück zum Impressums-Editor"
 
 #: cms/templates/imprint/imprint_revisions.html:21
-#: cms/templates/imprint/imprint_revisions.html:53
+#: cms/templates/imprint/imprint_revisions.html:54
 #: cms/templates/pages/page_revisions.html:25
-#: cms/templates/pages/page_revisions.html:57
+#: cms/templates/pages/page_revisions.html:58
 msgid "Author"
 msgstr "Autor"
 
-#: cms/templates/imprint/imprint_revisions.html:48
-#: cms/templates/pages/page_revisions.html:52
+#: cms/templates/imprint/imprint_revisions.html:43
+#: cms/templates/pages/_page_xliff_import_diff.html:34
+#: cms/templates/pages/page_revisions.html:47
+msgid "deleted user"
+msgstr "gelöschter Benutzer"
+
+#: cms/templates/imprint/imprint_revisions.html:49
+#: cms/templates/pages/page_revisions.html:53
 msgid "This is the version shown in the apps."
 msgstr "Diese Version wird in den Apps angezeigt."
 
-#: cms/templates/imprint/imprint_revisions.html:50
-#: cms/templates/pages/page_revisions.html:54
+#: cms/templates/imprint/imprint_revisions.html:51
+#: cms/templates/pages/page_revisions.html:55
 msgid "This is <b>not</b> the version shown in the apps."
 msgstr "Diese Version wird <b>nicht</b> in den Apps angezeigt."
 
-#: cms/templates/imprint/imprint_revisions.html:63
-#: cms/templates/imprint/imprint_revisions.html:77
-#: cms/templates/pages/page_revisions.html:67
-#: cms/templates/pages/page_revisions.html:81
+#: cms/templates/imprint/imprint_revisions.html:58
+#: cms/templates/imprint/imprint_revisions.html:72
+#: cms/templates/pages/page_revisions.html:62
+#: cms/templates/pages/page_revisions.html:76
 msgid "Permalink"
 msgstr "Permalink"
 
-#: cms/templates/imprint/imprint_revisions.html:65
-#: cms/templates/imprint/imprint_revisions.html:78
-#: cms/templates/pages/_page_xliff_import_diff.html:80
-#: cms/templates/pages/page_revisions.html:69
-#: cms/templates/pages/page_revisions.html:82
+#: cms/templates/imprint/imprint_revisions.html:60
+#: cms/templates/imprint/imprint_revisions.html:73
+#: cms/templates/pages/_page_xliff_import_diff.html:81
+#: cms/templates/pages/page_revisions.html:64
+#: cms/templates/pages/page_revisions.html:77
 #: cms/templates/push_notifications/push_notification_list.html:27
 msgid "Title"
 msgstr "Titel"
 
-#: cms/templates/imprint/imprint_revisions.html:67
-#: cms/templates/imprint/imprint_revisions.html:79
-#: cms/templates/pages/_page_xliff_import_diff.html:82
-#: cms/templates/pages/page_revisions.html:71
-#: cms/templates/pages/page_revisions.html:83
+#: cms/templates/imprint/imprint_revisions.html:62
+#: cms/templates/imprint/imprint_revisions.html:74
+#: cms/templates/pages/_page_xliff_import_diff.html:83
+#: cms/templates/pages/page_revisions.html:66
+#: cms/templates/pages/page_revisions.html:78
 msgid "Content"
 msgstr "Inhalt"
 
-#: cms/templates/imprint/imprint_revisions.html:84
-#: cms/templates/pages/page_revisions.html:90
+#: cms/templates/imprint/imprint_revisions.html:79
+#: cms/templates/pages/page_revisions.html:85
 msgid "Restore this version as draft"
 msgstr "Diese Version als Entwurf wiederherstellen"
 
-#: cms/templates/imprint/imprint_revisions.html:85
-#: cms/templates/pages/page_revisions.html:93
+#: cms/templates/imprint/imprint_revisions.html:80
+#: cms/templates/pages/page_revisions.html:88
 msgid "Restore and publish this version"
 msgstr "Diese Version wiederherstellen und veröffentlichen"
 
@@ -4268,7 +4274,7 @@ msgstr "Erstellt"
 
 #: cms/templates/languages/language_list.html:28
 #: cms/templates/offer_templates/offer_template_list.html:23
-#: cms/templates/pages/_page_xliff_import_diff.html:35
+#: cms/templates/pages/_page_xliff_import_diff.html:36
 #: cms/templates/pages/page_tree.html:78
 #: cms/templates/regions/region_list.html:23
 msgid "Last updated"
@@ -4418,27 +4424,27 @@ msgstr "Datei"
 msgid "Page"
 msgstr "Seite"
 
-#: cms/templates/pages/_page_xliff_import_diff.html:36
+#: cms/templates/pages/_page_xliff_import_diff.html:37
 msgid "by"
 msgstr "von"
 
-#: cms/templates/pages/_page_xliff_import_diff.html:40
+#: cms/templates/pages/_page_xliff_import_diff.html:41
 msgid "Versions"
 msgstr "Versionen"
 
-#: cms/templates/pages/_page_xliff_import_diff.html:44
+#: cms/templates/pages/_page_xliff_import_diff.html:45
 msgid "Show previous versions"
 msgstr "Bisherige Versionen anzeigen"
 
-#: cms/templates/pages/_page_xliff_import_diff.html:55
+#: cms/templates/pages/_page_xliff_import_diff.html:56
 msgid "Preview"
 msgstr "Vorschau"
 
-#: cms/templates/pages/_page_xliff_import_diff.html:62
+#: cms/templates/pages/_page_xliff_import_diff.html:63
 msgid "Source Code"
 msgstr "Quellcode"
 
-#: cms/templates/pages/_page_xliff_import_diff.html:79 xliff/utils.py:425
+#: cms/templates/pages/_page_xliff_import_diff.html:80 xliff/utils.py:425
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
@@ -4579,7 +4585,7 @@ msgstr "Versionen der Seite \"%(page_title)s\""
 msgid "Go Back to Page Editor"
 msgstr "Zurück zum Seiten-Editor"
 
-#: cms/templates/pages/page_revisions.html:95
+#: cms/templates/pages/page_revisions.html:90
 msgid "Restore this version and submit for review"
 msgstr "Diese Revision wiederherstellen und zum Review vorlegen"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Handle empty creator fields correctly 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix typo in roles fixture
- Handle empty `creator` fields correctly 
    - Show 'deleted user' instead of empty string in revision view
    - Allow duplication of translations with empty `creator` fields

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1031
