### PR TITLE
Enable full media library functionality in selection mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ UNRELEASED
 * Only show upcoming events per default
 * Allow configuration via /etc/integreat-cms.ini
 * Fix dependency versions for production setup
+* Fully functional media library in selection window
 
 
 2021.11.0-beta

--- a/integreat_cms/cms/templates/chat/_chat_messages.html
+++ b/integreat_cms/cms/templates/chat/_chat_messages.html
@@ -14,7 +14,7 @@
     ({{ message.sender.email|urlize }})
     {% endif %}
     {% has_perm 'cms.delete_chat_message_object' request.user message as can_delete_message %}
-    <button title="{% trans 'Delete chat message' %}" class="{% if not can_delete_message %} invisible {% endif %} confirmation-button btn-icon float-right ml-2"
+    <button title="{% trans 'Delete chat message' %}" class="{% if not can_delete_message %} invisible {% endif %} button-delete-chat-message btn-icon float-right ml-2"
             data-confirmation-title="{% trans 'Please confirm that you really want to delete this chat message:' %}"
             data-confirmation-text="{% trans 'Sender:' %} {{ message.sender.full_user_name }}<br>{% trans 'Sent on:' %} {{ message.sent_datetime }}"
             data-confirmation-subject="{{ message.text }}"

--- a/integreat_cms/cms/templates/dashboard/admin_dashboard.html
+++ b/integreat_cms/cms/templates/dashboard/admin_dashboard.html
@@ -22,6 +22,6 @@
     </div>
 </div>
 
-{% include "../generic_confirmation_dialog.html" with confirmation_ajax_enabled=True %}
+{% include "../generic_confirmation_dialog.html" %}
 
 {% endblock %}

--- a/integreat_cms/cms/templates/dashboard/dashboard.html
+++ b/integreat_cms/cms/templates/dashboard/dashboard.html
@@ -30,5 +30,5 @@
             </div>
         </div>
     </div>
-{% include "../generic_confirmation_dialog.html" with confirmation_ajax_enabled=True %}
+{% include "../generic_confirmation_dialog.html" %}
 {% endblock %}

--- a/integreat_cms/cms/templates/generic_confirmation_dialog.html
+++ b/integreat_cms/cms/templates/generic_confirmation_dialog.html
@@ -4,7 +4,7 @@
     html tags for title, text and subject are populated at runtime,
     their values will be set according to the buttons data- attributes
 -->
-<div id="confirmation-dialog" data-ajax="{{ confirmation_ajax_enabled }}" class="flex flex-col justify-center max-w-sm fixed inset-0 hidden">
+<div id="confirmation-dialog" class="flex flex-col justify-center max-w-sm fixed inset-0 hidden">
     <div class="content bg-gray-200 w-full p-4 shadow-md rounded">
         <div class="flex items-center font-bold py-2">
             <i data-feather="alert-triangle" class="text-red-500"></i>

--- a/integreat_cms/cms/templates/media/media_list.html
+++ b/integreat_cms/cms/templates/media/media_list.html
@@ -8,5 +8,5 @@
 ></integreat-media-management>
 {{ media_config_data|json_script:"media_config_data" }}
 
-{% include "../generic_confirmation_dialog.html" with confirmation_ajax_enabled=True %}
+{% include "../generic_confirmation_dialog.html" %}
 {% endblock %}

--- a/integreat_cms/cms/templates/media/media_list_admin.html
+++ b/integreat_cms/cms/templates/media/media_list_admin.html
@@ -9,5 +9,5 @@
 ></integreat-media-management>
 {{ media_config_data|json_script:"media_config_data" }}
 
-{% include "../generic_confirmation_dialog.html" with confirmation_ajax_enabled=True %}
+{% include "../generic_confirmation_dialog.html" %}
 {% endblock %}

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -365,12 +365,12 @@ label:not([for]) {
 }
 
 #popup-overlay {
-  z-index: 90;
+  z-index: 3090;
 }
 
 #confirmation-dialog {
   margin: 0 auto;
-  z-index: 100;
+  z-index: 3100;
 }
 
 #chat-history a {

--- a/integreat_cms/static/src/js/chat/delete-chat-message.ts
+++ b/integreat_cms/static/src/js/chat/delete-chat-message.ts
@@ -5,7 +5,7 @@ import { getCsrfToken } from "../utils/csrf-token";
 import { refreshAjaxConfirmationHandlers } from "../confirmation-popups";
 
 // Listen on the custom event "action-confirmed" which is triggered by the confirmation popup
-window.addEventListener("load", () => refreshAjaxConfirmationHandlers(deleteChatMessage));
+window.addEventListener("load", () => refreshAjaxConfirmationHandlers(".button-delete-chat-message", deleteChatMessage));
 
 // Function to delete a chat message
 export async function deleteChatMessage(event: Event) {
@@ -19,7 +19,7 @@ export async function deleteChatMessage(event: Event) {
 
   // Delete chat message
   const deletionButton = (event.target as HTMLElement).closest(
-    ".confirmation-button"
+    ".button-delete-chat-message"
   );
   try {
     const response = await fetch(deletionButton.getAttribute("data-action"), {

--- a/integreat_cms/static/src/js/chat/send-chat-message.ts
+++ b/integreat_cms/static/src/js/chat/send-chat-message.ts
@@ -55,7 +55,7 @@ async function sendChatMessage(event: Event) {
       // Trigger icon replacement
       feather.replace({ class: 'inline-block' });
 
-      refreshAjaxConfirmationHandlers(deleteChatMessage);
+      refreshAjaxConfirmationHandlers(".button-delete-chat-message", deleteChatMessage);
     } else {
       // Throw error which will then be caught later
       throw new Error(

--- a/integreat_cms/static/src/js/media-management/component/directory-content.tsx
+++ b/integreat_cms/static/src/js/media-management/component/directory-content.tsx
@@ -12,7 +12,6 @@ interface Props {
   fileIndexState: [number | null, StateUpdater<number | null>];
   directoryContent: MediaLibraryEntry[];
   mediaTranslations: any;
-  selectionMode?: boolean;
   globalEdit?: boolean;
 }
 
@@ -20,7 +19,6 @@ export default function DirectoryContent({
   fileIndexState,
   directoryContent,
   mediaTranslations,
-  selectionMode,
   globalEdit,
 }: Props) {
   // The file index contains the index of the file which is currently opened in the sidebar
@@ -34,7 +32,6 @@ export default function DirectoryContent({
             <DirectoryEntry
               directory={entry as Directory}
               mediaTranslations={mediaTranslations}
-              selectionMode={selectionMode}
               globalEdit={globalEdit}
             />
           </Link>
@@ -47,7 +44,6 @@ export default function DirectoryContent({
               setFileIndex(index);
             }}
             mediaTranslations={mediaTranslations}
-            selectionMode={selectionMode}
             globalEdit={globalEdit}
           />
         )

--- a/integreat_cms/static/src/js/media-management/component/directory-entry.tsx
+++ b/integreat_cms/static/src/js/media-management/component/directory-entry.tsx
@@ -10,7 +10,6 @@ interface Props {
   directory: Directory;
   onClick?: (event: MouseEvent) => void;
   mediaTranslations: any;
-  selectionMode?: boolean;
   globalEdit?: boolean;
 }
 
@@ -19,7 +18,6 @@ export default function DirectoryEntry({
   onClick,
   mediaTranslations,
   globalEdit,
-  selectionMode,
 }: Props) {
   return (
     <div
@@ -31,7 +29,7 @@ export default function DirectoryEntry({
       <span class="font-bold text-black text-center break-all leading-5 max-h-15 m-auto overflow-hidden">
         {directory.name}
       </span>
-      {!selectionMode && !globalEdit && directory.isGlobal && (
+      {!globalEdit && directory.isGlobal && (
         <span
           class="absolute bg-blue-500 text-white rounded-full m-2 p-2"
           title={mediaTranslations.text_dir_readonly}

--- a/integreat_cms/static/src/js/media-management/component/file-entry.tsx
+++ b/integreat_cms/static/src/js/media-management/component/file-entry.tsx
@@ -11,7 +11,6 @@ interface Props {
   active: boolean;
   onClick: (event: MouseEvent) => void;
   mediaTranslations: any;
-  selectionMode?: boolean;
   globalEdit?: boolean;
 }
 
@@ -21,7 +20,6 @@ export default function FileEntry({
   onClick,
   mediaTranslations,
   globalEdit,
-  selectionMode,
 }: Props) {
   return (
     <div
@@ -43,7 +41,7 @@ export default function FileEntry({
       <span className="flex-none leading-5 max-h-15 m-auto break-all overflow-hidden">
         {file.name}
       </span>
-      {!selectionMode && !globalEdit && file.isGlobal && (
+      {!globalEdit && file.isGlobal && (
         <span
           class="absolute bg-blue-500 text-white rounded-full m-2 p-2"
           title={mediaTranslations.text_file_readonly}

--- a/integreat_cms/static/src/js/media-management/library.tsx
+++ b/integreat_cms/static/src/js/media-management/library.tsx
@@ -192,7 +192,7 @@ export default function Library({
           <Search class="absolute m-2" />
           <input type="search" class="h-full py-2 pl-10 pr-4 rounded shadow" />
         </form>
-        {!selectionMode && (globalEdit || !directory?.isGlobal) && (
+        {(globalEdit || !directory?.isGlobal) && (
           <div className="flex flex-wrap justify-start gap-2">
             <button
               title={mediaTranslations.btn_create_directory}
@@ -257,7 +257,6 @@ export default function Library({
                 fileIndexState={[fileIndex, setFileIndex]}
                 directoryContent={directoryContent}
                 mediaTranslations={mediaTranslations}
-                selectionMode={selectionMode}
                 globalEdit={globalEdit}
               />
             </div>
@@ -285,7 +284,6 @@ export default function Library({
               apiEndpoints={apiEndpoints}
               mediaTranslations={mediaTranslations}
               submitForm={submitForm}
-              selectionMode={selectionMode}
               globalEdit={globalEdit}
               isLoading={isLoading}
             />


### PR DESCRIPTION
### Short description
This pr allows users to make changes to the content of the media library in selection mode.


### Proposed changes
- Get rid of global confirmation popup mode (ajax / forms) and set the mode per button
- Change ajax confirmation popups so that independent different ajax popups can be shown on the same page
- Enable full media library functionality by removing most `selectionMode` checks

### Resolved issues
Fixes: #968 
