### PR TITLE
Fix page permissions

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -174,7 +174,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "linkcheck",
     "mptt",
-    "rules",
+    "rules.apps.AutodiscoverRulesConfig",
     "webpack_loader",
     "widget_tweaks",
 ]


### PR DESCRIPTION
### Short description
This pr fixes a bug where non-admin users were not granted permission to edit pages, even if they were allowed to.
It looks like the bug might not actually be related to a django-rules issue. Instead, our [rules.py](https://github.com/Integreat/integreat-cms/blob/develop/integreat_cms/cms/rules.py) did not get loaded, which lead to the custom permission rules never being registered. This might be caused by the recent refactoring of the project structure.


### Proposed changes
- Tell the rules app to autodiscover rules config files

### Resolved issues
Fixes: #1028 
