### PR TITLE
Persist setup.cfg to workspace after CircleCI version bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,7 +261,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - setup.py
+            - setup.cfg
             - src/integreat_cms/__init__.py
   bump-version:
     docker:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The version is now contained in setup.cfg instead of setup.py, so we have to persist a different file after the version has been bumped. This should have been included in 36618d5fac30e0803c3da91d7d3cf4221c531517, but unfortunately I missed it.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Persist `setup.cfg` to workspace after CircleCI version bump
