### PR TITLE
Fix timeout bug by using the specific window method

### DIFF
--- a/integreat_cms/static/src/js/events/event-query-pois.ts
+++ b/integreat_cms/static/src/js/events/event-query-pois.ts
@@ -110,7 +110,7 @@ function renderPoiData(
   (document.getElementById("poi-query-input") as HTMLInputElement).value = "";
 }
 
-let scheduledFunction: number | false = false;
+let scheduledFunction: number | null = null;
 function setPoiQueryEventListeners() {
   // AJAX search
   document

--- a/integreat_cms/static/src/js/search-query.ts
+++ b/integreat_cms/static/src/js/search-query.ts
@@ -62,7 +62,7 @@ async function queryObjects(
     }
 }
 
-let scheduledFunction: number | false = false;
+let scheduledFunction: number | null = null;
 
 function setSearchQueryEventListeners() {
     let table_search_input = document.getElementById("table-search-input") as HTMLInputElement;
@@ -73,8 +73,8 @@ function setSearchQueryEventListeners() {
             event.preventDefault();
 
             // Reschedule function execution on new input
-            if (scheduledFunction) {
-                clearTimeout(scheduledFunction);
+            if (scheduledFunction != null) {
+                window.clearTimeout(scheduledFunction);
             }
             // Schedule function execution
             scheduledFunction = window.setTimeout(


### PR DESCRIPTION
### Short description
After the update of our JS dependencies, we can no longer use false for checking the existence of the timeout function.
`[webpack]       TS2322: Type 'Timeout' is not assignable to type 'number | false'.
[webpack]   Type 'Timeout' is not assignable to type 'false'.
[webpack] 
[webpack] webpack compiled with 1 error
`
### Proposed changes
<!-- Describe this PR in more detail. -->

- Change the Timeout type to null and change check accordingly.
- Use window.setTimeout() to distinguish from further Timeout functions.

